### PR TITLE
Build universal wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1


### PR DESCRIPTION
python setup.py bdist_wheel creates a Pure Python Wheel based on running Python version. Add a directive in setup.cfg to build a Universal Wheel that supports both Python 2 and 3.

c.f. https://packaging.python.org/tutorials/distributing-packages/#universal-
wheels