### PR TITLE
Move from optparse to argparse

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,35 +9,38 @@ addons:
     - gcc-5
     - g++-5
 
+env:
+  global:
+  - CXX=g++-5 CC=gcc-5 GCOV=gcov-5
+  - RUN_LINTER=1
+
 matrix:
   include:
+  - python: '2.6'
+    env: RUN_LINTER=
   - python: '2.7'
-    env: CXX=g++-5 CC=gcc-5 GCOV=gcov-5 COVERAGE_OPTS='--cov=gcovr --cov-branch'
+    env: COVERAGE_OPTS='--cov=gcovr --cov-branch'
   - python: pypy
-    env: CXX=g++-5 CC=gcc-5 GCOV=gcov-5
   - python: '3.4'
-    env: CXX=g++-5 CC=gcc-5 GCOV=gcov-5
   - python: '3.5'
-    env: CXX=g++-5 CC=gcc-5 GCOV=gcov-5 COVERAGE_OPTS='--cov=gcovr --cov-branch'
+    env: COVERAGE_OPTS='--cov=gcovr --cov-branch'
   - python: pypy3.5-5.8.0
-    env: CXX=g++-5 CC=gcc-5 GCOV=gcov-5
+  allow_failures:
+  - python: '2.6'
 
 install:
 - printenv
 - $CXX --version
-- pip install pytest pytest-cov
-- pip install ply
-- pip install ordereddict
-- pip install pyutilib
-- pip install flake8
-- pip install coverage
-- pip install codecov
+- pip install pytest
+- pip install ply ordereddict pyutilib
+- test -z "$RUN_LINTER" || pip install flake8
+- test -z "$COVERAGE_OPTS" || pip install pytest-cov coverage codecov
 - python setup.py develop
 
 script:
-- flake8 --ignore=E501
+- test -z "$RUN_LINTER" || flake8 --ignore=E501
 - python -m pytest -v $COVERAGE_OPTS gcovr doc/examples
-- if [ -n "$COVERAGE_OPTS" ]; then codecov -X gcov search; fi
+- test -z "$COVERAGE_OPTS" || codecov -X gcov search
 
 deploy:
     # disable testpypi deployment until #197 is fixed

--- a/doc/examples/test_examples.py
+++ b/doc/examples/test_examples.py
@@ -12,11 +12,12 @@ datadir = os.path.dirname(os.path.abspath(__file__))
 def find_test_cases():
     if sys.platform.startswith('win'):
         return
-    for script in glob.glob('{}/*.sh'.format(datadir)):
+    for script in glob.glob(datadir + '/*.sh'):
         basename = os.path.basename(script)
         name, _ = os.path.splitext(basename)
         for ext in 'txt xml'.split():
-            baseline = '{}/{}.{}'.format(datadir, name, ext)
+            baseline = '{datadir}/{name}.{ext}'.format(
+                datadir=datadir, name=name, ext=ext)
             if not os.path.exists(baseline):
                 continue
             yield (name, script, baseline)

--- a/doc/examples/test_examples.py
+++ b/doc/examples/test_examples.py
@@ -23,6 +23,14 @@ def find_test_cases():
             yield (name, script, baseline)
 
 
+def check_output(cmd):
+    """Emulate subprocess.check_output() for Python 2.6"""
+    p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+    (out, err) = p.communicate()
+    assert p.poll() == 0
+    return out
+
+
 @pytest.mark.parametrize(
     'args', find_test_cases(),
     ids=lambda args: os.path.basename(args[2]))
@@ -34,7 +42,7 @@ def test_example(args):
 
     startdir = os.getcwd()
     os.chdir(datadir)
-    output = scrub(subprocess.check_output(cmd).decode())
+    output = scrub(check_output(cmd).decode())
     with open(baseline_file) as f:
         baseline = scrub(f.read())
     if assert_equals is not None:

--- a/gcovr/__main__.py
+++ b/gcovr/__main__.py
@@ -479,7 +479,7 @@ def main(args=None):
             process_existing_gcov_file(file_, covdata, options)
         else:
             process_datafile(file_, covdata, options)
-    logger.verbose_msg("Gathered coveraged data for {} files", len(covdata))
+    logger.verbose_msg("Gathered coveraged data for {0} files", len(covdata))
 
     # Print report
     if options.xml or options.prettyxml:

