### PR TITLE
fix incorrect gcov relative filepath

### DIFF
--- a/scripts/gcovr
+++ b/scripts/gcovr
@@ -405,13 +405,10 @@ def process_gcov_data(data_fname, covdata, options):
     segments=line.split(':',3)
     if len(segments) != 4 or not segments[2].lower().strip().endswith('source'):
         raise RuntimeError('Fatal error parsing gcov file, line 1: \n\t"%s"' % line.rstrip())
-    currdir = os.getcwd()
-    os.chdir(root_dir)
     if sys.version_info >= (2,6):
         fname = os.path.abspath((segments[-1]).strip())
     else:
         fname = aliases.unalias_path(os.path.abspath((segments[-1]).strip()))
-    os.chdir(currdir)
     if options.verbose:
         sys.stdout.write("Parsing coverage data for file %s\n" % fname)
     #


### PR DESCRIPTION
when the gcov file is generated under sub directory, the relative path is still resolved to abs path related to root_dir. The abs path should be resolved related to the CWD.

code snippet:

``` python
def process_gcov_data(data_fname, covdata, options):
    INPUT = open(data_fname,"r")
    #
    # Get the filename
    #
    line = INPUT.readline()
    segments=line.split(':',3)
    if len(segments) != 4 or not segments[2].lower().strip().endswith('source'):
        raise RuntimeError('Fatal error parsing gcov file, line 1: \n\t"%s"' % line.rstrip())
    currdir = os.getcwd()
    os.chdir(root_dir) # <==== Following fname will be calculated related to root_dir
    if sys.version_info >= (2,6):
        fname = os.path.abspath((segments[-1]).strip())
    else:
        fname = aliases.unalias_path(os.path.abspath((segments[-1]).strip()))
    os.chdir(currdir)
```

fix available at https://github.com/kevincai/gcovr/commit/fcce76007162a381ef9d3d6e627c553b75f924fd.

Test passed with expected result.
