### PR TITLE
Refactor gcov parsing code, support upcoming GCC 8 changes

### DIFF
--- a/gcovr/__main__.py
+++ b/gcovr/__main__.py
@@ -302,6 +302,15 @@ def parse_arguments(args):
         dest="fail_under_branch",
         default=0.0
     )
+    parser.add_option(
+        '--gcov-ignore-parse-errors',
+        help="Skip lines with parse errors in GCOV files "
+             "instead of exiting with an error. "
+             "A report will be shown on stderr.",
+        action="store_true",
+        dest="gcov_ignore_parse_errors",
+        default=False
+    )
     parser.usage = "gcovr [options]"
     parser.description = \
         "A utility to run gcov and generate a simple report that summarizes " \

--- a/gcovr/gcov.py
+++ b/gcovr/gcov.py
@@ -14,7 +14,7 @@ import sys
 from os.path import normpath
 
 from .coverage import CoverageData
-from .utils import aliases, search_file
+from .utils import aliases, search_file, Logger
 
 output_re = re.compile("[Cc]reating [`'](.*)'$")
 source_re = re.compile("[Cc]annot open (source|graph) file")
@@ -412,37 +412,6 @@ class GcovParser(object):
                 covered=self.covered,
                 branches=self.branches,
                 noncode=self.noncode)
-
-
-class Logger(object):
-    def __init__(self, verbose=False):
-        self.verbose = verbose
-
-    def warn(self, pattern, *args, **kwargs):
-        """Write a formatted warning to STDERR.
-
-        pattern: a str.format pattern
-        args, kwargs: str.format arguments
-        """
-        pattern = "(WARNING) " + pattern + "\n"
-        sys.stderr.write(pattern.format(*args, **kwargs))
-
-    def msg(self, pattern, *args, **kwargs):
-        """Write a formatted message to STDOUT.
-
-        pattern: a str.format pattern
-        args, kwargs: str.format arguments
-        """
-        pattern = pattern + "\n"
-        sys.stdout.write(pattern.format(*args, **kwargs))
-
-    def verbose_msg(self, pattern, *args, **kwargs):
-        """Write a formatted message to STDOUT if in verbose mode.
-
-        see: self.msg()
-        """
-        if self.verbose:
-            self.msg(pattern, *args, **kwargs)
 
 
 #

--- a/gcovr/gcov.py
+++ b/gcovr/gcov.py
@@ -402,16 +402,13 @@ class GcovParser(object):
         # remove lines that are covered here.  Otherwise,
         # initialize covdata
         if self.fname not in covdata:
-            covdata[self.fname] = CoverageData(
-                self.fname, self.uncovered, self.uncovered_exceptional, self.covered, self.branches, self.noncode
-            )
-        else:
-            covdata[self.fname].update(
-                uncovered=self.uncovered,
-                uncovered_exceptional=self.uncovered_exceptional,
-                covered=self.covered,
-                branches=self.branches,
-                noncode=self.noncode)
+            covdata[self.fname] = CoverageData(self.fname)
+        covdata[self.fname].update(
+            uncovered=self.uncovered,
+            uncovered_exceptional=self.uncovered_exceptional,
+            covered=self.covered,
+            branches=self.branches,
+            noncode=self.noncode)
 
 
 #