--- a/gcovr/coverage.py
+++ b/gcovr/coverage.py
@@ -110,4 +110,4 @@ def find_consecutive_ranges(items):
 def format_range(first, last):
     if first == last:
         return str(first)
-    return "{}-{}".format(first, last)
+    return "{first}-{last}".format(first=first, last=last)

--- a/gcovr/gcov.py
+++ b/gcovr/gcov.py
@@ -36,17 +36,17 @@ def get_datafiles(flist, options):
     for dir_ in flist:
         if options.gcov_files:
             logger.verbose_msg(
-                "Scanning directory {} for gcov files...", dir_)
+                "Scanning directory {0} for gcov files...", dir_)
             files = search_file(
                 ".*\.gcov$", dir_, exclude_dirs=options.exclude_dirs)
             gcov_files = [file for file in files if file.endswith('gcov')]
             logger.verbose_msg(
-                "Found {} files (and will process {})",
+                "Found {0} files (and will process {1})",
                 len(files), len(gcov_files))
             allfiles.update(gcov_files)
         else:
             logger.verbose_msg(
-                "Scanning directory {} for gcda/gcno files...", dir_)
+                "Scanning directory {0} for gcda/gcno files...", dir_)
             files = search_file(
                 ".*\.gc(da|no)$", dir_, exclude_dirs=options.exclude_dirs)
             # gcno files will *only* produce uncovered results; however,
@@ -63,7 +63,7 @@ def get_datafiles(flist, options):
                 filenm.endswith('gcno') and filenm[:-2] + 'da' not in tmp
             ]
             logger.verbose_msg(
-                "Found {} files (and will process {})",
+                "Found {0} files (and will process {1})",
                 len(files), len(gcda_files) + len(gcno_files))
             allfiles.update(gcda_files)
             allfiles.update(gcno_files)
@@ -96,7 +96,7 @@ def process_gcov_data(data_fname, covdata, source_fname, options):
         root_dir=options.root_dir, starting_dir=options.starting_dir,
         logger=logger)
 
-    logger.verbose_msg("Parsing coverage data for file {}", fname)
+    logger.verbose_msg("Parsing coverage data for file {0}", fname)
 
     # Return if the filename does not match the filter
     # Return if the filename matches the exclude pattern
@@ -104,11 +104,11 @@ def process_gcov_data(data_fname, covdata, source_fname, options):
         fname, options.filter, options.exclude, strip=options.root_filter)
 
     if filtered:
-        logger.verbose_msg("  Filtering coverage data for file {}", fname)
+        logger.verbose_msg("  Filtering coverage data for file {0}", fname)
         return
 
     if excluded:
-        logger.verbose_msg("  Excluding coverage data for file {}", fname)
+        logger.verbose_msg("  Excluding coverage data for file {0}", fname)
         return
 
     parser = GcovParser(fname, logger=logger)
@@ -515,7 +515,7 @@ class GcovParser(object):
 def process_datafile(filename, covdata, options):
     logger = Logger(options.verbose)
 
-    logger.verbose_msg("Processing file: {}", filename)
+    logger.verbose_msg("Processing file: {0}", filename)
 
     abs_filename = os.path.abspath(filename)
     dirname, fname = os.path.split(abs_filename)
@@ -567,10 +567,10 @@ def process_datafile(filename, covdata, options):
 
     if not done:
         logger.warn(
-            "GCOV produced the following errors processing {}:\n"
-            "\t{}\n"
+            "GCOV produced the following errors processing {filename}:\n"
+            "\t{errors}\n"
             "\t(gcovr could not infer a working directory that resolved it.)",
-            filename, "\n\t".join(errors))
+            filename=filename, errors="\n\t".join(errors))
 
 
 def find_potential_working_directories_via_objdir(abs_filename, objdir, errors):
@@ -642,7 +642,9 @@ def run_gcov_and_process_files(
     env['LC_ALL'] = 'en_US'
 
     logger.verbose_msg(
-        "Running gcov: '{}' in '{}'", ' '.join(cmd), os.getcwd())
+        "Running gcov: '{cmd}' in '{cwd}'",
+        cmd=' '.join(cmd),
+        cwd=os.getcwd())
 
     out, err = subprocess.Popen(
         cmd, env=env,
@@ -691,11 +693,11 @@ def select_gcov_files_from_stdout(out, gcov_filter, gcov_exclude, logger):
             fname, gcov_filter, gcov_exclude)
 
         if filtered:
