### PR TITLE
fix for windows machines using out of source builds (CMake)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+/.settings

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ nosetests.xml
 .project
 .pydevproject
 /.settings
+.idea

--- a/gcovr/args.py
+++ b/gcovr/args.py
@@ -9,8 +9,9 @@
 #  For more information, see the README.md file.
 #  _________________________________________________________________________
 
-from os import environ
 from optparse import OptionParser
+from os import environ
+import os.path
 
 
 def parse_arguments():
@@ -200,5 +201,7 @@ def parse_arguments():
     parser.description = \
         'A utility to run gcov and generate a simple report that summarizes ' \
         'the coverage'
-
-    return parser.parse_args()
+    (options, args) = parser.parse_args()
+    if options.output is not None:
+        options.output = os.path.abspath(options.output)
+    return (options, args)

--- a/gcovr/data.py
+++ b/gcovr/data.py
@@ -231,6 +231,11 @@ def process_gcov_data(data_fname, covdata, options):
         fname = os.path.abspath((segments[-1]).strip())
     else:
         fname = aliases.unalias_path(os.path.abspath((segments[-1]).strip()))
+    #
+    # this fixes the problem on windows machines
+    #
+    fname = os.path.normcase(fname)
+
     os.chdir(currdir)
     if options.verbose:
         sys.stdout.write("Parsing coverage data for file %s\n" % fname)
@@ -239,9 +244,21 @@ def process_gcov_data(data_fname, covdata, options):
     #
     filtered_fname = None
     for i in range(0, len(options.filter)):
+
+        if options.verbose:
+            sys.stdout.write("\n\nFilter: %s" % options.filter[i].pattern)
+            sys.stdout.write("\nfname: %s" % fname)
+
         if options.filter[i].match(fname):
             filtered_fname = options.root_filter.sub('', fname)
             break
+        else:
+            if options.verbose:
+                sys.stdout.write("\nno match")
+
+    if options.verbose:
+        sys.stdout.write("\n\n")
+
     if filtered_fname is None:
         if options.verbose:
             sys.stdout.write("  Filtering coverage data for file %s\n" % fname)

--- a/gcovr/driver.py
+++ b/gcovr/driver.py
@@ -81,7 +81,7 @@ def main(options, args):
         options.exclude[i] = re.compile(options.exclude[i])
 
     options.root_filter = re.compile('')
-    options.root_dir = os.getcwd()
+    options.root_dir = os.path.normpath(os.getcwd())
     if options.root is not None:
         if not options.root:
             sys.stderr.write(
@@ -91,7 +91,7 @@ def main(options, args):
                 "\tThis option cannot be an empty string.\n"
             )
             sys.exit(1)
-        options.root_dir = os.path.abspath(options.root)
+        options.root_dir = os.path.normcase(os.path.abspath(options.root))
         options.root_filter = re.compile(re.escape(options.root_dir + os.sep))
     else:
         options.root = "."
@@ -111,9 +111,24 @@ def main(options, args):
     #
     # Get coverage data
     #
-    paths = args
-    if len(args) == 0:
-        paths = [options.root]
+
+    #
+    # if the objdir is given i think it also should be used to get the coverage data
+    #
+    if options.objdir:
+        paths = [options.objdir]
+    else:
+        paths = args
+        if len(args) == 0:
+            paths = [options.root]
+
+    if options.verbose:
+        if options.root is not None:
+            sys.stdout.write("\noptions.root: "+options.root)
+        if options.root_dir is not None:
+            sys.stdout.write("\noptions.root_dir: "+options.root_dir)
+        if options.objdir is not None:
+            sys.stdout.write("\noptions.objdir: " + options.objdir)
 
     covdata = get_coverage_data(paths, options)
 

--- a/scripts/gcovr
+++ b/scripts/gcovr
@@ -38,3 +38,4 @@ except ImportError:
 
 gcovr.driver.main_()
 
+


### PR DESCRIPTION
No you can use it with:
--object-directory=build_path
--root=source_path

I have also tested some other situations it worked fine for me - so maybe it also works fine for others :-)
I am not able to test i on linux or mac - so if someone can test it would be great.

I am also not sure if I change the code in that way the authors idea was. Because in the help I read that the objdir is used to search for the covarage but when you use this objdir it doesn´t do that. So for me this was an error and so I changed this behavior - now it matches with the documentation.

PS.:
For jenkins cobertura users => if you use root an objdir the source lookup also works fine :-)