--- a/gcovr/tests/test_gcov_parser.py
+++ b/gcovr/tests/test_gcov_parser.py
@@ -1,0 +1,258 @@
+# -*- coding:utf-8 -*-
+
+# This file is part of gcovr <http://gcovr.com/>.
+#
+# Copyright 2013-2018 the gcovr authors
+# Copyright 2013 Sandia Corporation
+# This software is distributed under the BSD license.
+
+import pytest
+
+from ..gcov import GcovParser
+from ..utils import Logger
+
+# This example is taken from the GCC 8 Gcov documentation:
+# <https://gcc.gnu.org/onlinedocs/gcc/Invoking-Gcov.html>
+GCOV_8_EXAMPLE = r"""
+        -:    0:Source:tmp.cpp
+        -:    0:Graph:tmp.gcno
+        -:    0:Data:tmp.gcda
+        -:    0:Runs:1
+        -:    0:Programs:1
+        -:    1:#include <stdio.h>
+        -:    2:
+        -:    3:template<class T>
+        -:    4:class Foo
+        -:    5:{
+        -:    6:  public:
+       1*:    7:  Foo(): b (1000) {}
+------------------
+Foo<char>::Foo():
+function Foo<char>::Foo() called 0 returned 0% blocks executed 0%
+    #####:    7:  Foo(): b (1000) {}
+------------------
+Foo<int>::Foo():
+function Foo<int>::Foo() called 1 returned 100% blocks executed 100%
+        1:    7:  Foo(): b (1000) {}
+------------------
+       2*:    8:  void inc () { b++; }
+------------------
+Foo<char>::inc():
+function Foo<char>::inc() called 0 returned 0% blocks executed 0%
+    #####:    8:  void inc () { b++; }
+------------------
+Foo<int>::inc():
+function Foo<int>::inc() called 2 returned 100% blocks executed 100%
+        2:    8:  void inc () { b++; }
+------------------
+        -:    9:
+        -:   10:  private:
+        -:   11:  int b;
+        -:   12:};
+        -:   13:
+        -:   14:template class Foo<int>;
+        -:   15:template class Foo<char>;
+        -:   16:
+        -:   17:int
+function main called 1 returned 100% blocks executed 81%
+        1:   18:main (void)
+        -:   19:{
+        -:   20:  int i, total;
+        1:   21:  Foo<int> counter;
+call    0 returned 100%
+branch  1 taken 100% (fallthrough)
+branch  2 taken 0% (throw)
+        -:   22:
+        1:   23:  counter.inc();
+call    0 returned 100%
+branch  1 taken 100% (fallthrough)
+branch  2 taken 0% (throw)
+        1:   24:  counter.inc();
+call    0 returned 100%
+branch  1 taken 100% (fallthrough)
+branch  2 taken 0% (throw)
+        1:   25:  total = 0;
+        -:   26:
+       11:   27:  for (i = 0; i < 10; i++)
+branch  0 taken 91% (fallthrough)
+branch  1 taken 9%
+       10:   28:    total += i;
+        -:   29:
+       1*:   30:  int v = total > 100 ? 1 : 2;
+branch  0 taken 0% (fallthrough)
+branch  1 taken 100%
+        -:   31:
+        1:   32:  if (total != 45)
+branch  0 taken 0% (fallthrough)
+branch  1 taken 100%
+    #####:   33:    printf ("Failure\n");
+call    0 never executed
+branch  1 never executed
+branch  2 never executed
+        -:   34:  else
+        1:   35:    printf ("Success\n");
+call    0 returned 100%
+branch  1 taken 100% (fallthrough)
+branch  2 taken 0% (throw)
+        1:   36:  return 0;
+        -:   37:}"""
+
+# This example is adapted from #226
+# <https://github.com/gcovr/gcovr/issues/226#issuecomment-368226650>
+# It is stripped down to the minimum useful testcase.
+GCOV_8_NAUTILUS = r"""
+        -:    0:Source:../src/nautilus-freedesktop-dbus.c
+        -:    0:Graph:/home/user/nautilus/_build/src/nautilus@sta/nautilus-freedesktop-dbus.c.gcno
+        -:    0:Data:-
+        -:    0:Runs:0
+        -:    0:Programs:0
+        -:    1:/*
+        -:    2: * nautilus-freedesktop-dbus: Implementation for the org.freedesktop DBus file-management interfaces
+        -:    3: *
+        -:    4: * Nautilus is free software; you can redistribute it and/or
+        -:    5: * modify it under the terms of the GNU General Public License as
+        -:    6: * published by the Free Software Foundation; either version 2 of the
+        -:    7: * License, or (at your option) any later version.
+        -:    8: *
+        -:    9: * Nautilus is distributed in the hope that it will be useful,
+        -:   10: * but WITHOUT ANY WARRANTY; without even the implied warranty of
+        -:   11: * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+        -:   12: * General Public License for more details.
+        -:   13: *
+        -:   14: * You should have received a copy of the GNU General Public License
+        -:   15: * along with this program; if not, see <http://www.gnu.org/licenses/>.
+        -:   16: *
+        -:   17: * Authors: Akshay Gupta <kitallis@gmail.com>
+        -:   18: *          Federico Mena Quintero <federico@gnome.org>
+        -:   19: */
+        -:   50:
+    #####:   51:G_DEFINE_TYPE (NautilusFreedesktopDBus, nautilus_freedesktop_dbus, G_TYPE_OBJECT);
+------------------
+nautilus_freedesktop_dbus_get_type:
+function nautilus_freedesktop_dbus_get_type called 0 returned 0% blocks executed 0%
+    #####:   51:G_DEFINE_TYPE (NautilusFreedesktopDBus, nautilus_freedesktop_dbus, G_TYPE_OBJECT);
+branch  0 never executed
+branch  1 never executed
+call    2 never executed
+branch  3 never executed
+branch  4 never executed
+branch  5 never executed
+branch  6 never executed
+call    7 never executed
+call    8 never executed
+call    9 never executed
+------------------
+nautilus_freedesktop_dbus_class_intern_init:
+function nautilus_freedesktop_dbus_class_intern_init called 0 returned 0% blocks executed 0%
+    #####:   51:G_DEFINE_TYPE (NautilusFreedesktopDBus, nautilus_freedesktop_dbus, G_TYPE_OBJECT);
+call    0 never executed
+branch  1 never executed
+branch  2 never executed
+call    3 never executed
+call    4 never executed
+------------------
+    #####:   52:foo() ? bar():
+        -:   53:  baz();  // above line tests that sections can be terminated
+    #####:   53:qux();
+"""
+
+GCOV_8_SOURCES = dict(
+    gcov_8_example=GCOV_8_EXAMPLE,
+    nautilus_example=GCOV_8_NAUTILUS)
+
+GCOV_8_EXPECTED_UNCOVERED_LINES = dict(
+    gcov_8_example='33',
+    nautilus_example='51,53')
+
+GCOV_8_EXPECTED_UNCOVERED_BRANCHES = dict(
+    gcov_8_example='21,23,24,27,30,32,33,35',
+    nautilus_example='51')
+
+
+@pytest.mark.parametrize('sourcename', sorted(GCOV_8_SOURCES))
+def test_gcov_8(capsys, sourcename):
+    """Verify support for GCC 8 .gcov files.
+
+    GCC 8 introduces two changes:
+    -   for partial lines, the execution count is followed by an asterisk.
+    -   instantiations for templates and macros
+        are show broken down for each specialization
+    """
+
+    source = GCOV_8_SOURCES[sourcename]
+    lines = source.splitlines()[1:]
+    expected_uncovered_lines = GCOV_8_EXPECTED_UNCOVERED_LINES[sourcename]
+    expected_uncovered_branches = GCOV_8_EXPECTED_UNCOVERED_BRANCHES[sourcename]
+
+    parser = GcovParser("tmp.cpp", Logger())
+    parser.parse_all_lines(lines, exclude_unreachable_branches=False)
+
+    covdata = dict()
+    parser.update_coverage(covdata)
+    coverage = covdata['tmp.cpp']
+
+    uncovered_lines = coverage.uncovered_str(
+        exceptional=False, show_branch=False)
+    uncovered_branches = coverage.uncovered_str(
+        exceptional=False, show_branch=True)
+    assert uncovered_lines == expected_uncovered_lines
+    assert uncovered_branches == expected_uncovered_branches
+    out, err = capsys.readouterr()
+    assert (out, err) == ('', '')
+
+    parser.check_unrecognized_lines()
+    parser.check_unclosed_exclusions()
+    out, err = capsys.readouterr()
+    assert (out, err) == ('', '')
+
+
+def test_unknown_tags(capsys):
+    source = r"bananas 7 times 3"
+    lines = source.splitlines()
+
+    parser = GcovParser("foo.c", Logger())
+    parser.parse_all_lines(lines, exclude_unreachable_branches=False)
+
+    covdata = dict()
+    parser.update_coverage(covdata)
+    coverage = covdata['foo.c']
+
+    uncovered_lines = coverage.uncovered_str(
+        exceptional=False, show_branch=False)
+    uncovered_branches = coverage.uncovered_str(
+        exceptional=False, show_branch=True)
+    assert uncovered_lines == ''
+    assert uncovered_branches == ''
+    out, err = capsys.readouterr()
+    assert (out, err) == ('', '')
+
+    parser.check_unrecognized_lines()
+    parser.check_unclosed_exclusions()
+    out, err = capsys.readouterr()
+    assert out == ''
+    err_phrases = [
+        '(WARNING) Unrecognized GCOV output',
+        'bananas',
+        'github.com/gcovr/gcovr',
+    ]
+    for phrase in err_phrases:
+        assert phrase in err
+
+
+def test_pathologic_codeline(capsys):
+    source = r": 7:haha"
+    lines = source.splitlines()
+
+    parser = GcovParser("foo.c", Logger())
+    parser.parse_all_lines(lines, exclude_unreachable_branches=False)
+    parser.check_unrecognized_lines()
+    out, err = capsys.readouterr()
+    assert out == ''
+    err_phrases = [
+        '(WARNING) Unrecognized GCOV output',
+        ': 7:haha',
+        'Exception during parsing',
+        'IndexError',
+    ]
+    for phrase in err_phrases:
+        assert phrase in err

