### PR TITLE
Move script/gcovr to gcovr/__main__.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
 - python setup.py develop
 
 script:
-- flake8 --ignore=E501 scripts/gcovr .
+- flake8 --ignore=E501
 - nosetests -v
 
 deploy:

--- a/gcovr/__main__.py
+++ b/gcovr/__main__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding:utf-8 -*-
 #
 # A report generator for gcov 3.4
@@ -2309,7 +2308,9 @@ def build_filter(regex):
         return re.compile(os.path.realpath(regex))
 
 
-def main(options, args):
+def main():
+    global options
+    options, args = parse_arguments()
 
     if options.version:
         sys.stdout.write(
@@ -2430,5 +2431,4 @@ def main(options, args):
 
 
 if __name__ == '__main__':
-    options, args = parse_arguments()
-    main(options, args)
+    main()

--- a/gcovr/tests/bad++char/Makefile
+++ b/gcovr/tests/bad++char/Makefile
@@ -5,15 +5,15 @@ run: txt xml html
 
 txt:
 	./testcase
-	../../../scripts/gcovr -d -o coverage.txt
+	$(GCOVR) -d -o coverage.txt
 
 xml:
 	./testcase
-	../../../scripts/gcovr -d -x -o coverage.xml
+	$(GCOVR) -d -x -o coverage.xml
 
 html:
 	./testcase
-	../../../scripts/gcovr -d --html-details -o coverage.html
+	$(GCOVR) -d --html-details -o coverage.html
 
 clean:
 	rm -f testcase

--- a/gcovr/tests/cmake_oos/Makefile
+++ b/gcovr/tests/cmake_oos/Makefile
@@ -16,15 +16,15 @@ run: txt xml html
 
 txt:
 	cd build && ./gcovrtest
-	../../../scripts/gcovr -d -o coverage.txt
+	$(GCOVR) -d -o coverage.txt
 
 xml:
 	cd build && ./gcovrtest
-	../../../scripts/gcovr -d -x -o coverage.xml
+	$(GCOVR) -d -x -o coverage.xml
 
 html:
 	cd build && ./gcovrtest
-	../../../scripts/gcovr -d --html-details -o coverage.html
+	$(GCOVR) -d --html-details -o coverage.html
 
 clean:
 	rm -rf build

--- a/gcovr/tests/dot/Makefile
+++ b/gcovr/tests/dot/Makefile
@@ -14,15 +14,15 @@ run: txt xml html
 
 txt:
 	./.subdir/testcase
-	../../../scripts/gcovr -r . -d -o coverage.txt
+	$(GCOVR) -r . -d -o coverage.txt
 
 xml:
 	./.subdir/testcase
-	../../../scripts/gcovr -r . -d -x -o coverage.xml
+	$(GCOVR) -r . -d -x -o coverage.xml
 
 html:
 	./.subdir/testcase
-	../../../scripts/gcovr -r . -d --html-details -o coverage.html
+	$(GCOVR) -r . -d --html-details -o coverage.html
 
 clean:
 	rm -f ./.subdir/testcase

--- a/gcovr/tests/excl-branch/Makefile
+++ b/gcovr/tests/excl-branch/Makefile
@@ -5,15 +5,15 @@ run: txt xml html
 
 txt:
 	./testcase
-	../../../scripts/gcovr --exclude-unreachable-branches -b -d -o coverage.txt
+	$(GCOVR) --exclude-unreachable-branches -b -d -o coverage.txt
 
 xml:
 	./testcase
-	../../../scripts/gcovr --exclude-unreachable-branches -b -d -x -o coverage.xml
+	$(GCOVR) --exclude-unreachable-branches -b -d -x -o coverage.xml
 
 html:
 	./testcase
-	../../../scripts/gcovr --exclude-unreachable-branches -b -d --html-details -o coverage.html
+	$(GCOVR) --exclude-unreachable-branches -b -d --html-details -o coverage.html
 
 clean:
 	rm -f testcase

--- a/gcovr/tests/excl-line/Makefile
+++ b/gcovr/tests/excl-line/Makefile
@@ -5,15 +5,15 @@ run: txt xml html
 
 txt:
 	./testcase
-	../../../scripts/gcovr -d -o coverage.txt
+	$(GCOVR) -d -o coverage.txt
 
 xml:
 	./testcase
-	../../../scripts/gcovr -d -x -o coverage.xml
+	$(GCOVR) -d -x -o coverage.xml
 
 html:
 	./testcase
-	../../../scripts/gcovr -d --html-details -o coverage.html
+	$(GCOVR) -d --html-details -o coverage.html
 
 clean:
 	rm -f testcase

--- a/gcovr/tests/filter-test/Makefile
+++ b/gcovr/tests/filter-test/Makefile
@@ -11,15 +11,15 @@ GCOVR_TEST_OPTIONS = -f '.*main.cpp'
 
 txt:
 	./testcase
-	../../../scripts/gcovr $(GCOVR_TEST_OPTIONS) -d -o coverage.txt
+	$(GCOVR) $(GCOVR_TEST_OPTIONS) -d -o coverage.txt
 
 xml:
 	./testcase
-	../../../scripts/gcovr $(GCOVR_TEST_OPTIONS) -d -x -o coverage.xml
+	$(GCOVR) $(GCOVR_TEST_OPTIONS) -d -x -o coverage.xml
 
 html:
 	./testcase
-	../../../scripts/gcovr $(GCOVR_TEST_OPTIONS) -d --html-details -o coverage.html
+	$(GCOVR) $(GCOVR_TEST_OPTIONS) -d --html-details -o coverage.html
 
 clean:
 	rm -f testcase

--- a/gcovr/tests/filter-test2/Makefile
+++ b/gcovr/tests/filter-test2/Makefile
@@ -20,15 +20,15 @@ run: txt xml html
 txt:
 	./testcase
 	echo "$(GCOVR_TEST_OPTIONS)"
-	../../../scripts/gcovr $(GCOVR_TEST_OPTIONS) -d -o coverage.txt
+	$(GCOVR) $(GCOVR_TEST_OPTIONS) -d -o coverage.txt
 
 xml:
 	./testcase
-	../../../scripts/gcovr $(GCOVR_TEST_OPTIONS) -d -x -o coverage.xml
+	$(GCOVR) $(GCOVR_TEST_OPTIONS) -d -x -o coverage.xml
 
 html:
 	./testcase
-	../../../scripts/gcovr $(GCOVR_TEST_OPTIONS) -d --html-details -o coverage.html
+	$(GCOVR) $(GCOVR_TEST_OPTIONS) -d --html-details -o coverage.html
 
 clean:
 	rm -f testcase

--- a/gcovr/tests/filter-test2/Makefile
+++ b/gcovr/tests/filter-test2/Makefile
@@ -2,7 +2,10 @@ CFLAGS= -fprofile-arcs -ftest-coverage -fPIC
 
 BASE_OS:=$(shell uname | cut -d'-' -f1)
 ifeq ($(BASE_OS),MSYS_NT)
-  GCOVR_TEST_OPTIONS := -f $(shell pwd | cygpath -w)\\main.cpp
+  # Absolute filters are known to not work on Windows right now.
+  # Use relative path instead
+  # GCOVR_TEST_OPTIONS := -f $(shell cygpath -w "$$PWD")\main.cpp
+  GCOVR_TEST_OPTIONS := -f main.cpp
 else
   GCOVR_TEST_OPTIONS := -f $(shell pwd)/main.cpp
 endif

--- a/gcovr/tests/linked/Makefile
+++ b/gcovr/tests/linked/Makefile
@@ -15,15 +15,15 @@ run: txt xml html
 
 txt:
 	./subdir/testcase
-	../../../scripts/gcovr -d -o coverage.txt
+	$(GCOVR) -d -o coverage.txt
 
 xml:
 	./subdir/testcase
-	../../../scripts/gcovr -d -x -o coverage.xml
+	$(GCOVR) -d -x -o coverage.xml
 
 html:
 	./subdir/testcase
-	../../../scripts/gcovr -d --html-details -o coverage.html
+	$(GCOVR) -d --html-details -o coverage.html
 
 clean:
 	rm -Rf subdir

--- a/gcovr/tests/nested/Makefile
+++ b/gcovr/tests/nested/Makefile
@@ -15,15 +15,15 @@ run: txt xml html
 
 txt:
 	./subdir/testcase
-	../../../scripts/gcovr -r subdir -d -o coverage.txt
+	$(GCOVR) -r subdir -d -o coverage.txt
 
 xml:
 	./subdir/testcase
-	../../../scripts/gcovr -r subdir -d -x -o coverage.xml
+	$(GCOVR) -r subdir -d -x -o coverage.xml
 
 html:
 	./subdir/testcase
-	../../../scripts/gcovr -r subdir -d --html-details -o coverage.html
+	$(GCOVR) -r subdir -d --html-details -o coverage.html
 
 clean:
 	rm -f ./subdir/testcase

--- a/gcovr/tests/nested2-use-existing/Makefile
+++ b/gcovr/tests/nested2-use-existing/Makefile
@@ -14,19 +14,19 @@ txt:
 	./subdir/B/testcase
 	make -C subdir/A coverage
 	$(GCOV) --branch-counts --branch-probabilities --preserve-paths subdir/B/main.o
-	../../../scripts/gcovr -r subdir -g -k -o coverage.txt .
+	$(GCOVR) -r subdir -g -k -o coverage.txt .
 
 xml:
 	./subdir/B/testcase
 	make -C subdir/A coverage
 	$(GCOV) --branch-counts --branch-probabilities --preserve-paths subdir/B/main.o
-	../../../scripts/gcovr -r subdir -g -k -x -o coverage.xml .
+	$(GCOVR) -r subdir -g -k -x -o coverage.xml .
 
 html:
 	./subdir/B/testcase
 	make -C subdir/A coverage
 	$(GCOV) --branch-counts --branch-probabilities --preserve-paths subdir/B/main.o
-	../../../scripts/gcovr -r subdir -g -k --html-details -o coverage.html .
+	$(GCOVR) -r subdir -g -k --html-details -o coverage.html .
 
 clean:
 	rm -f ./subdir/B/testcase subdir/lib.a

--- a/gcovr/tests/nested2/Makefile
+++ b/gcovr/tests/nested2/Makefile
@@ -9,15 +9,15 @@ run: txt xml html
 
 txt:
 	./subdir/B/testcase
-	../../../scripts/gcovr -r subdir -d -o coverage.txt
+	$(GCOVR) -r subdir -d -o coverage.txt
 
 xml:
 	./subdir/B/testcase
-	../../../scripts/gcovr -r subdir -d -x -o coverage.xml
+	$(GCOVR) -r subdir -d -x -o coverage.xml
 
 html:
 	./subdir/B/testcase
-	../../../scripts/gcovr -r subdir -d --html-details -o coverage.html
+	$(GCOVR) -r subdir -d --html-details -o coverage.html
 
 clean:
 	rm -f ./subdir/B/testcase subdir/lib.a

--- a/gcovr/tests/nested3/Makefile
+++ b/gcovr/tests/nested3/Makefile
@@ -17,15 +17,15 @@ run: txt xml html
 
 txt:
 	./subdir/testcase
-	../../../scripts/gcovr -r subdir --object-directory objs -d -o coverage.txt
+	$(GCOVR) -r subdir --object-directory objs -d -o coverage.txt
 
 xml:
 	./subdir/testcase
-	../../../scripts/gcovr -r subdir --object-directory objs -d -x -o coverage.xml
+	$(GCOVR) -r subdir --object-directory objs -d -x -o coverage.xml
 
 html:
 	./subdir/testcase
-	../../../scripts/gcovr -r subdir --object-directory objs -d --html-details -o coverage.html
+	$(GCOVR) -r subdir --object-directory objs -d --html-details -o coverage.html
 
 clean:
 	rm -f ./subdir/testcase

--- a/gcovr/tests/nobranch/Makefile
+++ b/gcovr/tests/nobranch/Makefile
@@ -5,15 +5,15 @@ run: txt xml html
 
 txt:
 	./testcase
-	../../../scripts/gcovr -d --branch --fail-under-branch 100.0 -o coverage.txt
+	$(GCOVR) -d --branch --fail-under-branch 100.0 -o coverage.txt
 
 xml:
 	./testcase
-	../../../scripts/gcovr -d --fail-under-branch 100.0 -x -o coverage.xml
+	$(GCOVR) -d --fail-under-branch 100.0 -x -o coverage.xml
 
 html:
 	./testcase
-	../../../scripts/gcovr -d --fail-under-branch 100.0 --html-details -o coverage.html
+	$(GCOVR) -d --fail-under-branch 100.0 --html-details -o coverage.html
 
 clean:
 	rm -f testcase

--- a/gcovr/tests/oos/Makefile
+++ b/gcovr/tests/oos/Makefile
@@ -12,15 +12,15 @@ GCOVR_TEST_OPTIONS =
 
 txt:
 	build/testcase
-	../../../scripts/gcovr $(GCOVR_TEST_OPTIONS) -d -o coverage.txt
+	$(GCOVR) $(GCOVR_TEST_OPTIONS) -d -o coverage.txt
 
 xml:
 	build/testcase
-	../../../scripts/gcovr $(GCOVR_TEST_OPTIONS) -d -x -o coverage.xml
+	$(GCOVR) $(GCOVR_TEST_OPTIONS) -d -x -o coverage.xml
 
 html:
 	build/testcase
-	../../../scripts/gcovr $(GCOVR_TEST_OPTIONS) -d --html-details -o coverage.html
+	$(GCOVR) $(GCOVR_TEST_OPTIONS) -d --html-details -o coverage.html
 
 clean:
 	rm -f build/*

--- a/gcovr/tests/oos2/Makefile
+++ b/gcovr/tests/oos2/Makefile
@@ -12,15 +12,15 @@ GCOVR_TEST_OPTIONS =
 
 txt:
 	build/testcase
-	../../../scripts/gcovr $(GCOVR_TEST_OPTIONS) -d -o coverage.txt
+	$(GCOVR) $(GCOVR_TEST_OPTIONS) -d -o coverage.txt
 
 xml:
 	build/testcase
-	../../../scripts/gcovr $(GCOVR_TEST_OPTIONS) -d -x -o coverage.xml
+	$(GCOVR) $(GCOVR_TEST_OPTIONS) -d -x -o coverage.xml
 
 html:
 	build/testcase
-	../../../scripts/gcovr $(GCOVR_TEST_OPTIONS) -d --html-details -o coverage.html
+	$(GCOVR) $(GCOVR_TEST_OPTIONS) -d --html-details -o coverage.html
 
 clean:
 	rm -f build/*

--- a/gcovr/tests/shared_lib/Makefile
+++ b/gcovr/tests/shared_lib/Makefile
@@ -41,7 +41,7 @@ ifeq ($(BASE_OS),MSYS_NT)
 else
 	LD_LIBRARY_PATH=`pwd`/lib testApp/test/a.out
 endif
-	../../../scripts/gcovr -d -o coverage.txt
+	$(GCOVR) -d -o coverage.txt
 
 xml:
 ifeq ($(BASE_OS),MSYS_NT)
@@ -49,7 +49,7 @@ ifeq ($(BASE_OS),MSYS_NT)
 else
 	LD_LIBRARY_PATH=`pwd`/lib testApp/test/a.out
 endif
-	../../../scripts/gcovr -d -x -o coverage.xml
+	$(GCOVR) -d -x -o coverage.xml
 
 html:
 ifeq ($(BASE_OS),MSYS_NT)
@@ -57,7 +57,7 @@ ifeq ($(BASE_OS),MSYS_NT)
 else
 	LD_LIBRARY_PATH=`pwd`/lib testApp/test/a.out
 endif
-	../../../scripts/gcovr -d --html-details -o coverage.html
+	$(GCOVR) -d --html-details -o coverage.html
 
 clean:
 	rm -rf obj

--- a/gcovr/tests/simple1/Makefile
+++ b/gcovr/tests/simple1/Makefile
@@ -5,19 +5,19 @@ run: txt xml html
 
 txt:
 	./testcase
-	../../../scripts/gcovr --fail-under-line 80.1; test $$? -eq 2
-	../../../scripts/gcovr --fail-under-branch 50.1; test $$? -eq 4
-	../../../scripts/gcovr --fail-under-line 80.1 --fail-under-branch 50.1; test $$? -eq 6
-	../../../scripts/gcovr --fail-under-line 79.9 --fail-under-branch 49.9
-	../../../scripts/gcovr -d -o coverage.txt
+	$(GCOVR) --fail-under-line 80.1; test $$? -eq 2
+	$(GCOVR) --fail-under-branch 50.1; test $$? -eq 4
+	$(GCOVR) --fail-under-line 80.1 --fail-under-branch 50.1; test $$? -eq 6
+	$(GCOVR) --fail-under-line 79.9 --fail-under-branch 49.9
+	$(GCOVR) -d -o coverage.txt
 
 xml:
 	./testcase
-	../../../scripts/gcovr -d -x -o coverage.xml
+	$(GCOVR) -d -x -o coverage.xml
 
 html:
 	./testcase
-	../../../scripts/gcovr -d --html-details -o coverage.html
+	$(GCOVR) -d --html-details -o coverage.html
 
 clean:
 	rm -f testcase

--- a/gcovr/tests/test_gcovr.py
+++ b/gcovr/tests/test_gcovr.py
@@ -9,7 +9,11 @@ import traceback
 import pyutilib.th as unittest
 import nose
 
+
 basedir = os.path.split(os.path.abspath(__file__))[0]
+python_interpreter = sys.executable.replace('\\', '/')  # use forward slash on windows as well
+env = os.environ
+env['GCOVR'] = python_interpreter + ' -m gcovr'
 
 
 @unittest.category('smoke')
@@ -83,7 +87,7 @@ def run(cmd):
         proc = subprocess.Popen(cmd,
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.STDOUT,
-                                env=os.environ)
+                                env=env)
         print("STDOUT - START")
         sys.stdout.write("%s" % proc.communicate()[0])
         print("STDOUT - END")

--- a/gcovr/tests/use-existing/Makefile
+++ b/gcovr/tests/use-existing/Makefile
@@ -8,17 +8,17 @@ run: txt xml html
 txt:
 	./testcase
 	$(GCOV) *.gcda --branch-counts --branch-probabilities --preserve-paths
-	../../../scripts/gcovr -v -g -d -o coverage.txt
+	$(GCOVR) -v -g -d -o coverage.txt
 
 xml:
 	./testcase
 	$(GCOV) *.gcda --branch-counts --branch-probabilities --preserve-paths
-	../../../scripts/gcovr -v -g -d -x -o coverage.xml
+	$(GCOVR) -v -g -d -x -o coverage.xml
 
 html:
 	./testcase
 	$(GCOV) *.gcda --branch-counts --branch-probabilities --preserve-paths
-	../../../scripts/gcovr -v -g -d --html-details -o coverage.html
+	$(GCOVR) -v -g -d --html-details -o coverage.html
 
 clean:
 	rm -f testcase

--- a/gcovr/tests/wspace/Makefile
+++ b/gcovr/tests/wspace/Makefile
@@ -5,15 +5,15 @@ run: txt xml html
 
 txt:
 	cd 'src code'; ./testcase
-	../../../scripts/gcovr -r 'src code' -d -o coverage.txt
+	$(GCOVR) -r 'src code' -d -o coverage.txt
 
 xml:
 	cd 'src code'; ./testcase
-	../../../scripts/gcovr -r 'src code' -d -x -o coverage.xml
+	$(GCOVR) -r 'src code' -d -x -o coverage.xml
 
 html:
 	cd 'src code'; ./testcase
-	../../../scripts/gcovr -r 'src code' -d --html-details -o coverage.html
+	$(GCOVR) -r 'src code' -d --html-details -o coverage.html
 
 clean:
 	rm -f */testcase

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,11 @@
 [bdist_wheel]
 universal=1
+
+[coverage:run]
+# be sure to use the same values in gcovr/tests/test_gcovr.py
+branch = True
+parallel = True
+
+[nosetests]
+cover-erase = True
+cover-package = gcovr

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@
 Script to generate the installer for gcovr.
 """
 
-import glob
 import os
 import os.path
 from setuptools import setup
@@ -21,8 +20,6 @@ from setuptools import setup
 def read(*rnames):
     return open(os.path.join(os.path.dirname(__file__), *rnames), 'rb').read().decode("UTF-8")
 
-
-scripts = glob.glob("scripts/*")
 
 setup(name='gcovr',
       version='3.4',
@@ -51,5 +48,9 @@ setup(name='gcovr',
       ],
       packages=['gcovr'],
       keywords=['utility'],
-      scripts=scripts
+      entry_points={
+          'console_scripts': [
+              'gcovr=gcovr.__main__:main',
+          ],
+      },
       )


### PR DESCRIPTION
This allows to run coverage on the module quite easily.
It will also prepare for future re-architecture of gcovr.