### PR TITLE
ensure that path is not using / on windows

### DIFF
--- a/scripts/gcovr
+++ b/scripts/gcovr
@@ -1577,7 +1577,7 @@ def print_html_report(covdata, details):
     )
     for f in keys:
         cdata = covdata[f]
-        filtered_fname = options.root_filter.sub('', f)
+        filtered_fname = os.path.normpath(options.root_filter.sub('', f))
         files.append(filtered_fname)
         dirs.append(os.path.dirname(filtered_fname) + os.sep)
         cdata._filename = filtered_fname


### PR DESCRIPTION
I hit a problem that the file path for html report would contain "/" characters and windows doesn't like that. So gcovr would bail out with an IO Error. Normalizing the path ensures that all "/" are converted to "\" on windows.

Add: (I don't know from where the slashes are coming from, maybe mingw?)
