### PR TITLE
scripts/gcovr: make html detail links relative

### DIFF
--- a/scripts/gcovr
+++ b/scripts/gcovr
@@ -1432,7 +1432,7 @@ def html_row(details, sourcefile, **kwargs):
     else:
         kwargs['altstyle'] = ''
     if details:
-        kwargs['filename'] = '<a href="%s">%s</a>' % (sourcefile, kwargs['filename'][len(kwargs['directory']):])
+        kwargs['filename'] = '<a href="%s">%s</a>' % (sourcefile.split("/")[-1], kwargs['filename'][len(kwargs['directory']):])
     else:
         kwargs['filename'] = kwargs['filename'][len(kwargs['directory']):]
     kwargs['LinesCoverage'] = round(kwargs['LinesCoverage'],1)


### PR DESCRIPTION
There is no need to have the complete path in the link especially as it
breaks if you want to upload the stats to another page.
