### PR TITLE
HTML report redesign & small report

### DIFF
--- a/scripts/gcovr
+++ b/scripts/gcovr
@@ -1470,6 +1470,8 @@ def source_row(lineno, source, cdata):
 #
 nrows = 0
 def html_row(details, sourcefile, **kwargs):
+    if options.relative_anchors:
+        sourcefile = os.path.basename(sourcefile)
     rowstr=Template('''
     <tr>
       <td class="coverFile" ${altstyle}>${filename}</td>
@@ -1822,6 +1824,11 @@ parser.add_option("-s", "--print-summary",
         help="Prints a small report to stdout with line & branch percentage coverage",
         action="store_true",
         dest="print_summary",
+        default=False)
+parser.add_option("--relative-anchors",
+        help="Set the anchors in the HTML report to be relative instead of absolute (set this to use the report in a web server)",
+        action="store_true",
+        dest="relative_anchors",
         default=False)
 parser.usage="gcovr [options]"
 parser.description="A utility to run gcov and generate a simple report that summarizes the coverage"


### PR DESCRIPTION
I tried to adapt the look a bit like LCOV, so it's more readable for people that are used to using it. It also fixes the fact that rows looked huge in Firefox & IE. 

The biggest change is that I've removed the full border on each cell, and now it looks more like a source file view. I've also coloured the line number and count columns.

I have also created an additional option to print a small report which will only display the percentage to stdout.
