### PR TITLE
llvm-cov: Check that code exists on lines before marking as uncovered

### DIFF
--- a/scripts/gcovr
+++ b/scripts/gcovr
@@ -431,6 +431,11 @@ def get_datafiles(flist, options):
     return allfiles
 
 
+def is_non_code(code):
+    code = code.strip().translate(None, '}{)(;')
+    return len(code) == 0 or code.startswith("//") or code == 'else'
+
+
 #
 # Process a single gcov datafile
 #
@@ -542,12 +547,14 @@ def process_gcov_data(data_fname, covdata, options):
             is_code_statement = True
             code = segments[2].strip()
             # remember certain non-executed lines
-            if excluding or len(code) == 0 or code == "{" or code == "}" or \
-                    code.startswith("//") or code == 'else':
+            if excluding or is_non_code(segments[2]):
                 noncode.add(lineno)
         elif tmp[0] == '#':
             is_code_statement = True
-            uncovered.add(lineno)
+            if is_non_code(segments[2]):
+                noncode.add( lineno )
+            else:
+                uncovered.add( lineno )
         elif tmp[0] == '=':
             is_code_statement = True
             uncovered_exceptional.add(lineno)


### PR DESCRIPTION
llvm-cov sometimes outputs that non-code lines are uncovered (and
which lines it reports changes from version to version, and even
from -std=gnu++11 to -std=gnu++14). While llvm-cov should obviously
fix its own bug, this is a far quicker fix.