### PR TITLE
Handle Windows paths correctly when generating HTML file names

### DIFF
--- a/gcovr/prints/html.py
+++ b/gcovr/prints/html.py
@@ -536,15 +536,11 @@ def print_html_report(covdata, options):
         filtered_fname = options.root_filter.sub('', f)
         files.append(filtered_fname)
         cdata._filename = filtered_fname
-        ttmp = os.path.abspath(options.output).split('.')
-        if len(ttmp) > 1:
-            cdata._sourcefile = \
-                '.'.join(ttmp[:-1]) + \
-                '.' + cdata._filename.replace('/', '_') + \
-                '.' + ttmp[-1]
-        else:
-            cdata._sourcefile = \
-                ttmp[0] + '.' + cdata._filename.replace('/', '_') + '.html'
+        path, ext = os.path.splitext(os.path.abspath(options.output))
+        if not ext:
+            ext = '.html'
+        cdata._sourcefile = '%s.%s%s' % (
+            path, cdata._filename.replace('/', '_'), ext)
     # Define the common root directory, which may differ from options.root
     # when source files share a common prefix.
     if len(files) > 1:

--- a/gcovr/prints/html.py
+++ b/gcovr/prints/html.py
@@ -18,6 +18,7 @@ except:
 
 import os
 import sys
+import re
 
 from time import time
 from string import Template
@@ -531,6 +532,10 @@ def print_html_report(covdata, options):
         key=options.sort_uncovered and _num_uncovered or
         options.sort_percent and _percent_uncovered or _alpha
     )
+
+    # These path separators are not allowed in the file name part
+    PATH_CHAR_RE = re.compile(r'[/\\:]')
+
     for f in keys:
         cdata = covdata[f]
         filtered_fname = options.root_filter.sub('', f)
@@ -540,7 +545,7 @@ def print_html_report(covdata, options):
         if not ext:
             ext = '.html'
         cdata._sourcefile = '%s.%s%s' % (
-            path, cdata._filename.replace('/', '_'), ext)
+            path, PATH_CHAR_RE.sub('_', cdata._filename), ext)
     # Define the common root directory, which may differ from options.root
     # when source files share a common prefix.
     if len(files) > 1:


### PR DESCRIPTION
Currently `gcovr` translates slash to underscore when it generates HTML file names from `.gcov` path names.

Windows path names can contain slash, backslash and colon, which are not allowed as characters in the file name part. Thus all of these 3 characters should be mapped to underscores to make sure the generated file names are valid.