--- a/gcovr/utils.py
+++ b/gcovr/utils.py
@@ -228,3 +228,43 @@ def build_filter(regex):
         return re.compile(re.escape(os.getcwd() + "\\") + regex)
     else:
         return re.compile(os.path.realpath(regex))
+
+
+class Logger(object):
+    def __init__(self, verbose=False):
+        self.verbose = verbose
+
+    def warn(self, pattern, *args, **kwargs):
+        """Write a formatted warning to STDERR.
+
+        pattern: a str.format pattern
+        args, kwargs: str.format arguments
+        """
+        pattern = "(WARNING) " + pattern + "\n"
+        sys.stderr.write(pattern.format(*args, **kwargs))
+
+    def error(self, pattern, *args, **kwargs):
+        """Write a formatted error to STDERR.
+
+        pattern: a str.format pattern
+        args, kwargs: str.format parameters
+        """
+        pattern = "(ERROR) " + pattern + "\n"
+        sys.stderr.write(pattern.format(*args, **kwargs))
+
+    def msg(self, pattern, *args, **kwargs):
+        """Write a formatted message to STDOUT.
+
+        pattern: a str.format pattern
+        args, kwargs: str.format arguments
+        """
+        pattern = pattern + "\n"
+        sys.stdout.write(pattern.format(*args, **kwargs))
+
+    def verbose_msg(self, pattern, *args, **kwargs):
+        """Write a formatted message to STDOUT if in verbose mode.
+
+        see: self.msg()
+        """
+        if self.verbose:
+            self.msg(pattern, *args, **kwargs)


