### PR TITLE
Use pypy3.5-5.8.0 for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     env: CXX=g++-5 CC=gcc-5 GCOV=gcov-5
   - python: '3.5'
     env: CXX=g++-5 CC=gcc-5 GCOV=gcov-5
-  - python: pypy3
+  - python: pypy3.5-5.8.0
     env: CXX=g++-5 CC=gcc-5 GCOV=gcov-5
 
 install:


### PR DESCRIPTION
pypy3 is broken on travis-ci c.f. travis-ci/travis-ci#6277
Update `.travis.yml` to use `pypy3.5-5.8.0` for testing