### PR TITLE
Fix running without -r option

### DIFF
--- a/scripts/gcovr
+++ b/scripts/gcovr
@@ -894,7 +894,7 @@ def print_text_report(covdata):
     # Header
     OUTPUT.write("-" * 78 + '\n')
     OUTPUT.write(" " * 27 + "GCC Code Coverage Report\n")
-    OUTPUT.write("Directory: " + options.root + "\n")
+    OUTPUT.write("Directory: " + root_dir + "\n")
     OUTPUT.write("-" * 78 + '\n')
     a = options.show_branch and "Branches" or "Lines"
     b = options.show_branch and "Taken" or "Exec"


### PR DESCRIPTION
If you run without any command line options, gcovr crashes without
this change since options.root never gets defined.  Using
root_dir in this case.