### PR TITLE
Filter option not affect when running with mingw-w64-x86_64-python3

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -37,6 +37,7 @@ The following developers contributed to gcovr (ordered alphabetically):
     Piotr Dziwinski,
     Reto Schneider,
     Robert Rosengren,
+    Songmin Li,
     Steven Myint,
     Sylvestre Ledru,
     trapzero,

--- a/gcovr/tests/filter-test2/Makefile
+++ b/gcovr/tests/filter-test2/Makefile
@@ -1,7 +1,7 @@
 CFLAGS= -fprofile-arcs -ftest-coverage -fPIC
 
 BASE_OS:=$(shell uname | cut -d'-' -f1)
-ifeq ($(BASE_OS),MINGW32_NT)
+ifneq (,$(findstring MINGW,$(BASE_OS)))
   BASE_OS:=MSYS_NT
 endif
 ifeq ($(BASE_OS),MSYS_NT)

--- a/gcovr/tests/shared_lib/Makefile
+++ b/gcovr/tests/shared_lib/Makefile
@@ -7,7 +7,7 @@ ifeq ($(BASE_OS),Darwin)
   CFLAGS     += -fPIC
   SOFLAGS    += -dynamiclib -undefined dynamic_lookup
 endif
-ifeq ($(BASE_OS),MINGW32_NT)
+ifneq (,$(findstring MINGW,$(BASE_OS)))
   BASE_OS:=MSYS_NT
 endif
 ifeq ($(BASE_OS),CYGWIN_NT)

--- a/gcovr/utils.py
+++ b/gcovr/utils.py
@@ -225,7 +225,7 @@ def build_filter(regex):
         # regex, but we do not want to escape the regex itself, so instead of
         # using realpath, we escape the path and join it manually (realpath
         # doesn't resolve symlinks on Windows anyway)
-        return re.compile(re.escape(os.getcwd() + "\\") + regex)
+        return re.compile(re.escape(os.getcwd() + os.path.sep) + regex)
     else:
         return re.compile(os.path.realpath(regex))
 


### PR DESCRIPTION

When I running gcovr with mingw-w64-x86_64-python3 on mingw64, the `-filter` option is not affect.

It seems mingw-w64-x86_64-python3 use '/' as `os.path.sep` by default, which
diff from other pythons on windows.

Modified tip:

1. Change hard code `"\\"` to `os.path.sep`. It is always safe and does not change the origin behavior.
2. uname on mingw64  env is `MINGW64_NT`,  change the logic to support both.