### PR TITLE
Why are branches that are never executed ignored?

### DIFF
--- a/scripts/gcovr
+++ b/scripts/gcovr
@@ -531,10 +531,9 @@ def process_gcov_data(data_fname, covdata, options):
                 fields = line.split()
                 try:
                     count = int(fields[3])
-                    branches.setdefault(lineno, {})[int(fields[1])] = count
                 except:
-                    # We ignore branches that were "never executed"
-                    pass
+                    count = 0
+                branches.setdefault(lineno, {})[int(fields[1])] = count
         elif tmp.startswith('call'):
             pass
         elif tmp.startswith('function'):


### PR DESCRIPTION
I've noticed the [Cobertura Jenkins plugin](https://github.com/cobertura/cobertura) reporting high conditional coverage for a poorly tested project. Further investigation revealed that all untested files reported no (and I don't mean 0%) conditional coverage, so the aggregated result only included already-tested files, which inflated the average.

The reason is that gcovr simply doesn't report these branches:

```
try:
    count = int(fields[3])
    branches.setdefault(lineno, {})[int(fields[1])] = count
except:
    # We ignore branches that were "never executed"
    pass
```

If I replace that with:

```
fields = line.split()
try:
    count = int(fields[3])
except:
    count = 0
branches.setdefault(lineno, {})[int(fields[1])] = count
```

I got the 0% coverage number for these files and the shamefully low aggregated result I was expecting.

Why are never executed branches currently skipped?
