### PR TITLE
expand README with user + contribution guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@ gcovr
 
 generate GCC code coverage reports
 
-[website] • [documentation] • [bugtracker] • [GitHub][repo] • [![Build Status][travis-ci-badge]][travis-ci]
+[website] • [documentation] • [bugtracker] • [GitHub][repo]
+
+[![Build Status][travis-ci-badge]][travis-ci] [![Install from PyPI][pypi-badge]][pypi]
 
 Gcovr provides a utility for managing the use of the GNU gcov utility
 and generating summarized code coverage results. This command is
@@ -37,7 +39,9 @@ Example HTML details:
   [repo]:       https://github.com/gcovr/gcovr/
   [bugtracker]: https://github.com/gcovr/gcovr/issues
   [travis-ci]: https://travis-ci.org/gcovr/gcovr
-  [travis-ci-badge]: https://api.travis-ci.org/gcovr/gcovr.svg?branch=master
+  [travis-ci-badge]: https://travis-ci.org/gcovr/gcovr.svg?branch=master
+  [pypi]: https://pypi.python.org/pypi/gcovr
+  [pypi-badge]: https://img.shields.io/pypi/v/gcovr.svg
 
 Installation
 ------------

--- a/README.md
+++ b/README.md
@@ -1,22 +1,140 @@
-[![Build Status](https://travis-ci.org/gcovr/gcovr.png?branch=master)](https://travis-ci.org/gcovr/gcovr) 
+gcovr
+=====
 
-Gcovr Overview
---------
+generate GCC code coverage reports
+
+[website] • [documentation] • [bugtracker] • [GitHub][repo] • [![Build Status](https://travis-ci.org/gcovr/gcovr.png?branch=master)][travis-ci]
 
 Gcovr provides a utility for managing the use of the GNU gcov utility
 and generating summarized code coverage results. This command is
 inspired by the Python coverage.py package, which provides a similar
-utility in Python. The gcovr command produces either compact
-human-readable summary reports, machine readable XML reports (in
-Cobertura format) or simple HTML reports. Thus, gcovr can be viewed
+utility for Python.
+
+The gcovr command can produce different kinds of coverage reports:
+
+  - default: compact human-readable summaries
+  - `--xml`: machine readable XML reports in Cobertura format
+  - `--html`: HTML summaries
+  - `--html-details`: HTML report with annotated source files
+
+Thus, gcovr can be viewed
 as a command-line alternative to the lcov utility, which runs gcov
 and generates an HTML-formatted report.
 
+Example HTML summary:
+
+![Example HTML summary][fig:html-summary]
+
+Example HTML details:
+
+![Example HTML details][fig:html-details]
+
+  [fig:html-summary]: doc/examples/example1.png
+  [fig:html-details]: doc/examples/example2_example1_cpp.png
+
+  [website]:        http://gcovr.com/
+  [documentation]:  http://gcovr.com/guide.html
+  [repo]:       https://github.com/gcovr/gcovr/
+  [bugtracker]: https://github.com/gcovr/gcovr/issues
+  [travis-ci]: https://travis-ci.org/gcovr/gcovr
+
+Installation
+------------
+
+Gcovr is available as a Python package that can be installed via [pip].
+
+  [pip]: https://pip.pypa.io/en/stable/
+
+Install newest stable release from PyPI:
+
+    pip install gcovr
+
+Install development version from GitHub:
+
+    pip install git+https://github.com/gcovr/gcovr.git
+
+Quickstart
+----------
+
+GCC can instrument the executables to emit coverage data.
+You need to recompile your code with the following flags:
+
+    -fprofile-arcs -ftest-coverage -g -O0
+
+Next, run your test suite.
+This will generate raw coverage files.
+
+Finally, invoke gcovr.
+This will print a tabular report on the console.
+
+    gcovr -r .
+
+You can also generate detailed HTML reports:
+
+    gcovr -r . --html --html-details -o coverage.html
+
+Gcovr will create one HTML report per source file next to the coverage.html summary.
+
+You should run gcovr from the build directory.
+The `-r` option should point to the root of your project.
+This only matters if you have a separate build directory.
+
+For complete documentation, read the [manual][documentation].
+
+Contributing
+------------
+
+When reporting a bug, first [search our issues][search all issues] to avoid duplicates.
+In your bug report, please describe what you expected gcovr to do, and what it actually did.
+Also try to include the following details:
+
+  - how you invoked gcovr, i.e. the exact flags and from which directory
+  - your project layout
+  - your gcovr version
+  - your compiler version
+  - your operating system
+  - and any other relevant details.
+
+Ideally, you can provide a short script and the smallest possible source file 
+to reproduce the problem.
+
+If you would like to help out, please take a look at our [open issues][bugtracker] and [pull requests].
+Maybe you know the answer to some problem,
+or can contribute your perspective as a gcovr user.
+In particular, testing proposed changes in your real-world project is very valuable.
+The issues labeled “[help wanted][label: help wanted]” and “[needs review][label: needs review]” would have the greatest impact.
+
+  [label: help wanted]: https://github.com/gcovr/gcovr/labels/help%20wanted
+  [label: needs review]: https://github.com/gcovr/gcovr/labels/needs%20review
+  [pull requests]: https://github.com/gcovr/gcovr/pulls
+  [search all issues]: https://github.com/gcovr/gcovr/issues?q=is%3Aissue
+
+Pull requests with bugfixes are welcome!
+If you want to contribute an enhancement,
+please open a new issue first so that your proposal can be discussed and honed.
+
+To work on the gcovr source code, you can clone the git repository, then run “`pip install -e .`”.
+To run the tests, you also have to “`pip install pyutilib`”.
+
+Currently, the whole program is in the `scripts/gcovr` file.
+It is roughly divided in coverage processing, the various output formats, and in the command line interface.
+The tests are in the `gcovr/tests` directory.
+You can run the tests with `nosetests -v`.
+
+After you've contributed a bit, consider becoming a gcovr developer.
+As a developer, you can:
+
+  - manage issues (label and close them)
+  - approve pull requests
+  - merge approved pull requests
+  - participate in votes
+
+Just open an issue that you're interested, and we'll have a quick vote.
+
+License
+-------
+
 Gcovr is available under the BSD License.
-
-A user guide can be downloaded from the [gcovr home page](http://gcovr.com).
-
-Developer discussions are hosted by [google groups](https://groups.google.com/forum/#!forum/gcovr-developers).
 
 Gcovr development moved to this repository in September, 2013 from
 Sandia National Laboratories.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ gcovr
 
 generate GCC code coverage reports
 
-[website] • [documentation] • [bugtracker] • [GitHub][repo] • [![Build Status](https://travis-ci.org/gcovr/gcovr.png?branch=master)][travis-ci]
+[website] • [documentation] • [bugtracker] • [GitHub][repo] • [![Build Status][travis-ci-badge]][travis-ci]
 
 Gcovr provides a utility for managing the use of the GNU gcov utility
 and generating summarized code coverage results. This command is
@@ -37,6 +37,7 @@ Example HTML details:
   [repo]:       https://github.com/gcovr/gcovr/
   [bugtracker]: https://github.com/gcovr/gcovr/issues
   [travis-ci]: https://travis-ci.org/gcovr/gcovr
+  [travis-ci-badge]: https://api.travis-ci.org/gcovr/gcovr.svg?branch=master
 
 Installation
 ------------


### PR DESCRIPTION
The current README is a bit spartan. This PR adds:

 - :link: lots of useful links right at the top
 - :framed_picture: screenshots
 - :building_construction: installation instructions
 - :rocket: quickstart documentation
 - :hammer: contributing guidelines

This cannibalizes a bit on the [guide](http://gcovr.com/guide.html), but I'd rather have the important parts right on the repository start page.

A note on the developer role: I've currently set up the pull requests so that they can be merged by any developer if another developer has approved the PR through GitHub's code review features. (And the Travis build must pass, and there mustn't be any merge conflicts). The goal is that every change that is merged into master will have been seen by at least two people. So the developer role is more about reviewing PRs than about writing code.

Currently I am exercising my admin powers to merge my own PRs without approval. But in the long run I'd like to see other people contributing with reviews and merges, if only so that development can continue if none of the admins is at hand. 