### PR TITLE
Fix most PEP 8 warnings + CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,11 @@ install:
 - pip install ply
 - pip install ordereddict
 - pip install pyutilib
+- pip install flake8
 - python setup.py develop
 
 script:
+- flake8 --ignore=E501 --exclude=admin scripts/gcovr .
 - nosetests -v
 
 deploy:

--- a/doc/examples/test_examples.py
+++ b/doc/examples/test_examples.py
@@ -6,58 +6,62 @@ from os.path import dirname, abspath, basename
 import sys
 import re
 
-currdir = dirname(abspath(__file__))+os.sep
+currdir = dirname(abspath(__file__)) + os.sep
 datadir = currdir
 
 compilerre = re.compile("^(?P<path>[^:]+)(?P<rest>:.*)$")
-dirre      = re.compile("^([^%s]*/)*" % re.escape(os.sep))
-xmlre      = re.compile("\"(?P<path>[^\"]*/[^\"]*)\"")
-datere     = re.compile("date=\"[^\"]*\"")
-versionre  = re.compile("version=\"[^\"]*\"")
+dirre = re.compile("^([^%s]*/)*" % re.escape(os.sep))
+xmlre = re.compile("\"(?P<path>[^\"]*/[^\"]*)\"")
+datere = re.compile("date=\"[^\"]*\"")
+versionre = re.compile("version=\"[^\"]*\"")
 timestampre = re.compile("timestamp=\"[^\"]*\"")
-failure    = re.compile("^(?P<prefix>.+)file=\"(?P<path>[^\"]+)\"(?P<suffix>.*)$")
+failure = re.compile("^(?P<prefix>.+)file=\"(?P<path>[^\"]+)\"(?P<suffix>.*)$")
+
 
 def filter(line):
-    # for xml, remove prefixes from everything that looks like a 
+    # for xml, remove prefixes from everything that looks like a
     # file path inside ""
     line = xmlre.sub(
-            lambda match: '"'+re.sub("^[^/]+/", "", match.group(1))+'"',
-            line
-            )
+        lambda match: '"' + re.sub("^[^/]+/", "", match.group(1)) + '"',
+        line
+    )
     # Remove date info
-    line = datere.sub( lambda match: 'date=""', line)
+    line = datere.sub(lambda match: 'date=""', line)
     # Remove version info
-    line = versionre.sub( lambda match: 'version=""', line)
+    line = versionre.sub(lambda match: 'version=""', line)
     # Remove timestamp info
-    line = timestampre.sub( lambda match: 'timestamp=""', line)
+    line = timestampre.sub(lambda match: 'timestamp=""', line)
 
     if 'Running' in line:
         return False
     if "IGNORE" in line:
         return True
-    pathmatch = compilerre.match(line) # see if we can remove the basedir
-    failmatch = failure.match(line) # see if we can remove the basedir
-    #print "HERE", pathmatch, failmatch
+    pathmatch = compilerre.match(line)  # see if we can remove the basedir
+    failmatch = failure.match(line)  # see if we can remove the basedir
+    # print "HERE", pathmatch, failmatch
     if failmatch:
         parts = failmatch.groupdict()
-        #print "X", parts
+        # print "X", parts
         line = "%s file=\"%s\" %s" % (parts['prefix'], dirre.sub("", parts['path']), parts['suffix'])
     elif pathmatch:
         parts = pathmatch.groupdict()
-        #print "Y", parts
+        # print "Y", parts
         line = dirre.sub("", parts['path']) + parts['rest']
     return line
 
+
 # Declare an empty TestCase class
-class Test(unittest.TestCase): pass
+class Test(unittest.TestCase):
+    pass
+
 
 if not sys.platform.startswith('win'):
     # Find all *.sh files, and use them to define baseline tests
-    for file in glob.glob(datadir+'*.sh'):
+    for file in glob.glob(datadir + '*.sh'):
         bname = basename(file)
-        name=bname.split('.')[0]
-        if os.path.exists(datadir+name+'.txt'):
-            Test.add_baseline_test(cwd=datadir, cmd=file, baseline=datadir+name+'.txt', name=name, filter=filter)
+        name = bname.split('.')[0]
+        if os.path.exists(datadir + name + '.txt'):
+            Test.add_baseline_test(cwd=datadir, cmd=file, baseline=datadir + name + '.txt', name=name, filter=filter)
 
 # Execute the tests
 if __name__ == '__main__':

