### PR TITLE
Check gcov support re #231

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+
+# Pycharm
+.idea/

--- a/gcovr/__main__.py
+++ b/gcovr/__main__.py
@@ -37,7 +37,8 @@ import sys
 from optparse import Option, OptionParser, OptionValueError
 from os.path import normpath
 
-from .gcov import get_datafiles, process_existing_gcov_file, process_datafile
+from .gcov import get_datafiles, process_existing_gcov_file, process_datafile, \
+    gcov_support
 from .utils import get_global_stats, build_filter
 from .version import __version__
 
@@ -361,6 +362,13 @@ def main(args=None):
         )
         sys.exit(1)
     options.root_dir = os.path.abspath(options.root)
+
+    # check that gcov is new enough
+    try:
+        gcov_support.check(options.gcov_cmd)
+    except EnvironmentError as err:
+        sys.stderr.write("(ERROR) " + str(err) + "\n")
+        sys.exit(1)
 
     #
     # Setup filters

--- a/gcovr/gcov.py
+++ b/gcovr/gcov.py
@@ -56,7 +56,8 @@ class GCovSupportChecker(object):
                         pass
 
                     raise EnvironmentError(
-                        "'" + gcov_path + "' does not support " + option)
+                        "gcov command: '" + gcov_path +
+                        "' does not support " + option)
 
         return self.checked[gcov_path]
 

--- a/gcovr/gcov.py
+++ b/gcovr/gcov.py
@@ -25,6 +25,44 @@ exclude_line_pattern = re.compile('([GL]COVR?)_EXCL_(LINE|START|STOP)')
 c_style_comment_pattern = re.compile('/\*.*?\*/')
 cpp_style_comment_pattern = re.compile('//.*?$')
 
+gcov_required_options = [
+    "--branch-counts",
+    "--branch-probabilities",
+    "--preserve-paths",
+    '--object-directory']
+
+
+class GCovSupportChecker(object):
+    """Check that gcov supports the options we need"""
+    def __init__(self):
+        self.checked = {}
+
+    def check(self, gcov_path):
+        if gcov_path not in self.checked:
+            cmd = gcov_path.split()
+            cmd.append("--help")
+            self.checked[gcov_path] = False
+            try:
+                help = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+            except subprocess.CalledProcessError as cpe:
+                help = cpe.output
+            help = str(help)
+            for option in gcov_required_options:
+                if option not in help:
+                    try:
+                        gcov_path = subprocess.check_output(
+                            ["which", gcov_path]).strip().decode("utf-8")
+                    except subprocess.CalledProcessError:
+                        pass
+
+                    raise EnvironmentError(
+                        "'" + gcov_path + "' does not support " + option)
+
+        return self.checked[gcov_path]
+
+
+gcov_support = GCovSupportChecker()
+
 
 #
 # Get the list of datafiles in the directories specified by the user
@@ -440,14 +478,13 @@ def process_datafile(filename, covdata, options):
         potential_wd.append(options.root_dir)
 
     #
-    # If the first element of cmd - the executable name - has embedded spaces
-    # it probably includes extra arguments.
+    # If the first element of cmd - the executable name - has embedded
+    # whitespace it probably includes extra arguments.
     #
-    cmd = options.gcov_cmd.split(' ') + [
-        abs_filename,
-        "--branch-counts", "--branch-probabilities", "--preserve-paths",
-        '--object-directory', dirname
-    ]
+    cmd = options.gcov_cmd.split()
+    cmd.append(abs_filename)
+    cmd.extend(gcov_required_options)
+    cmd.append(dirname)
 
     # NB: Currently, we will only parse English output
     env = dict(os.environ)

--- a/gcovr/tests/test_args.py
+++ b/gcovr/tests/test_args.py
@@ -29,6 +29,12 @@ def test_version(capsys):
     assert c.exception.code == 0
 
 
+def test_incompatible_gcov(capsys):
+    c = capture(capsys, ['--gcov-executable=/bin/sh'])
+    assert c.exception.code != 0
+    assert c.err.startswith("(ERROR) gcov command: '/bin/sh' does not support ")
+
+
 def test_help(capsys):
     c = capture(capsys, ['-h'])
     assert c.err == ''


### PR DESCRIPTION
Early on check that the gcov command we use supports the required command line options.