### PR TITLE
Bugfix issue #17: Using gcovr html details on windows

### DIFF
--- a/gcovr/prints/html.py
+++ b/gcovr/prints/html.py
@@ -540,11 +540,12 @@ def print_html_report(covdata, options):
         if len(ttmp) > 1:
             cdata._sourcefile = \
                 '.'.join(ttmp[:-1]) + \
-                '.' + cdata._filename.replace('/', '_') + \
+                '.' + cdata._filename.replace(os.sep, '_').replace(':', '') + \
                 '.' + ttmp[-1]
         else:
             cdata._sourcefile = \
-                ttmp[0] + '.' + cdata._filename.replace('/', '_') + '.html'
+                ttmp[0] + '.' + \
+                cdata._filename.replace(os.sep, '_').replace(':', '') + '.html'
     # Define the common root directory, which may differ from options.root
     # when source files share a common prefix.
     if len(files) > 1:


### PR DESCRIPTION
gcovr could not create detailed output html files on Windows OS
due to characters '\' and ':' in relative and absolute source file paths.

These characters should be replaced to underscores like '/' chars
was replaced for unix-like systems.

OS-independent way to replace '\' on Windows is to use
os.sep instead of hard-coded '/'.

But it's still necessary to replace also a colon characters.
It's done by second stage replace.

Similar (but not full - without colons replacement) patch was
introduced on master branch by kreuzberger at 19:09:05 10/09/2014
It's commit hash was 6a4b40900c0506e6fb97b91abe5979ac25fd2d3e.