### PR TITLE
If given, options.output is relative to start directory.

### DIFF
--- a/gcovr/args.py
+++ b/gcovr/args.py
@@ -9,8 +9,9 @@
 #  For more information, see the README.md file.
 #  _________________________________________________________________________
 
-from os import environ
 from optparse import OptionParser
+from os import environ
+import os.path
 
 
 def parse_arguments():
@@ -200,5 +201,7 @@ def parse_arguments():
     parser.description = \
         'A utility to run gcov and generate a simple report that summarizes ' \
         'the coverage'
-
-    return parser.parse_args()
+    (options, args) = parser.parse_args()
+    if options.output is not None:
+        options.output = os.path.abspath(options.output)
+    return (options, args)


### PR DESCRIPTION
If we enter a relative path with --output, we want it to be relative to
the directory we stand in when we run gcovr.

Because we call os.chdir in the code, the easiest way to guarantee this
is to make the path absolute before we start calling os.chdir.