### PR DESCRIPTION
This PR refactors the `gcovr.gcov` module. There are _a lot_ of changes. In general, I tried to extract smaller, more meaningful functions, and reduce repeated code. Most functions should now fit into one or two screens.

  - Finding the source file from a .gcov file is now done by `guess_source_file_name()`, `guess_source_file_name_via_aliases()` and `guess_source_file_name_heuristics()`. The code is now clearer and less deeply nested.

 - The actual .gcov file parsing code was gathered into a `GcovParser` class. This class carries the parsing state from one line to the next. Previously, all of these members were variables around a huge loop.

    - `parse_all_lines()` runs the parser.
    - `parse_line()` parses a single line in a gcov report, and keeps track of relevant state.
    - `parse_code_line()` parses the normal `  4:  7:  foo()` style gcov lines (execution count : line number : source code).
    - `parse_tag_line()` handles extra information, such as `branch` statistics and GCC 8 specialization sections.
    - `parse_exclusion_marker` assists `parse_line()` with markers like GCOV_EXCL_LINE etc.
    - `check_unclosed_exclusions()` and `check_unrecognized_lines()` emit warnings after parsing has completed
    - `update_coverage()` writes the data into a `CoverageData` object.

 - `find_potential_working_directories_via_objdir()` implements heuristics to suggest a gcov working directory.

 - `run_gcov_and_process_files()` runs the external gcov tool, collects the output, and processes the generated files. `select_gcov_files_from_stdout()` assists with finding the output files.

 - `apply_filter_include_exclude()` extracts the common filter application. It receives a (relative) filename, a list of filters that must match, and a list of exclusion filters that must not match. As filters are now processed in a single place, this will make them easier to improve via #191.

 - A `gcovr.utils.Logger` class has been created. This helps to have a more uniform message output format, and avoids countless `if: options.verbose: ...` branches. The available methods are:

     - `verbose_msg()`  basically just calls `if verbose: self.msg()`.
     - `msg()` writes info to STDOUT.
     - `warn()` writes a `(WARNING)` to STDERR.
     - `error()` writes an `(ERROR)` to STDERR.

    I suppose this can be improved/refined in the future.

 - The `CoverageData` class was simplified.

    - As an optimization, the constructor used to steal data structures from the gcov parsing code. Now, it maintains its own data structures that are only modified through the `update()` method. This drastically simplifies the code at no noticeable loss of performance.
    - smaller functions such as `find_consecutive_ranges()` were extracted.
    - this could be simplified even further with the `collections.Counter` class, but that would definitively break Python 2.6 compatibility.

The changes to support the upcoming GCC 8 were made in response to #226. The new gcov report format gets new sections that report coverage individually for each template or macro specialization. This PR does not support them, but merely strips away the section delimiters. The result is that branches are parsed for such lines, but I'm not sure how coverage from multiple sections on the same line is combined.

To prevent future problems like this, the parsing code was made more “robust”. The `GcovParser.parse_all_lines()` method catches *any* exceptions during parsing. The exception and the problematic line are stored. After parsing, the `check_unrecognized_lines()` method can be called to report these lines and exceptions. It will emit a warning on STDERR with all the offending lines, and also points to the Github issues. Previously, this message would only be shown in verbose mode, now it is shown always. Any exceptions are also printed as warnings (but I didn't find out how to include the stack trace). Afterwards, gcovr continues as usual and will not exit with an error. The implications of this design are:

 - If there is a parsing problem, there will always be a message on the console.
 - This will likely go unnoticed if gcovr is used automated, e.g. on a CI server, as gcovr will continue successfully.
 - There is one message per parsed file, which may spam the console for huge projects. There is currently no deduplication.
 - The error message points directly to Github rather than vaguely at “the gcovr developers”, which should make it easier for users to report problems.
 - The exceptions are reported separately from the lines that caused them, which makes it more difficult to act on a bug report.

So there's still a lot that can be improved with regards to gcov parsing and logging, but this is a start.