### PR TITLE
Better contribution docs, mention Gitter chatroom

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
   global:
   - CXX=g++-5 CC=gcc-5 GCOV=gcov-5
   - RUN_LINTER=1
+  - BUILD_DOCS=
 
 matrix:
   include:
@@ -23,7 +24,7 @@ matrix:
   - python: pypy
   - python: '3.4'
   - python: '3.5'
-    env: COVERAGE_OPTS='--cov=gcovr --cov-branch'
+    env: COVERAGE_OPTS='--cov=gcovr --cov-branch' BUILD_DOCS=1
   - python: pypy3.5-5.8.0
 
 install:
@@ -33,12 +34,14 @@ install:
 - pip install ply ordereddict pyutilib
 - test -z "$RUN_LINTER" || pip install flake8
 - test -z "$COVERAGE_OPTS" || pip install pytest-cov coverage codecov
+- test -z "$BUILD_DOCS" || pip install -r doc/requirements.txt
 - python setup.py develop
 
 script:
 - test -z "$RUN_LINTER" || flake8 --ignore=E501
 - python -m pytest -v $COVERAGE_OPTS gcovr doc/examples
 - test -z "$COVERAGE_OPTS" || codecov -X gcov search
+- test -z "$BUILD_DOCS" || (cd doc; make html O=-W)
 
 deploy:
   - provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,3 +64,11 @@ deploy:
       tags: true
       branch: master
       python: '2.7'
+
+notifications:
+  webhooks:
+    urls:
+      - https://webhooks.gitter.im/e/cda77870362da0942755
+    on_success: change
+    on_failure: always
+    on_start: never

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -105,6 +105,13 @@ This can take a week.
 Please fix any issues that are discovered during this process.
 Feel free to force-push your updates to the pull request branch.
 
+If you need assistance for your pull request, you can
+
+  - chat in `our Gitter room <https://gitter.im/gcovr/gcovr>`_
+  - discuss your problem in an issue
+  - open an unfinished pull request as a work in progress (WIP),
+    and explain what you've like to get reviewed
+
 How to set up a development environment
 ---------------------------------------
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,8 +1,18 @@
 Contributing
 ============
 
-Reporting bugs
---------------
+This document contains:
+
+-   our `guidelines for bug reports <How to report bugs_>`_
+-   `general contribution guidelines <How to help_>`_
+-   a `checklist for pull requests <How to submit a Pull Request_>`_
+-   a developer guide that explains the
+    `development environment <How to set up a development environment_>`_,
+    `project structure <Project Structure_>`_,
+    and `test suite <Test suite_>`_
+
+How to report bugs
+------------------
 
 When reporting a bug, first `search our issues <search all issues_>`_ to avoid duplicates.
 In your bug report, please describe what you expected gcovr to do, and what it actually did.
@@ -20,81 +30,194 @@ and the smallest possible source file to reproduce the problem.
 
 .. _search all issues: https://github.com/gcovr/gcovr/issues?q=is%3Aissue
 
-Helping out
+How to help
 -----------
 
-If you would like to help out, please take a look at our `open issues <bugtracker_>`_ and `pull requests`_.
-Maybe you know the answer to some problem,
-or can contribute your perspective as a gcovr user.
-In particular, testing proposed changes in your real-world project is very valuable.
-The issues labeled “\ `help wanted <label help wanted_>`_\ ” and “\ `needs review <label needs review_>`_\ ” would have the greatest impact.
+If you would like to help out, please take a look at our
+`open issues <bugtracker_>`_ and `pull requests`_.
+The issues labeled `help wanted <label help wanted_>`_ and
+`needs review <label needs review_>`_ would have the greatest impact.
+
+There are many ways how you can help:
+
+-   assist other users with their problems
+-   share your perspective as a gcovr user in discussions
+-   test proposed changes in your real-world projects
+-   improve our documentation
+-   submit pull requests with bug fixes and enhancements
 
 .. _bugtracker: https://github.com/gcovr/gcovr/issues
 .. _label help wanted: https://github.com/gcovr/gcovr/labels/help%20wanted
 .. _label needs review: https://github.com/gcovr/gcovr/labels/needs%20review
 .. _pull requests: https://github.com/gcovr/gcovr/pulls
 
-Pull requests with bugfixes are welcome!
-If you want to contribute an enhancement,
-please open a new issue first so that your proposal can be discussed and honed.
-
-Working with the source code
+How to submit a Pull Request
 ----------------------------
 
-To work on the gcovr source code, you can clone the git repository,
-then run “\ ``pip install -e .``\ ”.
-You can then run gcovr as ``gcovr`` or ``python -m gcovr``.
+Thank you for helping with gcovr development!
+Please follow this checklist for your pull request:
 
