### PR TITLE
[Fix #93] --html-detailed triggers html reports by itself

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -11,6 +11,7 @@ The following developers contributed to gcovr (ordered alphabetically):
     Attie Grande,
     Bernhard Breinbauer,
     Carlos Jenkins,
+    Dom Postorivo,
     goriy,
     ja11sop,
     Jessica Levine,

--- a/gcovr/tests/bad++char/Makefile
+++ b/gcovr/tests/bad++char/Makefile
@@ -13,7 +13,7 @@ xml:
 
 html:
 	./testcase
-	../../../scripts/gcovr -d --html --html-details -o coverage.html
+	../../../scripts/gcovr -d --html-details -o coverage.html
 
 clean:
 	rm -f testcase

--- a/gcovr/tests/cmake_oos/Makefile
+++ b/gcovr/tests/cmake_oos/Makefile
@@ -24,7 +24,7 @@ xml:
 
 html:
 	cd build && ./gcovrtest
-	../../../scripts/gcovr -d --html --html-details -o coverage.html
+	../../../scripts/gcovr -d --html-details -o coverage.html
 
 clean:
 	rm -rf build

--- a/gcovr/tests/dot/Makefile
+++ b/gcovr/tests/dot/Makefile
@@ -22,7 +22,7 @@ xml:
 
 html:
 	./.subdir/testcase
-	../../../scripts/gcovr -r . -d --html --html-details -o coverage.html
+	../../../scripts/gcovr -r . -d --html-details -o coverage.html
 
 clean:
 	rm -f ./.subdir/testcase

--- a/gcovr/tests/excl-branch/Makefile
+++ b/gcovr/tests/excl-branch/Makefile
@@ -13,7 +13,7 @@ xml:
 
 html:
 	./testcase
-	../../../scripts/gcovr --exclude-unreachable-branches -b -d --html --html-details -o coverage.html
+	../../../scripts/gcovr --exclude-unreachable-branches -b -d --html-details -o coverage.html
 
 clean:
 	rm -f testcase

--- a/gcovr/tests/excl-line/Makefile
+++ b/gcovr/tests/excl-line/Makefile
@@ -13,7 +13,7 @@ xml:
 
 html:
 	./testcase
-	../../../scripts/gcovr -d --html --html-details -o coverage.html
+	../../../scripts/gcovr -d --html-details -o coverage.html
 
 clean:
 	rm -f testcase

--- a/gcovr/tests/filter-test/Makefile
+++ b/gcovr/tests/filter-test/Makefile
@@ -19,7 +19,7 @@ xml:
 
 html:
 	./testcase
-	../../../scripts/gcovr $(GCOVR_TEST_OPTIONS) -d --html --html-details -o coverage.html
+	../../../scripts/gcovr $(GCOVR_TEST_OPTIONS) -d --html-details -o coverage.html
 
 clean:
 	rm -f testcase

--- a/gcovr/tests/filter-test2/Makefile
+++ b/gcovr/tests/filter-test2/Makefile
@@ -25,7 +25,7 @@ xml:
 
 html:
 	./testcase
-	../../../scripts/gcovr $(GCOVR_TEST_OPTIONS) -d --html --html-details -o coverage.html
+	../../../scripts/gcovr $(GCOVR_TEST_OPTIONS) -d --html-details -o coverage.html
 
 clean:
 	rm -f testcase

--- a/gcovr/tests/linked/Makefile
+++ b/gcovr/tests/linked/Makefile
@@ -23,7 +23,7 @@ xml:
 
 html:
 	./subdir/testcase
-	../../../scripts/gcovr -d --html --html-details -o coverage.html
+	../../../scripts/gcovr -d --html-details -o coverage.html
 
 clean:
 	rm -Rf subdir

--- a/gcovr/tests/nested/Makefile
+++ b/gcovr/tests/nested/Makefile
@@ -23,7 +23,7 @@ xml:
 
 html:
 	./subdir/testcase
-	../../../scripts/gcovr -r subdir -d --html --html-details -o coverage.html
+	../../../scripts/gcovr -r subdir -d --html-details -o coverage.html
 
 clean:
 	rm -f ./subdir/testcase

--- a/gcovr/tests/nested2-use-existing/Makefile
+++ b/gcovr/tests/nested2-use-existing/Makefile
@@ -26,7 +26,7 @@ html:
 	./subdir/B/testcase
 	make -C subdir/A coverage
 	$(GCOV) --branch-counts --branch-probabilities --preserve-paths subdir/B/main.o
-	../../../scripts/gcovr -r subdir -g -k --html --html-details -o coverage.html .
+	../../../scripts/gcovr -r subdir -g -k --html-details -o coverage.html .
 
 clean:
 	rm -f ./subdir/B/testcase subdir/lib.a

--- a/gcovr/tests/nested2/Makefile
+++ b/gcovr/tests/nested2/Makefile
@@ -17,7 +17,7 @@ xml:
 
 html:
 	./subdir/B/testcase
-	../../../scripts/gcovr -r subdir -d --html --html-details -o coverage.html
+	../../../scripts/gcovr -r subdir -d --html-details -o coverage.html
 
 clean:
 	rm -f ./subdir/B/testcase subdir/lib.a

--- a/gcovr/tests/nested3/Makefile
+++ b/gcovr/tests/nested3/Makefile
@@ -25,7 +25,7 @@ xml:
 
 html:
 	./subdir/testcase
-	../../../scripts/gcovr -r subdir --object-directory objs -d --html --html-details -o coverage.html
+	../../../scripts/gcovr -r subdir --object-directory objs -d --html-details -o coverage.html
 
 clean:
 	rm -f ./subdir/testcase

--- a/gcovr/tests/nobranch/Makefile
+++ b/gcovr/tests/nobranch/Makefile
@@ -13,7 +13,7 @@ xml:
 
 html:
 	./testcase
-	../../../scripts/gcovr -d --fail-under-branch 100.0 --html --html-details -o coverage.html
+	../../../scripts/gcovr -d --fail-under-branch 100.0 --html-details -o coverage.html
 
 clean:
 	rm -f testcase

--- a/gcovr/tests/oos/Makefile
+++ b/gcovr/tests/oos/Makefile
@@ -20,7 +20,7 @@ xml:
 
 html:
 	build/testcase
-	../../../scripts/gcovr $(GCOVR_TEST_OPTIONS) -d --html --html-details -o coverage.html
+	../../../scripts/gcovr $(GCOVR_TEST_OPTIONS) -d --html-details -o coverage.html
 
 clean:
 	rm -f build/*

--- a/gcovr/tests/oos2/Makefile
+++ b/gcovr/tests/oos2/Makefile
@@ -20,7 +20,7 @@ xml:
 
 html:
 	build/testcase
-	../../../scripts/gcovr $(GCOVR_TEST_OPTIONS) -d --html --html-details -o coverage.html
+	../../../scripts/gcovr $(GCOVR_TEST_OPTIONS) -d --html-details -o coverage.html
 
 clean:
 	rm -f build/*

--- a/gcovr/tests/shared_lib/Makefile
+++ b/gcovr/tests/shared_lib/Makefile
@@ -57,7 +57,7 @@ ifeq ($(BASE_OS),MSYS_NT)
 else
 	LD_LIBRARY_PATH=`pwd`/lib testApp/test/a.out
 endif
-	../../../scripts/gcovr -d --html --html-details -o coverage.html
+	../../../scripts/gcovr -d --html-details -o coverage.html
 
 clean:
 	rm -rf obj

--- a/gcovr/tests/simple1/Makefile
+++ b/gcovr/tests/simple1/Makefile
@@ -17,7 +17,7 @@ xml:
 
 html:
 	./testcase
-	../../../scripts/gcovr -d --html --html-details -o coverage.html
+	../../../scripts/gcovr -d --html-details -o coverage.html
 
 clean:
 	rm -f testcase

--- a/gcovr/tests/use-existing/Makefile
+++ b/gcovr/tests/use-existing/Makefile
@@ -18,7 +18,7 @@ xml:
 html:
 	./testcase
 	$(GCOV) *.gcda --branch-counts --branch-probabilities --preserve-paths
-	../../../scripts/gcovr -v -g -d --html --html-details -o coverage.html
+	../../../scripts/gcovr -v -g -d --html-details -o coverage.html
 
 clean:
 	rm -f testcase

--- a/gcovr/tests/wspace/Makefile
+++ b/gcovr/tests/wspace/Makefile
@@ -13,7 +13,7 @@ xml:
 
 html:
 	cd 'src code'; ./testcase
-	../../../scripts/gcovr -r 'src code' -d --html --html-details -o coverage.html
+	../../../scripts/gcovr -r 'src code' -d --html-details -o coverage.html
 
 clean:
 	rm -f */testcase

--- a/scripts/gcovr
+++ b/scripts/gcovr
@@ -2419,7 +2419,7 @@ if options.verbose:
 #
 if options.xml or options.prettyxml:
     print_xml_report(covdata)
-elif options.html:
+elif options.html or options.html_details:
     print_html_report(covdata, options.html_details)
 else:
     print_text_report(covdata)


### PR DESCRIPTION
This fixes #93 with the main fix being a simple change to scripts/gcovr. The other changes were to remove the extra --html flags in the test makefiles to confirm the behaviour of the change.

Eventually, we should have separate tests for html and html-detailed, but that seemed like too big of a change for just this fix.