--- a/doc/include_anchors.py
+++ b/doc/include_anchors.py
@@ -13,8 +13,9 @@ pat3 = re.compile('([^@]+)@:([a-zA-Z0-9]+)')
 
 processed = set()
 
+
 def process(dir, root, suffix):
-    #print "PROCESS ",root, suffix
+    # print "PROCESS ",root, suffix
     bname = "%s%s" % (dir, root)
     global processed
     if bname in processed:
@@ -39,14 +40,14 @@ def process(dir, root, suffix):
     INPUT.close()
     for anchor in anchors:
         if anchor != '':
-            print "ERROR: anchor '%s' did not terminate" % anchor
+            print("ERROR: anchor '%s' did not terminate" % anchor)
         anchors[anchor].close()
     #
     processed.add(bname)
 
 
 for file in sys.argv[1:]:
-    print "Processing file '%s' ..." % file
+    print("Processing file '%s' ..." % file)
     INPUT = open(file, 'r')
     for line in INPUT:
         suffix = None
@@ -69,13 +70,12 @@ for file in sys.argv[1:]:
             if m:
                 suffix = 'cpp'
         #
-        if not suffix is None:
-            #print "HERE", line, suffix
-            fname = m.group(1)+m.group(2)+'.'+suffix
+        if suffix is not None:
+            # print "HERE", line, suffix
+            fname = m.group(1) + m.group(2) + '.' + suffix
             if not os.path.exists(fname):
-                print line
-                print "ERROR: file '%s' does not exist!" % fname
+                print(line)
+                print("ERROR: file '%s' does not exist!" % fname)
                 sys.exit(1)
             process(m.group(1), m.group(2), suffix)
     INPUT.close()
-

--- a/gcovr/tests/test_gcovr.py
+++ b/gcovr/tests/test_gcovr.py
@@ -10,9 +10,11 @@ import pyutilib.th as unittest
 basedir = os.path.split(os.path.abspath(__file__))[0]
 starting_dir = os.getcwd()
 
+
 class GcovrTxt(unittest.TestCase):
     def __init__(self, *args, **kwds):
         unittest.TestCase.__init__(self, *args, **kwds)
+
 
 GcovrTxt = unittest.category('smoke')(GcovrTxt)
 
@@ -30,7 +32,7 @@ class GcovrXml(unittest.TestCase):
 
         contents = self.xml_attrs_re.sub('\\1=""', contents)
         contents = self.gcovr_version_re.sub('version=""', contents)
-        contents = contents.replace("\r","")
+        contents = contents.replace("\r", "")
 
         F = open(filename, 'w')
         F.write(contents)
@@ -43,6 +45,7 @@ class GcovrXml(unittest.TestCase):
         self.scrub_xml(reference)
         self.assertMatchesXmlBaseline(coverage, reference, tolerance=1e-4, exact=True)
 
+
 GcovrXml = unittest.category('smoke')(GcovrXml)
 
 
@@ -53,80 +56,82 @@ class GcovrHtml(unittest.TestCase):
 
     def compare_html(self):
         F = open("coverage.html")
-        testData = self.xml_re.sub('\\1=""',F.read()).replace("\r","")
+        testData = self.xml_re.sub('\\1=""', F.read()).replace("\r", "")
         F.close()
         F = open('coverage.html', 'w')
         F.write(testData)
         F.close()
         F = open("reference/coverage.html")
-        refData = self.xml_re.sub('\\1=""',F.read()).replace("\r","")
+        refData = self.xml_re.sub('\\1=""', F.read()).replace("\r", "")
         F.close()
         F = open('reference/coverage.html', 'w')
         F.write(refData)
         F.close()
-        #self.assertSequenceEqual(testData.split('\n'), refData.split('\n'))
-        self.assertMatchesXmlBaseline('coverage.html', os.path.join('reference','coverage.html'), tolerance=1e-4)
+        # self.assertSequenceEqual(testData.split('\n'), refData.split('\n'))
+        self.assertMatchesXmlBaseline('coverage.html', os.path.join('reference', 'coverage.html'), tolerance=1e-4)
+
 
 GcovrHtml = unittest.category('smoke')(GcovrHtml)
 
 
 def run(cmd):
     try:
-        proc = subprocess.Popen( cmd,
-                                 stdout=subprocess.PIPE,
-                                 stderr=subprocess.STDOUT,
-                                 env=os.environ )
+        proc = subprocess.Popen(cmd,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT,
+                                env=os.environ)
         print("STDOUT - START")
-        sys.stdout.write("%s"%proc.communicate()[0])
+        sys.stdout.write("%s" % proc.communicate()[0])
         print("STDOUT - END")
         return not proc.returncode
     except Exception:
         e = sys.exc_info()[1]
         sys.stdout.write("Caught unexpected exception in test driver: %s\n%s"
-                         % ( str(e), traceback.format_exc() ))
+                         % (str(e), traceback.format_exc()))
         raise
-    
 
-    
 
 @unittest.nottest
 def gcovr_test_txt(self, name):
-    os.chdir(os.path.join(basedir,name))
-    run(["make","clean"]) or self.fail("Clean failed")
+    os.chdir(os.path.join(basedir, name))
+    run(["make", "clean"]) or self.fail("Clean failed")
     run(["make"]) or self.fail("Make failed")
-    run(["make","txt"]) or self.fail("Execution failed")
+    run(["make", "txt"]) or self.fail("Execution failed")
     self.assertFileEqualsBaseline("coverage.txt", "reference/coverage.txt")
-    run(["make","clean"]) or self.fail("Clean failed")
+    run(["make", "clean"]) or self.fail("Clean failed")
     os.chdir(basedir)
+
 
 @unittest.nottest
 def gcovr_test_xml(self, name):
-    os.chdir(os.path.join(basedir,name))
-    run(["make","clean"]) or self.fail("Clean failed")
+    os.chdir(os.path.join(basedir, name))
+    run(["make", "clean"]) or self.fail("Clean failed")
     run(["make"]) or self.fail("Make failed")
-    run(["make","xml"]) or self.fail("Execution failed")
+    run(["make", "xml"]) or self.fail("Execution failed")
     self.compare_xml()
-    run(["make","clean"]) or self.fail("Clean failed")
+    run(["make", "clean"]) or self.fail("Clean failed")
     os.chdir(basedir)
+
 
 @unittest.nottest
 def gcovr_test_html(self, name):
-    os.chdir(os.path.join(basedir,name))
+    os.chdir(os.path.join(basedir, name))
     run(["make"]) or self.fail("Make failed")
-    run(["make","html"]) or self.fail("Execution failed")
+    run(["make", "html"]) or self.fail("Execution failed")
     self.compare_html()
-    run(["make","clean"]) or self.fail("Clean failed")
+    run(["make", "clean"]) or self.fail("Clean failed")
     os.chdir(basedir)
 
-skip_dirs = [ '.', '..', '.svn' ]
+
+skip_dirs = ['.', '..', '.svn']
 
 for f in os.listdir(basedir):
-    if os.path.isdir(os.path.join(basedir,f)) and f not in skip_dirs:
+    if os.path.isdir(os.path.join(basedir, f)) and f not in skip_dirs:
         if 'pycache' in f:
             continue
         GcovrTxt.add_fn_test(fn=gcovr_test_txt, name=f)
         GcovrXml.add_fn_test(fn=gcovr_test_xml, name=f)
-        #GcovrHtml.add_fn_test(fn=gcovr_test_html, name=f)
-	
+        # GcovrHtml.add_fn_test(fn=gcovr_test_html, name=f)
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/gcovr
+++ b/scripts/gcovr
@@ -533,14 +533,14 @@ def process_gcov_data(data_fname, covdata, source_fname, options):
 
     if options.verbose:
         print("Finding source file corresponding to a gcov data file")
-        print('  currdir      '+currdir)
-        print('  gcov_fname   '+data_fname)
-        print('               '+str(segments))
-        print('  source_fname '+str(source_fname))
-        print('  root         '+root_dir)
-        # print('  common_dir   '+common_dir)
-        # print('  subdir       '+subdir)
-        print('  fname        '+fname)
+        print('  currdir      ' + currdir)
+        print('  gcov_fname   ' + data_fname)
+        print('               ' + str(segments))
+        print('  source_fname ' + str(source_fname))
+        print('  root         ' + root_dir)
+        # print('  common_dir   ' + common_dir)
+        # print('  subdir       ' + subdir)
+        print('  fname        ' + fname)
 
     if options.verbose:
         sys.stdout.write("Parsing coverage data for file %s\n" % fname)
