### PR TITLE
Update changelog, copyright, and author list

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,4 +1,38 @@
-William Hart - lead developer
-John Siirola - lead developer
+Maintainers:
 
-Each release documents author contributions.
+* William Hart
+* John Siirola
+* Lukas Atkinson
+
+Contributors, ordered alphabetically:
+
+* Andrew Stone
+* Arvin Schnell
+* Attie Grande
+* Bernhard Breinbauer
+* Carlos Jenkins
+* goriy
+* ja11sop
+* Jessica Levine
+* John Siirola
+* Jörg Kreuzberger
+* Kai Blaschke
+* Kevin Cai
+* libPhipp
+* Lukas Atkinson
+* Luke Woydziak
+* Matsumoto Taichi
+* Matthias Schmieder
+* Matthieu Darbois
+* Michał Pszona
+* Mikael Salson
+* Mikk Leini
+* Nikolaj Schumacher
+* Piotr Dziwinski
+* Reto Schneider
+* Robert Rosengren
+* Sylvestre Ledru
+* trapzero
+* William Hart
+
+Additionally, each release documents author contributions.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,8 +1,24 @@
 = `gcovr` Release History and Change Log =
 
 === 3.4 ''(TODO)'' ===
- - Fix to support filtering with absolute paths
- - Added --html-encoding command line option (#139)
+ - Added --html-encoding command line option (#139).
+ - Added --fail-under-line and --fail-under-branch options,
+   which will error under a given minimum coverage. (#173, #116)
+ - Better pathname resolution heuristics for --use-gcov-file. (#146)
+ - The --root option defaults to current directory '.'.
+ - Improved reports for "(", ")", ";" lines.
+ - HTML reports show full timestamp, not just date. (#165)
+ - HTML reports treat 0/0 coverage as NaN, not 100% or 0%. (#105, #149, #196)
+ - Add support for coverage-04.dtd Cobertura XML format (#164, #186)
+ - Only Python 2.6+ is supported, with 2.7+ or 3.4+ recommended. (#195)
+ - Added CI testing for Windows using Appveyor. (#189, #200)
+ - Reports use forward slashes in paths, even on Windows. (#200)
+ - Fix to support filtering with absolute paths.
+ - Fix HTML generation with Python 3. (#168, #182, #163)
+ - Fix --html-details under Windows. (#157)
+ - Fix filters under Windows. (#158)
+ - Fix verbose output when using existing gcov files (#143, #144)
+
 
 === 3.3 ''(6 August 2016)'' ===
  - Added CI testing using TravisCI
@@ -16,6 +32,7 @@
  - Fixed unexpected semantics with --root argument (#108)
  - More careful checks for covered lines (#109)
 
+
 === 3.2 ''(5 July 2014)'' ===
  - Adding a test for out of source builds
  - Using the starting directory when processing gcov filenames.
@@ -25,6 +42,7 @@
  - Add option for using existing gcov files (#35)
  - Fixing --root argument processing (#27)
  - Adding logic to cover branches that are ignored (#28)
+
 
 === 3.1 ''(6 December 2013)'' ===
  - Change to make the -r/--root options define the root directory 
@@ -36,6 +54,7 @@
  - Adding tests for deeply nested code, and symbolic links.
  - Add support for multiple —filter options in same manner as —exclude 
    option.
+
 
 === 3.0 ''(10 August 2013)'' ===
  - Adding the '--gcov-executable' option to specify
@@ -57,6 +76,7 @@
  - Added the '—xml-pretty' option, which is used to
    generate pretty XML output for the user manual.
  - Many documentation updates
+
 
 === 2.4 ''(13 April 2012)'' ===
  - New approach to walking the directory tree that is more robust to

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,3 +1,4 @@
+Copyright 2013-2018 the gcovr authors
 Copyright 2013 Sandia Corporation. Under the terms of Contract DE-AC04-
 94AL85000 with Sandia Corporation, the U.S. Government retains certain
 rights in this software.

--- a/README.md
+++ b/README.md
@@ -141,7 +141,15 @@ Just open an issue that you're interested, and we'll have a quick vote.
 License
 -------
 
-Gcovr is available under the BSD License.
+Copyright 2013-2018 the gcovr authors
+
+Copyright 2013 Sandia Corporation.
+Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+the U.S. Government retains certain rights in this software.
+
+Gcovr is available under the 3-clause BSD License.
+See LICENSE.txt for full details.
+See AUTHORS.txt for the full list of contributors.
 
 Gcovr development moved to this repository in September, 2013 from
 Sandia National Laboratories.


### PR DESCRIPTION
 - The changelog lists the most relevant changes since the 3.3 release
 - The AUTHORS file now lists *all* contributors, as extracted from the git log.
 - The copyright statement in the README and LICENSE now states copyright for the 2013–2018 period, credited collectively to “the gcovr authors”.

This PR is part of the 3.4 release preparations, see #202.