### PR TITLE
Saner XML tests

### DIFF
--- a/gcovr/tests/simple1/reference/coverage.xml
+++ b/gcovr/tests/simple1/reference/coverage.xml
@@ -1,4 +1,4 @@
-<?xml version="" ?>
+<?xml version="1.0" ?>
 <!DOCTYPE coverage
   SYSTEM 'http://cobertura.sourceforge.net/xml/coverage-04.dtd'>
 <coverage branch-rate="0.5" branches-covered="4" branches-valid="8" complexity="0.0" line-rate="0.8" lines-covered="8" lines-valid="10" timestamp="" version="">

--- a/gcovr/tests/test_gcovr.py
+++ b/gcovr/tests/test_gcovr.py
@@ -41,7 +41,7 @@ class GcovrXml(unittest.TestCase):
         reference = os.path.join('reference', 'coverage.xml')
         self.scrub_xml(coverage)
         self.scrub_xml(reference)
-        self.assertMatchesXmlBaseline(coverage, reference, tolerance=1e-4)
+        self.assertMatchesXmlBaseline(coverage, reference, tolerance=1e-4, exact=True)
 
 GcovrXml = unittest.category('smoke')(GcovrXml)
 

--- a/gcovr/tests/test_gcovr.py
+++ b/gcovr/tests/test_gcovr.py
@@ -20,22 +20,28 @@ GcovrTxt = unittest.category('smoke')(GcovrTxt)
 class GcovrXml(unittest.TestCase):
     def __init__(self, *args, **kwds):
         unittest.TestCase.__init__(self, *args, **kwds)
-        self.xml_re = re.compile('((timestamp)|(version))="[^"]*"')
+        self.xml_attrs_re = re.compile(r'(timestamp)="[^"]*"')
+        self.gcovr_version_re = re.compile(r'version="gcovr [^"]+"')
+
+    def scrub_xml(self, filename):
+        F = open(filename)
+        contents = F.read()
+        F.close()
+
+        contents = self.xml_attrs_re.sub('\\1=""', contents)
+        contents = self.gcovr_version_re.sub('version=""', contents)
+        contents = contents.replace("\r","")
+
+        F = open(filename, 'w')
+        F.write(contents)
+        F.close()
 
     def compare_xml(self):
-        F = open("coverage.xml")
-        testData = self.xml_re.sub('\\1=""',F.read()).replace("\r","")
-        F.close()
-        F = open('coverage.xml', 'w')
-        F.write(testData)
-        F.close()
-        F = open("reference/coverage.xml")
-        refData = self.xml_re.sub('\\1=""',F.read()).replace("\r","")
-        F.close()
-        F = open('reference/coverage.xml', 'w')
-        F.write(refData)
-        F.close()
-        self.assertMatchesXmlBaseline('coverage.xml', os.path.join('reference','coverage.xml'), tolerance=1e-4)
+        coverage = 'coverage.xml'
+        reference = os.path.join('reference', 'coverage.xml')
+        self.scrub_xml(coverage)
+        self.scrub_xml(reference)
+        self.assertMatchesXmlBaseline(coverage, reference, tolerance=1e-4)
 
 GcovrXml = unittest.category('smoke')(GcovrXml)
 

--- a/gcovr/tests/use-existing/reference/coverage.xml
+++ b/gcovr/tests/use-existing/reference/coverage.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <!DOCTYPE coverage
   SYSTEM 'http://cobertura.sourceforge.net/xml/coverage-03.dtd'>
-<coverage branch-rate="0.5" line-rate="0.8" timestamp="" version="">
+<coverage branch-rate="0.5" branches-covered="4" branches-valid="8" complexity="0.0" line-rate="0.8" lines-covered="8" lines-valid="10" timestamp="" version="">
 <sources>
 <source>.</source>
 </sources>

--- a/gcovr/tests/use-existing/reference/coverage.xml
+++ b/gcovr/tests/use-existing/reference/coverage.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <!DOCTYPE coverage
   SYSTEM 'http://cobertura.sourceforge.net/xml/coverage-03.dtd'>
-<coverage branch-rate="0.5" line-rate="0.8" timestamp="1471799597" version="gcovr 3.3">
+<coverage branch-rate="0.5" line-rate="0.8" timestamp="" version="">
 <sources>
 <source>.</source>
 </sources>


### PR DESCRIPTION
The work on #186 and #164  by @libPhipp highlighted two problems with the XML tests:

 1. The XML files are scrubbed with a simple regex to remove the gcovr version. This also removes the XML version, thus creating an invalid XML document. The version regex was made more picky to only scrub gcovr versions.

 2. The tests did not assert that exactly the expected document was created, but would ignore unexpected data. Now the documents must be an exact match. Formatting and order is still ignored.