### PR TITLE
allow users (esp. Clang users) to supply args to the gcov command

### DIFF
--- a/scripts/gcovr
+++ b/scripts/gcovr
@@ -805,6 +805,12 @@ def process_datafile(filename, covdata, options):
             sys.stdout.write(
                 "Running gcov: '%s' in '%s'\n" % (' '.join(cmd), os.getcwd())
             )
+
+        # If the first element of cmd - the executable name - has embedded spaces it probably
+        # includes extra arguments.  Replace the first element of "cmd" with a sequence consisting
+        # of its space-separated components:
+        cmd[0:1]=cmd[0].split(' ')
+
         out, err = subprocess.Popen(
             cmd, env=env,
             stdout=subprocess.PIPE,


### PR DESCRIPTION
Analyzing coverage reports generated by Clang/LLVM requires the use of a substitute for `gcov`.  gcovr supports doing this via an environment variable **GCOV** or with a command line option.  Unfortunately Clang users must run not just a single command, but a command with an option: `llvm-cov gcov`.  This results in an error when gcovr tries to run the gcov subprocess.

This PR addresses the problem by interpreting gcov commands with embedded spaces as a command with supplied arguments and prefixes its own set of arguments with those supplied by the user.  The result is that Clang users can run gcovr with something like:

```
GCOV='llvm-cov gcov' gcovr --root=. other-arguments...
```
and get good results.