@@ -589,7 +589,7 @@ def process_gcov_data(data_fname, covdata, source_fname, options):
         if len(segments) > 1:
             try:
                 lineno = int(segments[1].strip())
-            except:
+            except:  # noqa E722
                 pass  # keep previous line number!
 
         if exclude_line_flag in line:
@@ -672,7 +672,7 @@ def process_gcov_data(data_fname, covdata, source_fname, options):
                 fields = line.split()
                 try:
                     count = int(fields[3])
-                except:
+                except:  # noqa E722
                     count = 0
                 branches.setdefault(lineno, {})[int(fields[1])] = count
         elif tmp.startswith('call'):
@@ -710,10 +710,10 @@ def process_gcov_data(data_fname, covdata, source_fname, options):
             excluding.pop()
 
     if options.verbose:
-        print('uncovered '+str(uncovered))
-        print('covered '+str(covered))
-        print('branches '+str(branches))
-        print('noncode '+str(noncode))
+        print('uncovered ' + str(uncovered))
+        print('covered ' + str(covered))
+        print('branches ' + str(branches))
+        print('noncode ' + str(noncode))
     #
     # If the file is already in covdata, then we
     # remove lines that are covered here.  Otherwise,
@@ -763,7 +763,7 @@ def process_gcov_data(data_fname, covdata, source_fname, options):
 #
 def process_datafile(filename, covdata, options):
     if options.verbose:
-        print("Processing file: "+filename)
+        print("Processing file: " + filename)
     #
     # Launch gcov
     #
@@ -2369,6 +2369,7 @@ if options.root is not None:
 else:
     root_dir = starting_dir
 
+
 #
 # Setup filters
 #
@@ -2381,6 +2382,7 @@ def build_filter(regex):
         return re.compile(re.escape(os.getcwd() + "\\") + regex)
     else:
         return re.compile(os.path.realpath(regex))
+
 
 for i in range(0, len(options.exclude)):
     options.exclude[i] = build_filter(options.exclude[i])

--- a/setup.py
+++ b/setup.py
@@ -14,12 +14,13 @@ Script to generate the installer for gcovr.
 
 import glob
 import os
+import os.path
+from setuptools import setup
+
 
 def read(*rnames):
     return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
 
-from setuptools import setup
-import os.path
 
 if os.path.exists('README.md'):
     import shutil
@@ -30,25 +31,24 @@ setup(name='gcovr',
       version='3.3',
       maintainer='William Hart',
       maintainer_email='wehart@sandia.gov',
-      url = 'http://gcovr.com',
-      license = 'BSD',
-      platforms = ["any"],
-      description = 'A Python script for summarizing gcov data.',
-      long_description = read('README.txt'),
-      classifiers = [
-            'Development Status :: 4 - Beta',
-            'Intended Audience :: End Users/Desktop',
-            'Intended Audience :: Science/Research',
-            'License :: OSI Approved :: BSD License',
-            'Natural Language :: English',
-            'Operating System :: Microsoft :: Windows',
-            'Operating System :: Unix',
-            'Programming Language :: Python',
-            'Programming Language :: Unix Shell',
-            'Topic :: Software Development :: Libraries :: Python Modules'
-        ],
+      url='http://gcovr.com',
+      license='BSD',
+      platforms=["any"],
+      description='A Python script for summarizing gcov data.',
+      long_description=read('README.txt'),
+      classifiers=[
+          'Development Status :: 4 - Beta',
+          'Intended Audience :: End Users/Desktop',
+          'Intended Audience :: Science/Research',
+          'License :: OSI Approved :: BSD License',
+          'Natural Language :: English',
+          'Operating System :: Microsoft :: Windows',
+          'Operating System :: Unix',
+          'Programming Language :: Python',
+          'Programming Language :: Unix Shell',
+          'Topic :: Software Development :: Libraries :: Python Modules'
+      ],
       packages=['gcovr'],
       keywords=['utility'],
       scripts=scripts
       )
-


### PR DESCRIPTION
Follow-up on #187 
Added TravisCI testing.
`admin` folder is excluded from the check
There are 2 `# noqa` exceptions in `scripts/gcovr`:
```
scripts/gcovr:592:13: E722 do not use bare except'
scripts/gcovr:675:17: E722 do not use bare except'
```
