### PR TITLE
Add MINGW32_NT checks for test Makefiles (see #240).

### DIFF
--- a/gcovr/tests/filter-test2/Makefile
+++ b/gcovr/tests/filter-test2/Makefile
@@ -1,6 +1,9 @@
 CFLAGS= -fprofile-arcs -ftest-coverage -fPIC
 
 BASE_OS:=$(shell uname | cut -d'-' -f1)
+ifeq ($(BASE_OS),MINGW32_NT)
+  BASE_OS:=MSYS_NT
+endif
 ifeq ($(BASE_OS),MSYS_NT)
   # Absolute filters are known to not work on Windows right now.
   # Use relative path instead

--- a/gcovr/tests/shared_lib/Makefile
+++ b/gcovr/tests/shared_lib/Makefile
@@ -7,6 +7,9 @@ ifeq ($(BASE_OS),Darwin)
   CFLAGS     += -fPIC
   SOFLAGS    += -dynamiclib -undefined dynamic_lookup
 endif
+ifeq ($(BASE_OS),MINGW32_NT)
+  BASE_OS:=MSYS_NT
+endif
 ifeq ($(BASE_OS),CYGWIN_NT)
   DYNLIB_EXT = dll
   #DEFINES   += -mno-cygwin


### PR DESCRIPTION
Add checks for MINGW32_NT to filter-test2 and shared_lib test Makefiles and set BASE_OS to MSYS_NT.