### PR TITLE
Use CXX environment variable in doc/examples tests

### DIFF
--- a/doc/examples/example.sh
+++ b/doc/examples/example.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-export PATH=`pwd`/../../scripts:$PATH
+g++() {
+	$(which ${CXX:-g++}) $*
+}
 
 #BEGIN compile
 g++ -fprofile-arcs -ftest-coverage -fPIC -O0 example.cpp -o program

--- a/doc/examples/example_branches.sh
+++ b/doc/examples/example_branches.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-export PATH=`pwd`/../../scripts:$PATH
-
-g++ -fprofile-arcs -ftest-coverage -fPIC -O0 example.cpp -o program
+${CXX:-g++} -fprofile-arcs -ftest-coverage -fPIC -O0 example.cpp -o program
 
 ./program
 

--- a/doc/examples/example_html.sh
+++ b/doc/examples/example_html.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-export PATH=`pwd`/../../scripts:$PATH
-
-g++ -fprofile-arcs -ftest-coverage -fPIC -O0 example.cpp -o program
+${CXX:-g++} -fprofile-arcs -ftest-coverage -fPIC -O0 example.cpp -o program
 
 ./program
 

--- a/doc/examples/example_xml.sh
+++ b/doc/examples/example_xml.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-export PATH=`pwd`/../../scripts:$PATH
-
-g++ -fprofile-arcs -ftest-coverage -fPIC -O0 example.cpp -o program
+${CXX:-g++} -fprofile-arcs -ftest-coverage -fPIC -O0 example.cpp -o program
 
 ./program
 


### PR DESCRIPTION
All other tests use CXX environment variable that defaults to g++.
That allows to set CXX to g++-5 when it's not the default C++ compiler.
Also remove the now unsued scripts folder from PATH