### PR TITLE
handle `--root` option correctly

### DIFF
--- a/scripts/gcovr
+++ b/scripts/gcovr
@@ -1825,7 +1825,7 @@ if len(args) == 1:
     if options.root is None:
         datafiles = get_datafiles(["."], options)
     else:
-        datafiles = get_datafiles(options.root, options)
+        datafiles = get_datafiles([options.root], options)
 else:
     datafiles = get_datafiles(args[1:], options)
 #


### PR DESCRIPTION
- otherwise get_datafiles() will take each char in the `options.root` as a single directory
- fixes #37
