### PR TITLE
Fix issue #45: --root option fails

### DIFF
--- a/scripts/gcovr
+++ b/scripts/gcovr
@@ -370,7 +370,7 @@ def search_file(expr, path):
 #
 def get_datafiles(flist, options):
     allfiles=set()
-    for dir in flist:
+    for dir in flist.split(' '):
         if options.verbose:
             sys.stdout.write( "Scanning directory %s for gcda/gcno files...\n"
                               % (dir, ) )


### PR DESCRIPTION
If root is set to a path, such as "test/data/here", flist will be
set to "test/data/here" and the search will begin iterate over
each letter, resulting in an error since "t" is not a valid directory.

It's been changed to assume directories are separated by whitespace
and treat them as wholes.