-To run the tests, you also have to “\ ``pip install pyutilib pytest flake8``\ ”.
-To build the documentation, you also have to “\ ``pip install -r doc/requirements.txt``\ ”.
+-   **Is this a good approach?**
+    Fixing open issues is always welcome!
+    If you want to implement an enhancement,
+    please discuss it first as a GitHub issue.
+
+-   **Does it work?**
+    Please run the tests locally::
+
+        python -m pytest
+
+    In any case, the tests will run automatically
+    when you open the pull request.
+    But please prevent unnecessary build failures
+    and run the tests yourself first.
+    If you cannot run the tests locally,
+    you can activate Travis CI or Appveyor for your fork.
+
+    If you add new features, please try to add a test case.
+
+-   **Does it conform to the style guide?**
+    The source code should conform to the :pep:`8` standard.
+    Please check your code::
+
+        python -m flake8 doc gcovr --ignore E501
+
+-   **Add yourself as an author.**
+    If this is your first contribution to gcovr,
+    please add yourself to the ``AUTHORS.txt`` file.
+
+-   **One change at a time.**
+    Please keep your commits and your whole pull request fairly small,
+    so that the changes are easy to review.
+    Each commit should only contain one kind of change,
+    e.g. refactoring *or* new functionality.
+
+-   **Why is this change necessary?**
+    When you open the PR,
+    please explain why we need this change and what your PR does.
+    If this PR fixes an open issue,
+    reference that issue in the pull request description.
+
+Once you submit the PR, it will be automatically tested on Windows and Linux,
+and code coverage will be collected.
+Your code will be reviewed.
+This can take a week.
+Please fix any issues that are discovered during this process.
+Feel free to force-push your updates to the pull request branch.
+
+How to set up a development environment
+---------------------------------------
+
+-   (Optional) Fork the project on GitHub.
+
+-   Clone the git repository.
+
+-   (Optional) Set up a virtualenv.
+
+-   Install gcovr in development mode, and install the test requirements::
+
+        pip install -e .
+        pip install -r requirements.txt
+
+    You can then run gcovr as ``gcovr`` or ``python -m gcovr``.
+
+    Run the tests to verify that everything works (see below).
+
+-   (Optional) Install documentation requirements::
+
+        pip install -r doc/requirements.txt
+
+    See ``doc/README.txt`` for details on working with the documentation.
+
+-   (Optional) Activate Travis and Appveyor for your forked GitHub repository,
+    so that the cross-platform compatibility tests get run
+    whenever you push your work to your repository.
+    These tests will also be run
+    when you open a pull request to the main gcovr repository.
+
+Tip: If you have problems getting everything set up, consider looking at the
+``.travis.yml`` (Linux) and
+``appveyor.yml`` (Windows) files.
+
+On **Windows**, you will need to install a GCC toolchain
+as the tests expect a Unix-like environment.
+You can use MinGW-W64 or MinGW.
+To run the tests,
+please make sure that the ``make`` and ``cmake`` from your MinGW distribution 
+are in the system ``PATH``.
+
+Project Structure
+-----------------
+
+======================= =======================================================
+Path                    Description
+======================= =======================================================
+``/``                   project root
+``/gcovr/``             the gcovr source code (Python module)
+``/gcovr/__main__.py``  command line interface + top-level behaviour
+``/gcovr/templates/``   HTML report templates
+``/gcovr/tests/``       unit tests + integration test corpus
+``/setup.py``           Python package configuration
+``/doc/``               documentation
+``/doc/sources/``       user guide + website
+``/doc/examples/``      runnable examples for the user guide
+======================= =======================================================
 
 The program entrypoint and command line interface is in ``gcovr/__main__.py``.
 The coverage data is parsed in the ``gcovr.gcov`` module.
 The HTML, XML, text, and summary reports
 are in ``gcovr.html_generator`` and respective modules.
 
+Test suite
+----------
+
 The tests are in the ``gcovr/tests`` directory.
 You can run the tests with ``python -m pytest``.
 
