### PR TITLE
Add --fail-under-line and --fail-under-branch options to return exit status 2/4/6 under a coverage threshold

### DIFF
--- a/gcovr/tests/simple1/Makefile
+++ b/gcovr/tests/simple1/Makefile
@@ -5,6 +5,10 @@ run: txt xml html
 
 txt:
 	./testcase
+	../../../scripts/gcovr --fail-under-line 80.1; test $$? -eq 2
+	../../../scripts/gcovr --fail-under-branch 50.1; test $$? -eq 4
+	../../../scripts/gcovr --fail-under-line 80.1 --fail-under-branch 50.1; test $$? -eq 6
+	../../../scripts/gcovr --fail-under-line 79.9 --fail-under-branch 49.9
 	../../../scripts/gcovr -d -o coverage.txt
 
 xml:

--- a/scripts/gcovr
+++ b/scripts/gcovr
@@ -1039,9 +1039,9 @@ def print_text_report(covdata):
 
 
 #
-# Prints a small report to the standard output
+# Get global statistics
 #
-def print_summary(covdata):
+def get_global_stats(covdata):
     lines_total = 0
     lines_covered = 0
     branches_total = 0
@@ -1064,6 +1064,18 @@ def print_summary(covdata):
     percent_branches = branches_total and \
         (100.0 * branches_covered / branches_total)
 
+    return (lines_total, lines_covered, percent,
+            branches_total, branches_covered, percent_branches)
+
+
+#
+# Prints a small report to the standard output
+#
+def print_summary(covdata):
+    (lines_total, lines_covered, percent,
+        branches_total, branches_covered,
+        percent_branches) = get_global_stats(covdata)
+
     lines_out = "lines: %0.1f%% (%s out of %s)\n" % (
         percent, lines_covered, lines_total
     )
@@ -1073,6 +1085,22 @@ def print_summary(covdata):
 
     sys.stdout.write(lines_out)
     sys.stdout.write(branches_out)
+
+
+#
+# Exits with status 2 if below threshold
+#
+def fail_under(covdata, threshold_line, threshold_branch):
+    (lines_total, lines_covered, percent,
+        branches_total, branches_covered,
+        percent_branches) = get_global_stats(covdata)
+
+    if percent < threshold_line and percent_branches < threshold_branch:
+        sys.exit(6)
+    if percent < threshold_line:
+        sys.exit(2)
+    if percent_branches < threshold_branch:
+        sys.exit(4)
 
 
 #
@@ -2260,6 +2288,28 @@ parser.add_option(
     dest="print_summary",
     default=False
 )
+parser.add_option(
+    "--fail-under-line",
+    type="float",
+    metavar="MIN",
+    help="Exit with a status of 2 if the total line coverage is less "
+         "than MIN. "
+         "Can be ORed with exit status of '--fail-under-branch' option",
+    action="store",
+    dest="fail_under_line",
+    default=0.0
+)
+parser.add_option(
+    "--fail-under-branch",
+    type="float",
+    metavar="MIN",
+    help="Exit with a status of 4 if the total branch coverage is less "
+         "than MIN. "
+         "Can be ORed with exit status of '--fail-under-line' option",
+    action="store",
+    dest="fail_under_branch",
+    default=0.0
+)
 parser.usage = "gcovr [options]"
 parser.description = \
     "A utility to run gcov and generate a simple report that summarizes " \
@@ -2381,3 +2431,6 @@ else:
 
 if options.print_summary:
     print_summary(covdata)
+
+if options.fail_under_line > 0.0 or options.fail_under_branch > 0.0:
+    fail_under(covdata, options.fail_under_line, options.fail_under_branch)


### PR DESCRIPTION
This might be useful to fail tests if coverage is not high enough.