### PR TITLE
Drop support for Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ env:
 
 matrix:
   include:
-  - python: '2.6'
-    env: RUN_LINTER=
   - python: '2.7'
     env: COVERAGE_OPTS='--cov=gcovr --cov-branch'
   - python: pypy

--- a/doc/examples/test_examples.py
+++ b/doc/examples/test_examples.py
@@ -20,18 +20,8 @@ def find_test_cases():
                 datadir=datadir, name=name, ext=ext)
             if not os.path.exists(baseline):
                 continue
-            if ext == 'xml' and sys.version_info < (2, 7):
-                yield pytest.param((name, script, baseline), marks=pytest.mark.xfail)
             else:
                 yield (name, script, baseline)
-
-
-def check_output(cmd):
-    """Emulate subprocess.check_output() for Python 2.6"""
-    p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
-    (out, err) = p.communicate()
-    assert p.poll() == 0
-    return out
 
 
 @pytest.mark.parametrize(
@@ -45,7 +35,7 @@ def test_example(args):
 
     startdir = os.getcwd()
     os.chdir(datadir)
-    output = scrub(check_output(cmd).decode())
+    output = scrub(subprocess.check_output(cmd).decode())
     with open(baseline_file) as f:
         baseline = scrub(f.read())
     if assert_equals is not None:

--- a/doc/source/guide.rst
+++ b/doc/source/guide.rst
@@ -326,10 +326,12 @@ Installation
 
 Which environments does ``gcovr`` support?
 
--   Python: 2.7+ and 3.4+.
-    Python 2.6 is supported on a best-effort basis.
+-   Python: 2.7 and 3.4+.
 
     The automated tests run on CPython 2.7, 3.4, and 3.5, and PyPy 2.7 and 3.5.
+
+    Python 2.6 is no longer supported.
+    The last stable release for that Python version was 3.4.
 
 -   Operating System: Linux, Windows, and macOS.
 

--- a/gcovr/__main__.py
+++ b/gcovr/__main__.py
@@ -490,7 +490,7 @@ def main(args=None):
                  'workdir': mkdtemp(),
                  'toerase': set(),
                  'options': options}) as pool:
-        logger.verbose_msg("Pool started with {0} threads", pool.size())
+        logger.verbose_msg("Pool started with {} threads", pool.size())
         for file_ in datafiles:
             if options.gcov_files:
                 pool.add(process_existing_gcov_file, file_)
@@ -516,7 +516,7 @@ def main(args=None):
         if os.path.exists(filepath):
             os.remove(filepath)
 
-    logger.verbose_msg("Gathered coveraged data for {0} files", len(covdata))
+    logger.verbose_msg("Gathered coveraged data for {} files", len(covdata))
 
     # Print report
     if options.xml or options.prettyxml:

--- a/gcovr/gcov.py
+++ b/gcovr/gcov.py
@@ -37,17 +37,17 @@ def get_datafiles(flist, options):
     for dir_ in flist:
         if options.gcov_files:
             logger.verbose_msg(
-                "Scanning directory {0} for gcov files...", dir_)
+                "Scanning directory {} for gcov files...", dir_)
             files = search_file(
                 ".*\.gcov$", dir_, exclude_dirs=options.exclude_dirs)
             gcov_files = [file for file in files if file.endswith('gcov')]
             logger.verbose_msg(
-                "Found {0} files (and will process {1})",
+                "Found {} files (and will process {})",
                 len(files), len(gcov_files))
             allfiles.update(gcov_files)
         else:
             logger.verbose_msg(
-                "Scanning directory {0} for gcda/gcno files...", dir_)
+                "Scanning directory {} for gcda/gcno files...", dir_)
             files = search_file(
                 ".*\.gc(da|no)$", dir_, exclude_dirs=options.exclude_dirs)
             # gcno files will *only* produce uncovered results; however,
@@ -64,7 +64,7 @@ def get_datafiles(flist, options):
                 filenm.endswith('gcno') and filenm[:-2] + 'da' not in tmp
             ]
             logger.verbose_msg(
-                "Found {0} files (and will process {1})",
+                "Found {} files (and will process {})",
                 len(files), len(gcda_files) + len(gcno_files))
             allfiles.update(gcda_files)
             allfiles.update(gcno_files)
@@ -96,7 +96,7 @@ def process_gcov_data(data_fname, covdata, source_fname, options, currdir=None):
         root_dir=options.root_dir, starting_dir=options.starting_dir,
         logger=logger, currdir=currdir)
 
-    logger.verbose_msg("Parsing coverage data for file {0}", fname)
+    logger.verbose_msg("Parsing coverage data for file {}", fname)
 
     # Return if the filename does not match the filter
     # Return if the filename matches the exclude pattern
@@ -104,11 +104,11 @@ def process_gcov_data(data_fname, covdata, source_fname, options, currdir=None):
         fname, options.filter, options.exclude, strip=options.root_filter)
 
     if filtered:
