### PR TITLE
Added --html-encoding command line option

### DIFF
--- a/gcovr/args.py
+++ b/gcovr/args.py
@@ -136,6 +136,13 @@ def parse_arguments():
         default=False
     )
     parser.add_option(
+        '--html-encoding',
+        help='HTML file encoding (default: UTF-8).',
+        action='store',
+        dest='html_encoding',
+        default='UTF-8'
+    )
+    parser.add_option(
         '--html-absolute-paths',
         help='Set the paths in the HTML report to be absolute instead '
              'of relative.',

--- a/gcovr/prints/html.py
+++ b/gcovr/prints/html.py
@@ -270,7 +270,7 @@ root_page = Template('''
 <html>
 
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <meta http-equiv="Content-Type" content="text/html; charset=${ENC}"/>
   <title>${HEAD}</title>
   <style media="screen" type="text/css">
   ${CSS}
@@ -371,7 +371,7 @@ source_page = Template('''
 <html>
 
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <meta http-equiv="Content-Type" content="text/html; charset=${ENC}"/>
   <title>${HEAD}</title>
   <style media="screen" type="text/css">
   ${CSS}
@@ -469,6 +469,7 @@ def print_html_report(covdata, options):
         details = False
     data = {}
     data['HEAD'] = "Head"
+    data['ENC'] = options.html_encoding
     data['VERSION'] = version_str()
     data['TIME'] = str(int(time()))
     data['DATE'] = date.today().isoformat()


### PR DESCRIPTION
This option provides ability to set output html files
encoding other than default UTF-8.
