### PR TITLE
Fix wrong argument type

### DIFF
--- a/scripts/gcovr
+++ b/scripts/gcovr
@@ -1825,7 +1825,7 @@ if len(args) == 1:
     if options.root is None:
         datafiles = get_datafiles(["."], options)
     else:
-        datafiles = get_datafiles(options.root, options)
+        datafiles = get_datafiles([options.root], options)
 else:
     datafiles = get_datafiles(args[1:], options)
 #


### PR DESCRIPTION
If `options.root` is set, it is passed as a value instead of a list. That means gcovr will start looking for object files in `/` (the first character of the absolute path) which (almost literally) takes forever.