-The test suite compiles example programs
-and compares the gcovr output against baseline files.
-This is driven by a Makefile in each ``gcovr/tests/*`` directory.
-Because the tests are a bit slow,
-you can limit the tests to a specific output format or test case, e.g.:
+There are unit tests for some parts of gcovr,
+and a comprehensive corpus of example projects
+that are executed as the ``test_gcovr.py`` test.
+Each ``gcovr/tests/*`` directory is one such example project.
+
+Each project in the corpus
+contains a ``Makefile`` and a ``reference`` directory.
+The Makefile controls how the project is built,
+and how gcovr should be invoked.
+The reference directory contains baseline files against
+which the gcovr output is compared.
+Each project is tested three times to cover ``txt``, ``html``, and ``xml`` output.
+
+Because the tests are a bit slow, you can limit the tests to a specific
+test file, example project, or output format.
+For example:
 
 .. code:: bash
 
     # run only XML tests
     python -m pytest -k xml
+
     # run the simple1 tests
     python -m pytest -k simple1
+
     # run the simple1 tests only for XML
     python -m pytest -k 'xml and simple1'
 
-The output formats are ``txt``, ``html``, and ``xml``.
 To see all tests, run pytest in ``-v`` verbose mode.
 To see which tests would be run, add the ``--collect-only`` option.
 
 The tests currently assume that you are using GCC 5.
 
-The source code should conform to the PEP-8 standard,
-as checked by the ``flake8`` tool.
-You can ignore any existing warnings about E501 (over-long lines).
-
-When you submit a pull request,
-your commits will be tested automatically on Windows and Linux.
-Please run the tests and the style check locally
-to avoid unnecessary build failures.
-
 Become a gcovr developer
 ------------------------
 
-After you've contributed a bit, consider becoming a gcovr developer.
+After you've contributed a bit 
+(whether with discussions, documentation, or code),
+consider becoming a gcovr developer.
 As a developer, you can:
 
--  manage issues (label and close them)
--  approve pull requests
--  merge approved pull requests
--  participate in votes
+-   manage issues and pull requests (label and close them)
+-   review pull requests
+    (a developer must approve each PR before it can be merged)
+-   participate in votes
 
 Just open an issue that you're interested, and we'll have a quick vote.

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ generate GCC code coverage reports
 
 website_ • documentation_ • bugtracker_ • `GitHub <repo_>`_
 
-|travis-ci-badge| |appveyor-ci-badge| |pypi-badge| |codecov-badge|
+|travis-ci-badge| |appveyor-ci-badge| |pypi-badge| |codecov-badge| |gitter-badge|
 
 .. begin abstract
 
@@ -60,6 +60,9 @@ Example HTML details:
 .. |codecov-badge| image:: https://codecov.io/gh/gcovr/gcovr/branch/master/graph/badge.svg
    :target: https://codecov.io/gh/gcovr/gcovr/branch/master
    :alt: Codecov status
+.. |gitter-badge| image:: https://badges.gitter.im/gcovr/gcovr.svg
+   :target: https://gitter.im/gcovr/gcovr
+   :alt: Gitter chat
 
 .. end links
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,3 +37,11 @@ build: off
 test_script:
   - 'python -m pytest -v --cov=gcovr --cov-branch gcovr doc/examples'
   - 'codecov -X gcov search'
+
+
+notifications:
+  - provider: Webhook
+    url: https://webhooks.gitter.im/e/5c98eaf2d3e76753369e
+    on_build_success: false
+    on_build_failure: true
+    on_build_status_changed: true

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -11,6 +11,7 @@ gcovr
 
   * Submit a ticket |rarr| `<https://github.com/gcovr/gcovr/issues>`_
   * Stack Overflow |rarr| `<http://stackoverflow.com/search?q=[gcovr]>`_
+  * Chat on Gitter |rarr| `<https://gitter.im/gcovr/gcovr>`_
 
 * Download
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -5,24 +5,19 @@ gcovr
    :start-after: .. begin abstract
    :end-before: .. end abstract
 
-.. include:: <isonum.txt>
+.. admonition:: Quick Links
 
-* Getting Help
+    * Getting Help
 
-  * Submit a ticket |rarr| `<https://github.com/gcovr/gcovr/issues>`_
-  * Stack Overflow |rarr| `<http://stackoverflow.com/search?q=[gcovr]>`_
-  * Chat on Gitter |rarr| `<https://gitter.im/gcovr/gcovr>`_
+      * `Submit a ticket <https://github.com/gcovr/gcovr/issues>`_
+      * `Stack Overflow <https://stackoverflow.com/questions/tagged/gcovr>`_
+      * `Chat on Gitter <https://gitter.im/gcovr/gcovr>`_
 
-* Download
+    * Install from `PyPI <https://pypi.org/project/gcovr/>`_: ``pip install gcovr``
 
-  * PyPI |rarr| `<https://pypi.org/project/gcovr/>`_
+    * `Source Code on GitHub <https://github.com/gcovr/gcovr>`_
 
-* Source Code
-
-  * Browse Source (GitHub) |rarr| `<https://github.com/gcovr/gcovr>`_
-  * Source Downloads |rarr| `<https://github.com/gcovr/gcovr/releases>`_
-
-..    Change Log |rarr| https://raw.github.com/gcovr/gcovr/master/CHANGELOG.txt
+    * :doc:`changelog`
 
 .. toctree::
    :maxdepth: 2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pyutilib
+pytest
+flake8


### PR DESCRIPTION
I dumped my experience from a few PRs into improved contribution docs. My goal is to clarify expectations around PRs, and make it easier to get started in a local development environment. For example, development requirements are now listed in the top-level `requirements.txt`.

This PR also advertises [a Gitter chatroom](https://gitter.im/gcovr/gcovr). Having a chat is desirable because informal real-time discussions are sometimes much more efficient than typing up issue comments. I tested this by walking a first-time contributor through Git and the pull request process.

Gitter is a chat service with good GitHub integration. The chat rooms are fairly open and can be viewed without having to log in. For logged-in users, there is an IRC bridge. Gcovr developers (i.e. anyone with push access to this repo) are automatically admins in the chatroom.

While I was already working on the docs, I also added the documentation build process to Travis. This should help validate any documentation changes, since the GitHub preview is insufficient to render Sphinx documents. I also made the quick links on the documentation frontpage more compact.

(A quick note on my plans regarding the gcovr website: once this PR is merged, I want to switch the gcovr website to the sphinx documentation version, even though it will document the state of the gcovr development version and not the 3.4 release. I'll then try to figure out automatic deployment. Once Read The Docs supports HTTPS for custom domains, I'd like to migrate there to get multi-version documentation.)