-        logger.verbose_msg("  Filtering coverage data for file {0}", fname)
+        logger.verbose_msg("  Filtering coverage data for file {}", fname)
         return
 
     if excluded:
-        logger.verbose_msg("  Excluding coverage data for file {0}", fname)
+        logger.verbose_msg("  Excluding coverage data for file {}", fname)
         return
 
     parser = GcovParser(fname, logger=logger)
@@ -515,7 +515,7 @@ class GcovParser(object):
 def process_datafile(filename, covdata, options, toerase, workdir):
     logger = Logger(options.verbose)
 
-    logger.verbose_msg("Processing file: {0}", filename)
+    logger.verbose_msg("Processing file: {}", filename)
 
     abs_filename = os.path.abspath(filename)
     dirname, fname = os.path.split(abs_filename)
@@ -699,11 +699,11 @@ def select_gcov_files_from_stdout(out, gcov_filter, gcov_exclude, logger, chdir,
             fname, gcov_filter, gcov_exclude)
 
         if filtered:
-            logger.verbose_msg("Filtering gcov file {0}", fname)
+            logger.verbose_msg("Filtering gcov file {}", fname)
             continue
 
         if excluded:
-            logger.verbose_msg("Excluding gcov file {0}", fname)
+            logger.verbose_msg("Excluding gcov file {}", fname)
             continue
 
         if tempdir and tempdir != chdir:
@@ -727,11 +727,11 @@ def process_existing_gcov_file(filename, covdata, options, toerase, workdir):
 
     if filtered:
         logger.verbose_msg(
-            "This gcov file does not match the filter: {0}", filename)
+            "This gcov file does not match the filter: {}", filename)
         return
 
     if excluded:
-        logger.verbose_msg("Excluding gcov file: {0}", filename)
+        logger.verbose_msg("Excluding gcov file: {}", filename)
         return
 
     process_gcov_data(filename, covdata, None, options)

--- a/gcovr/tests/test_gcovr.py
+++ b/gcovr/tests/test_gcovr.py
@@ -14,9 +14,6 @@ from pyutilib.misc.xmltodict import parse as parse_xml
 python_interpreter = sys.executable.replace('\\', '/')  # use forward slash on windows as well
 env = os.environ
 env['GCOVR'] = python_interpreter + ' -m gcovr'
-if sys.version_info < (2, 7):  # pragma: no cover
-    # fallback for "python -m module"
-    env['GCOVR'] = 'gcovr'
 
 basedir = os.path.split(os.path.abspath(__file__))[0]
 
@@ -123,7 +120,7 @@ def test_build(name, format):
         if assert_equals is not None:
             assert_equals(coverage, reference)
         else:
-            assert coverage == reference, "coverage={0}, reference={1}".format(
+            assert coverage == reference, "coverage={}, reference={}".format(
                 coverage_file, reference_file)
 
     assert run(["make", "clean"])

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ Script to generate the installer for gcovr.
 
 import os
 import os.path
-import runpy
+from runpy import run_path
 from setuptools import setup
 
 
@@ -22,16 +22,6 @@ def read(*rnames):
     return open(os.path.join(os.path.dirname(__file__), *rnames), 'rb').read().decode("UTF-8")
 
 
-def run_path(filename):
-    variables = dict()
-    execfile(filename, globals(), variables)  # noqa: F821 execfile()
-    return variables
-
-
-# Retrieve the gcovr version. This prefers to use runpy.run_path() which is
-# only supported in Python 2.7 or later, and falls back to execfile() which
-# does not exist in Python 3.x.
-run_path = getattr(runpy, 'run_path', run_path)
 version = run_path('./gcovr/version.py')['__version__']
 
 setup(name='gcovr',
@@ -41,7 +31,7 @@ setup(name='gcovr',
       url='http://gcovr.com',
       license='BSD',
       platforms=["any"],
-      python_requires='>=2.6',
+      python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
       description='A Python script for summarizing gcov data.',
       long_description=read('README.rst'),
       classifiers=[
@@ -61,7 +51,6 @@ setup(name='gcovr',
       ],
       packages=['gcovr'],
       install_requires=[
-          'argparse ; python_version < "2.7"',
           'jinja2',
       ],
       package_data={


### PR DESCRIPTION
I've previously advocated for keeping 2.6-compatibility, but have since changed my mind. There are lots of small inconveniences when restricted to the 2.6/3.x common subset. In particular, this drastically restricts the choice of upstream modules.

Old versions of gcovr will of course continue to work. This also means there will never be a gcovr version that works well on Windows with Python 2.6, but since that OS doesn't bundle Python such a
version lock-in is less likely.

Now is a good time to drop support since the next release will likely be 4.0, and we already have a number of other somewhat breaking changes (e.g. different installation procedure). One biggie that is still pending is improved Windows filtering (see #191). I would not like to be locked in to Python 2.6 for the rest of gcovr 4.x.

Request for comments: Are there any problems that I missed? Will this make someone else's life much more difficult? I will wait at least 2 weeks before applying this change in order to provide enough time for feedback.