### PR TITLE
Fix --print-summary

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -17,6 +17,7 @@ The following developers contributed to gcovr (ordered alphabetically):
     ja11sop,
     James Reynolds,
     Jessica Levine,
+    Joel Klinghed,
     John Siirola,
     Jörg Kreuzberger,
     Kai Blaschke,

--- a/gcovr/__main__.py
+++ b/gcovr/__main__.py
@@ -526,7 +526,7 @@ def main(args=None):
         print_text_report(covdata, options)
 
     if options.print_summary:
-        print_summary(covdata, options)
+        print_summary(covdata)
 
     if options.fail_under_line > 0.0 or options.fail_under_branch > 0.0:
         fail_under(covdata, options.fail_under_line, options.fail_under_branch)


### PR DESCRIPTION
Just a quick fix for:
TypeError: print_summary() takes 1 positional argument but 2 were given
