### PR TITLE
Mark test_examples xml test as a known failure with python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,13 +25,11 @@ matrix:
   - python: '3.5'
     env: COVERAGE_OPTS='--cov=gcovr --cov-branch'
   - python: pypy3.5-5.8.0
-  allow_failures:
-  - python: '2.6'
 
 install:
 - printenv
 - $CXX --version
-- pip install pytest
+- pip install pytest --upgrade
 - pip install ply ordereddict pyutilib
 - test -z "$RUN_LINTER" || pip install flake8
 - test -z "$COVERAGE_OPTS" || pip install pytest-cov coverage codecov

--- a/doc/examples/test_examples.py
+++ b/doc/examples/test_examples.py
@@ -20,7 +20,10 @@ def find_test_cases():
                 datadir=datadir, name=name, ext=ext)
             if not os.path.exists(baseline):
                 continue
-            yield (name, script, baseline)
+            if ext == 'xml' and sys.version_info < (2, 7):
+                yield pytest.param((name, script, baseline), marks=pytest.mark.xfail)
+            else:
+                yield (name, script, baseline)
 
 
 def check_output(cmd):


### PR DESCRIPTION
Also remove allowed failure for python 2.6 in travis-ci