### PR TITLE
Fix XML report generation with python 3

### DIFF
--- a/scripts/gcovr
+++ b/scripts/gcovr
@@ -1878,7 +1878,7 @@ def print_xml_report(covdata):
     if options.prettyxml:
         import textwrap
         lines = doc.toprettyxml(" ").split('\n')
-        for i in xrange(len(lines)):
+        for i in range(len(lines)):
             n = 0
             while n < len(lines[i]) and lines[i][n] == " ":
                 n += 1


### PR DESCRIPTION
This patch replaces `xrange` function (removed in python 3) with `range`
in XML report generation (when using the `--xml-pretty` option).