### PR TITLE
Now handles source files that are not next to the object files better

### DIFF
--- a/scripts/gcovr
+++ b/scripts/gcovr
@@ -71,6 +71,13 @@ c_style_comment_pattern = re.compile('/\*.*?\*/')
 cpp_style_comment_pattern = re.compile('//.*?$')
 
 
+def find_file(path, name):
+    result = []
+    for root, dirs, files in os.walk(path):
+        if name in files:
+            result.append(os.path.join(root, name))
+    return result
+
 def version_str():
     ans = __version__
     m = re.match('\$Revision:\s*(\S+)\s*\$', src_revision)
@@ -452,6 +459,18 @@ def process_gcov_data(data_fname, covdata, options):
         fname = os.path.abspath((segments[-1]).strip())
     else:
         fname = aliases.unalias_path(os.path.abspath((segments[-1]).strip()))
+    if not os.path.isfile(fname):
+        fname_matches = find_file(starting_dir, segments[-1].strip())
+        if len(fname_matches) == 0 and options.objdir:
+            fname_matches = find_file(options.objdir, segments[-1].strip())
+        if len(fname_matches) == 1:
+            fname = fname_matches[0]
+        elif len(fname_matches) == 0:
+            if options.verbose:
+                sys.stdout.write('No source file found for gcov file "%s" (looking for "%s")\n' % (data_fname, segments[-1].strip()))
+            return
+        elif options.verbose:
+            sys.stdout.write('Multiple source files found for gcov file "%s": \n\t%s\n' % (data_fname, '\n\t'.join(fname_matches)))
     os.chdir(currdir)
     if options.verbose:
         sys.stdout.write("Parsing coverage data for file %s\n" % fname)


### PR DESCRIPTION
We have the following directory structure for our projects:

```
./${SOURCE_FILES}
./obj/${OBJECT_FILES}
./test/${TEST_HARNESS_SOURCE_FILES}
./test/obj/${TEST_HARNESS_OBJECT_FILES}
```

Previously, our hierarchy was not playing nicely with `gcovr`. Typically, it would look for `${TEST_HARNESS_SOURCE_FILE}` in `./` which didn't work out too well for obvious reasons.

After the patch, this now works correctly - it will search the directory and sub directories for `${TEST_HARNESS_SOURCE_FILE}`.

One issue that I can foresee is where there are multiple filenames that match with what the `*.gcov` files are calling for... in this case the functionality is not improved. I am considering implementing a 'best match' approach, though have no particular reason to at the moment. I wonder if the `*.gcno`, `*.gcga` or `*.gcov` files have any further information that we could use (e.g: source file timestamp, total line count, etc...) to perform better matching where multiple files with a given name exist.

Attie
