### PR TITLE
Out of Source build that reflects proper use case

### DIFF
--- a/gcovr/tests/oos/Makefile
+++ b/gcovr/tests/oos/Makefile
@@ -1,10 +1,10 @@
 CFLAGS= -fprofile-arcs -ftest-coverage -fPIC
 
 all:
-	mkdir -p build
-	$(CXX) $(CFLAGS) -c src/file1.cpp -o build/file1.o
-	$(CXX) $(CFLAGS) -c src/main.cpp -o build/main.o
-	$(CXX) $(CFLAGS) build/main.o build/file1.o -o build/testcase
+	mkdir -p build/src
+	cd build; $(CXX) $(CFLAGS) -c ../src/file1.cpp -o src/file1.o
+	cd build; $(CXX) $(CFLAGS) -c ../src/main.cpp -o src/main.o
+	cd build; $(CXX) $(CFLAGS) src/main.o src/file1.o -o testcase
 
 run: txt xml html
 
@@ -23,5 +23,5 @@ html:
 	../../../scripts/gcovr $(GCOVR_TEST_OPTIONS) -d --html --html-details -o coverage.html
 
 clean:
-	rm -f build/*
+	rm -rf build/*
 	rm -f coverage.txt coverage.xml coverage*.html


### PR DESCRIPTION
The following change to the oos testcase, such that I believe it more
closely reflects how tools like autoconf/automake/cmake perform out of
source builds (what they call vpath builds)

It currently fails, showing that gcovr has issues with oos paths.
See github issues #61 #64 #72 #112