-            logger.verbose_msg("Filtering gcov file {}", fname)
+            logger.verbose_msg("Filtering gcov file {0}", fname)
             continue
 
         if excluded:
-            logger.verbose_msg("Excluding gcov file {}", fname)
+            logger.verbose_msg("Excluding gcov file {0}", fname)
             continue
 
         active_files.append(fname)
@@ -714,11 +716,11 @@ def process_existing_gcov_file(filename, covdata, options):
 
     if filtered:
         logger.verbose_msg(
-            "This gcov file does not match the filter: {}", filename)
+            "This gcov file does not match the filter: {0}", filename)
         return
 
     if excluded:
-        logger.verbose_msg("Excluding gcov file: {}", filename)
+        logger.verbose_msg("Excluding gcov file: {0}", filename)
         return
 
     process_gcov_data(filename, covdata, None, options)

--- a/gcovr/tests/test_args.py
+++ b/gcovr/tests/test_args.py
@@ -32,7 +32,7 @@ def test_version(capsys):
 def test_help(capsys):
     c = capture(capsys, ['-h'])
     assert c.err == ''
-    assert c.out.startswith('Usage: gcovr [options]')
+    assert c.out.startswith('usage: gcovr [options]')
     assert c.exception.code == 0
 
 

--- a/gcovr/tests/test_gcovr.py
+++ b/gcovr/tests/test_gcovr.py
@@ -76,7 +76,7 @@ def run(cmd):
 
 
 def find_reference_files(pattern):
-    for reference in glob.glob("reference/{}".format(pattern)):
+    for reference in glob.glob("reference/" + pattern):
         coverage = os.path.basename(reference)
         yield coverage, reference
 
@@ -120,7 +120,7 @@ def test_build(name, format):
         if assert_equals is not None:
             assert_equals(coverage, reference)
         else:
-            assert coverage == reference, "coverage={}, reference={}".format(
+            assert coverage == reference, "coverage={0}, reference={1}".format(
                 coverage_file, reference_file)
 
     assert run(["make", "clean"])

--- a/gcovr/tests/test_gcovr.py
+++ b/gcovr/tests/test_gcovr.py
@@ -14,6 +14,9 @@ from pyutilib.misc.xmltodict import parse as parse_xml
 python_interpreter = sys.executable.replace('\\', '/')  # use forward slash on windows as well
 env = os.environ
 env['GCOVR'] = python_interpreter + ' -m gcovr'
+if sys.version_info < (2, 7):  # pragma: no cover
+    # fallback for "python -m module"
+    env['GCOVR'] = 'gcovr'
 
 basedir = os.path.split(os.path.abspath(__file__))[0]
 

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,9 @@ setup(name='gcovr',
           'Topic :: Software Development :: Libraries :: Python Modules',
       ],
       packages=['gcovr'],
+      install_requires=[
+          'argparse ; python_version < "2.7"',
+      ],
       keywords=['utility'],
       entry_points={
           'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,17 @@ def read(*rnames):
     return open(os.path.join(os.path.dirname(__file__), *rnames), 'rb').read().decode("UTF-8")
 
 
-version = runpy.run_path('./gcovr/version.py')['__version__']
+def run_path(filename):
+    variables = dict()
+    execfile(filename, globals(), variables)  # noqa: F821 execfile()
+    return variables
+
+
+# Retrieve the gcovr version. This prefers to use runpy.run_path() which is
+# only supported in Python 2.7 or later, and falls back to execfile() which
+# does not exist in Python 3.x.
+run_path = getattr(runpy, 'run_path', run_path)
+version = run_path('./gcovr/version.py')['__version__']
 
 setup(name='gcovr',
       version=version,


### PR DESCRIPTION
Argparse is the better optparse. The only reason why we hadn't already switched was that argparse was only introduced in Python 2.7. Luckily there's a backport that can be installed from PyPI, so I added a version-dependent dependency.

The difficult part was enabling the necessary tests on Travis CI first. This surfaced a few compatibility problems that were accumulated in the recent refactorings. Especially `subprocess` and `runpy` lack many convenience functions, and format strings `"foo{bar}"` must not have empty placeholders `{}`. The tests cannot rely on the `python -m gcovr` style invocation, but the `gcovr` entrypoint script is available anyway. Now all tests except for an XML example pass.