### PR TITLE
Move argument validation outside of argparse

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
 script:
 - test -z "$RUN_LINTER" || flake8 --ignore=E501
 - test -z "$RUN_LINTER" || admin/release_checklist --no-verify-tags 4.1
-- python -m pytest -v $COVERAGE_OPTS gcovr doc/examples
+- python -m pytest -v --doctest-modules $COVERAGE_OPTS gcovr doc/examples
 - test -z "$COVERAGE_OPTS" || codecov -X gcov search
 - test -z "$BUILD_DOCS" || (cd doc; make html O=-W)
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,8 @@ matrix:
 install:
 - printenv
 - $CXX --version
-- pip install pytest --upgrade
+- pip install --upgrade pip  # avoid installation problems
+- pip install --upgrade pytest
 - pip install ply ordereddict pyutilib
 - test -z "$RUN_LINTER" || pip install flake8
 - test -z "$COVERAGE_OPTS" || pip install pytest-cov coverage codecov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,7 @@ install:
 build: off
 
 test_script:
-  - 'python -m pytest -v --cov=gcovr --cov-branch gcovr doc/examples'
+  - 'python -m pytest -v --doctest-modules --cov=gcovr --cov-branch gcovr doc/examples'
   - 'codecov -X gcov search'
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,7 @@ install:
   - 'set PATH=%PYTHONPATH%;%PYTHONPATH%\Scripts;%PATH%'
   - 'python -V'
   - '%CXX% --version'
+  - 'python -m pip install --upgrade pip'
   - 'python -m pip install pytest pytest-cov'
   - 'python -m pip install ply'
   - 'python -m pip install ordereddict'

--- a/gcovr/__main__.py
+++ b/gcovr/__main__.py
@@ -29,17 +29,16 @@
 # $Date$
 #
 
-import locale
 import os
 import re
 import sys
 
-from argparse import ArgumentParser, ArgumentTypeError
+from argparse import ArgumentParser
 from os.path import normpath
-from multiprocessing import cpu_count
 from tempfile import mkdtemp
 from shutil import rmtree
 
+from .configuration import GCOVR_CONFIG_OPTION_GROUPS, GCOVR_CONFIG_OPTIONS
 from .gcov import get_datafiles, process_existing_gcov_file, process_datafile
 from .utils import (get_global_stats, build_filter, AlwaysMatchFilter,
                     DirectoryPrefixFilter, Logger)
@@ -73,24 +72,6 @@ def fail_under(covdata, threshold_line, threshold_branch):
         sys.exit(4)
 
 
-# helper for percentage actions
-def check_percentage(value):
-    try:
-        x = float(value)
-        if not (0.0 <= x <= 100.0):
-            raise ValueError()
-    except ValueError:
-        raise ArgumentTypeError(
-            "{value} not in range [0.0, 100.0]".format(value=value))
-    return x
-
-
-def check_non_empty(value):
-    if not value:
-        raise ArgumentTypeError("value should not be empty")
-    return value
-
-
 def create_argument_parser():
     """Create the argument parser."""
 
@@ -100,13 +81,6 @@ def create_argument_parser():
         "A utility to run gcov and summarize the coverage in simple reports."
 
     parser.epilog = "See <http://gcovr.com/> for the full manual."
-
-    # Style guide for option help messages:
-    # - Prefer complete sentences.
-    # - Phrase first sentence as a command:
-    #   “Print report”, not “Prints report”.
-    # - Must be readable on the command line,
-    #   AND parse as reStructured Text.
 
     options = parser.add_argument_group('Options')
     options.add_argument(
@@ -121,328 +95,22 @@ def create_argument_parser():
         dest="version",
         default=False
     )
-    options.add_argument(
-        "-v", "--verbose",
-        help="Print progress messages. "
-             "Please include this output in bug reports.",
-        action="store_true",
-        dest="verbose",
-        default=False
-    )
-    options.add_argument(
-        "-r", "--root",
-        help="The root directory of your source files. "
-             "Defaults to '%(default)s', the current directory. "
-             "File names are reported relative to this root. "
-             "The --root is the default --filter.",
-        action="store",
-        dest="root",
-        default='.'
-    )
-    options.add_argument(
-        'search_paths',
-        help="Search these directories for coverage files. "
-             "Defaults to --root and --object-directory.",
-        nargs='*',
-    )
-    options.add_argument(
-        "--fail-under-line",
-        type=check_percentage,
-        metavar="MIN",
-        help="Exit with a status of 2 "
-             "if the total line coverage is less than MIN. "
-             "Can be ORed with exit status of '--fail-under-branch' option.",
-        action="store",
-        dest="fail_under_line",
-        default=0.0
-    )
-    options.add_argument(
-        "--fail-under-branch",
-        type=check_percentage,
-        metavar="MIN",
-        help="Exit with a status of 4 "
-             "if the total branch coverage is less than MIN. "
-             "Can be ORed with exit status of '--fail-under-line' option.",
-        action="store",
-        dest="fail_under_branch",
-        default=0.0
-    )
-    options.add_argument(
-        '--source-encoding',
-        help="Select the source file encoding. "
-             "Defaults to the system default encoding (%(default)s).",
-        action='store',
-        dest='source_encoding',
-        default=locale.getpreferredencoding()
-    )
 
-    output_options = parser.add_argument_group(
-        "Output Options",
-        description="Gcovr prints a text report by default, "
-                    "but can switch to XML or HTML."
-    )
-    output_options.add_argument(
-        "-o", "--output",
-        help="Print output to this filename. Defaults to stdout. "
-             "Required for --html-details.",
-        action="store",
-        dest="output",
-        default=None
-    )
-    output_options.add_argument(
-        "-b", "--branches",
-        help="Report the branch coverage instead of the line coverage. "
-             "For text report only.",
-        action="store_true",
-        dest="show_branch",
-        default=None
-    )
-    output_options.add_argument(
-        "-u", "--sort-uncovered",
-        help="Sort entries by increasing number of uncovered lines. "
-             "For text and HTML report.",
-        action="store_true",
-        dest="sort_uncovered",
-        default=None
-    )
-    output_options.add_argument(
-        "-p", "--sort-percentage",
-        help="Sort entries by increasing percentage of uncovered lines. "
-             "For text and HTML report.",
-        action="store_true",
-        dest="sort_percent",
-        default=None
-    )
-    output_options.add_argument(
-        "-x", "--xml",
-        help="Generate a Cobertura XML report.",
-        action="store_true",
-        dest="xml",
-        default=False
-    )
-    output_options.add_argument(
-        "--xml-pretty",
-        help="Pretty-print the XML report. Implies --xml. Default: %(default)s.",
-        action="store_true",
-        dest="prettyxml",
-        default=False
-    )
-    output_options.add_argument(
-        "--html",
-        help="Generate a HTML report.",
-        action="store_true",
-        dest="html",
-        default=False
-    )
-    output_options.add_argument(
-        "--html-details",
-        help="Add annotated source code reports to the HTML report. "
-             "Requires --output as a basename for the reports. "
-             "Implies --html.",
-        action="store_true",
-        dest="html_details",
-        default=False
-    )
-    output_options.add_argument(
-        "--html-title",
-        metavar="TITLE",
-        help="Use TITLE as title for the HTML report. Default is %(default)s.",
-        action="store",
-        dest="html_title",
-        default="Head"
-    )
-    options.add_argument(
-        "--html-medium-threshold",
-        type=check_percentage,
-        metavar="MEDIUM",
-        help="If the coverage is below MEDIUM, the value is marked "
-             "as low coverage in the HTML report. "
-             "MEDIUM has to be lower than or equal to value of --html-high-threshold. "
-             "If MEDIUM is equal to value of --html-high-threshold the report has "
-             "only high and low coverage. Default is %(default)s.",
-        action="store",
-        dest="html_medium_threshold",
-        default=75.0
-    )
-    options.add_argument(
-        "--html-high-threshold",
-        type=check_percentage,
-        metavar="HIGH",
-        help="If the coverage is below HIGH, the value is marked "
-             "as medium coverage in the HTML report. "
-             "HIGH has to be greater than or equal to value of --html-medium-threshold. "
-             "If HIGH is equal to value of --html-medium-threshold the report has "
-             "only high and low coverage. Default is %(default)s.",
-        action="store",
-        dest="html_high_threshold",
-        default=90.0
-    )
-    output_options.add_argument(
-        "--html-absolute-paths",
-        help="Use absolute paths to link the --html-details reports. "
-             "Defaults to relative links.",
-        action="store_false",
-        dest="relative_anchors",
-        default=True
-    )
-    output_options.add_argument(
-        '--html-encoding',
-        help="Override the declared HTML report encoding. "
-             "Defaults to %(default)s. "
-             "See also --source-encoding.",
-        action='store',
-        dest='html_encoding',
-        default='UTF-8'
-    )
-    output_options.add_argument(
-        "-s", "--print-summary",
-        help="Print a small report to stdout "
-             "with line & branch percentage coverage. "
-             "This is in addition to other reports. "
-             "Default: %(default)s.",
-        action="store_true",
-        dest="print_summary",
-        default=False
-    )
+    # setup option groups
+    groups = {}
+    for (key, args) in GCOVR_CONFIG_OPTION_GROUPS.items():
+        #
+        group = parser.add_argument_group(args["name"],
+                                          description=args["description"])
+        groups[key] = group
 
-    filter_options = parser.add_argument_group(
-        "Filter Options",
-        description="Filters decide which files are included in the report. "
-                    "Any filter must match, and no exclude filter must match. "
-                    "A filter is a regular expression that matches a path. "
-                    "Filter paths use forward slashes, even on Windows."
-    )
-    filter_options.add_argument(
-        "-f", "--filter",
-        help="Keep only source files that match this filter. "
-             "Can be specified multiple times. "
-             "If no filters are provided, defaults to --root.",
-        action="append",
-        dest="filter",
-        default=[]
-    )
-    filter_options.add_argument(
-        "-e", "--exclude",
-        help="Exclude source files that match this filter. "
-             "Can be specified multiple times.",
-        action="append",
-        dest="exclude",
-        type=check_non_empty,
-        default=[]
-    )
-    filter_options.add_argument(
-        "--gcov-filter",
-        help="Keep only gcov data files that match this filter. "
-             "Can be specified multiple times.",
-        action="append",
-        dest="gcov_filter",
-        default=[]
-    )
-    filter_options.add_argument(
-        "--gcov-exclude",
-        help="Exclude gcov data files that match this filter. "
-             "Can be specified multiple times.",
-        action="append",
-        dest="gcov_exclude",
-        default=[]
-    )
-    filter_options.add_argument(
-        "--exclude-directories",
-        help="Exclude directories that match this regex "
-             "while searching raw coverage files. "
-             "Can be specified multiple times.",
-        action="append",
-        dest="exclude_dirs",
-        type=check_non_empty,
-        default=[]
-    )
-
-    gcov_options = parser.add_argument_group(
-        "GCOV Options",
-        "The 'gcov' tool turns raw coverage files (.gcda and .gcno) "
-        "into .gcov files that are then processed by gcovr. "
-        "The gcno files are generated by the compiler. "
-        "The gcda files are generated when the instrumented program is executed."
-    )
-    gcov_options.add_argument(
-        "--gcov-executable",
-        help="Use a particular gcov executable. "
-             "Must match the compiler you are using, "
-             "e.g. 'llvm-cov gcov' for Clang. "
-             "Can include additional arguments. "
-             "Defaults to the GCOV environment variable, "
-             "or 'gcov': '%(default)s'.",
-        action="store",
-        dest="gcov_cmd",
-        default=os.environ.get('GCOV', 'gcov')
-    )
-    gcov_options.add_argument(
-        "--exclude-unreachable-branches",
-        help="Exclude branch coverage with LCOV/GCOV exclude markers. "
-             "Additionally, exclude branch coverage from lines "
-             "without useful source code "
-             "(often, compiler-generated \"dead\" code). "
-             "Default: %(default)s.",
-        action="store_true",
-        dest="exclude_unreachable_branches",
-        default=False
-    )
-    gcov_options.add_argument(
-        "-g", "--use-gcov-files",
-        help="Use existing gcov files for analysis. Default: %(default)s.",
-        action="store_true",
-        dest="gcov_files",
-        default=False
-    )
-    gcov_options.add_argument(
-        '--gcov-ignore-parse-errors',
-        help="Skip lines with parse errors in GCOV files "
-             "instead of exiting with an error. "
-             "A report will be shown on stderr. "
-             "Default: %(default)s.",
-        action="store_true",
-        dest="gcov_ignore_parse_errors",
-        default=False
-    )
-    gcov_options.add_argument(
-        '--object-directory',
-        help="Override normal working directory detection. "
-             "Gcovr needs to identify the path between gcda files "
-             "and the directory where the compiler was originally run. "
-             "Normally, gcovr can guess correctly. "
-             "This option specifies either "
-             "the path from gcc to the gcda file (i.e. gcc's '-o' option), "
-             "or the path from the gcda file to gcc's working directory.",
-        action="store",
-        dest="objdir",
-        default=None
-    )
-    gcov_options.add_argument(
-        "-k", "--keep",
-        help="Keep gcov files after processing. "
-             "This applies both to files that were generated by gcovr, "
-             "or were supplied via the --use-gcov-files option. "
-             "Default: %(default)s.",
-        action="store_true",
-        dest="keep",
-        default=False
-    )
-    gcov_options.add_argument(
-        "-d", "--delete",
-        help="Delete gcda files after processing. Default: %(default)s.",
-        action="store_true",
-        dest="delete",
-        default=False
-    )
-    gcov_options.add_argument(
-        "-j",
-        help="Set the number of threads to use in parallel.",
-        nargs="?",
-        const=cpu_count(),
-        type=int,
-        dest="gcov_parallel",
-        default=1
-    )
+    # create each option value
+    for opt in GCOVR_CONFIG_OPTIONS:
+        if opt.group is None:
+            opt.add_option_to_parser(options)
+        else:
+            opt.add_option_to_parser(groups[opt.group])
+    #
     return parser
 
 
@@ -457,6 +125,12 @@ COPYRIGHT = (
 def main(args=None):
     parser = create_argument_parser()
     options = parser.parse_args(args=args)
+
+    # process namespace to add a default value for any options that
+    # weren't provided.
+    for opt in GCOVR_CONFIG_OPTIONS:
+        if not hasattr(options, opt.name):
+            setattr(options, opt.name, opt.default)
 
     logger = Logger(options.verbose)
 

--- a/gcovr/__main__.py
+++ b/gcovr/__main__.py
@@ -38,7 +38,7 @@ from os.path import normpath
 from tempfile import mkdtemp
 from shutil import rmtree
 
-from .configuration import GCOVR_CONFIG_OPTION_GROUPS, GCOVR_CONFIG_OPTIONS
+from .configuration import argument_parser_setup, GCOVR_CONFIG_OPTIONS
 from .gcov import get_datafiles, process_existing_gcov_file, process_datafile
 from .utils import (get_global_stats, build_filter, AlwaysMatchFilter,
                     DirectoryPrefixFilter, Logger)
@@ -96,21 +96,8 @@ def create_argument_parser():
         default=False
     )
 
-    # setup option groups
-    groups = {}
-    for (key, args) in GCOVR_CONFIG_OPTION_GROUPS.items():
-        #
-        group = parser.add_argument_group(args["name"],
-                                          description=args["description"])
-        groups[key] = group
+    argument_parser_setup(parser, options)
 
-    # create each option value
-    for opt in GCOVR_CONFIG_OPTIONS:
-        if opt.group is None:
-            opt.add_option_to_parser(options)
-        else:
-            opt.add_option_to_parser(groups[opt.group])
-    #
     return parser
 
 

--- a/gcovr/configuration.py
+++ b/gcovr/configuration.py
@@ -131,8 +131,11 @@ class GcovrConfigOption(object):
         self.help = help.format(**self.__dict__)
 
     def __repr__(self):
-        r"""String representation of instance."""
+        r"""String representation of instance.
 
+        >>> GcovrConfigOption('foo', ['-f', '--foo'], help="fooify")
+        GcovrConfigOption('foo', [-f, --foo], ..., help='fooify', ...)
+        """
         kwargs = [
             '{k}={v!r}'.format(k=k, v=v)
             for k, v in sorted(self.__dict__.items())

--- a/gcovr/configuration.py
+++ b/gcovr/configuration.py
@@ -16,7 +16,7 @@ import os
 
 
 def check_percentage(value):
-    r""""
+    r"""
     Check that the percentage is within a reasonable range and if so return it.
     """
     try:
@@ -35,7 +35,7 @@ def check_non_empty(value):
     return value
 
 
-class GcovrConfigOption:
+class GcovrConfigOption(object):
     r"""
     Represents a single setting for a gcovr runtime parameter.
 
@@ -46,91 +46,170 @@ class GcovrConfigOption:
     keyword argument is expected to return a valid conversion of a string
     value or throw an error.
 
-    This class is initializer in a very similar fashion as adding arguments
-    to an argparse Parser instance with a few minor changes.
-        1. The first positional argument is the "name" (i.e. "dest" in
-           argparse speak) and is required.
-        2. A "group" keyword argument has been added which corresponds to a
-           key in the GCOVR_CONFIG_OPTION_GROUPS dictionary.
+    Arguments:
+        name (str):
+            Destination (options object field),
+            must be valid Python identifier.
+        flags (list of str, optional):
+            Any command line flags. If empty, the option is positional.
+
+    Keyword Arguments:
+        action (str, optional):
+            What to do when the option is parsed.
+            See the available *argparse* actions. In particular:
+            - store (default): store the option argument
+            - store_const: store the const value
+            - store_true, store_false: shortcuts for store_const
+            - append: append the option argument
+        choices (list):
+            Value must be one of these after conversion.
+        const (any, optional):
+            Assigned by the "store_const" action.
+        default (any, optional):
+            Default value if the option is not found, defaults to None.
+        group (str, optional):
+            Name of the option group in GCOVR_CONFIG_OPTION_GROUPS.
+            Only relevant for documentation purposes.
+        help (str):
+            Help message.
+            Must display well on terminal *and* render as Restructured Text.
+            Any named curly-brace placeholders
+            are filled in from the option attributes via ``str.format()``.
+        metavar (str, optional):
+            Name of the value in help messages, defaults to the name.
+        nargs (int or '+', '*', '?', optional):
+            How often the option may occur.
+            Special case for "?": if the option exists but has no value,
+            the const value is stored.
+        required (bool, optional):
+            Whether this option is required, defaults to False.
+        type (function, optional):
+            Check and convert the option value, may throw exceptions.
     """
 
-    def __init__(self, name, *flags, **kwargs):
-        self.name = name
-        self.flags = flags
-        self.group = kwargs.pop("group", None)
-        self.default = None
-        #
-        # set remaining kwargs as attributes
-        for key, value in kwargs.items():
-            setattr(self, key, value)
-        if hasattr(self, 'help'):
-            self.help = self.help.format(**self.__dict__)
-        #
+    def __init__(
+        self, name, flags=None,
+        action='store', choices=None, const=None, default=None, group=None,
+        help=None, metavar=None, nargs=None, required=False, type=None,
+    ):
+        if flags is None:
+            flags = []
+
+        assert help is not None, "help required"
+
         # the store_true and store_false actions have hardcoded boolean
         # constants in their definitions so they need switched to the generic
         # store_const in order for the logic here to work correctly.
-        if getattr(self, 'action', None) == 'store_true':
-            self.action = 'store_const'
-            self.const = True
-            self.default = False
-        if getattr(self, 'action', None) == 'store_false':
-            self.action = 'store_const'
-            self.const = False
-            self.default = True
+        if action == 'store_true':
+            assert const is None, "action=store_true and const conflict"
+            assert default is None, "action=store_true and default conflict"
+            action = 'store_const'
+            const = True
+            default = False
+        elif action == 'store_false':
+            assert const is None, "action=store_false and const conflict"
+            assert default is None, "action=store_false and default conflict"
+            action = 'store_const'
+            const = False
+            default = True
+
+        self.name = name
+        self.flags = flags
+
+        self.action = action
+        self.choices = choices
+        self.const = const
+        self.default = default
+        self.group = group
+        self.help = None  # assigned later
+        self.metavar = metavar
+        self.nargs = nargs
+        self.required = required
+        self.type = type
+
+        # format the help
+        self.help = help.format(**self.__dict__)
 
     def __repr__(self):
         r"""String representation of instance."""
-        fmt = "GcovrConfigOption({name!r}, {flags}group={group!r}, {kwargs})"
-        kwargs = dict(self.__dict__)
-        for key in ["name", "flags", "group"]:
-            del kwargs[key]
-        kwargs = ['{k}={v!r}'.format(k=k, v=v) for k, v in kwargs.items()]
-        #
-        return fmt.format(name=self.name,
-                          flags=', '.join(self.flags) + ', ',
-                          group=self.group,
-                          kwargs=', '.join(kwargs))
 
-    def add_option_to_parser(self, parser):
-        r"""Adds the argument to an argparse parser or option group."""
-        # extract keyword args from instance
-        keys = ["action", "nargs", "const", "type", "choices",
-                "required", "help", "metavar"]
-        kwargs = {"default": SUPPRESS}
-        for key in keys:
-            if hasattr(self, key):
-                kwargs[key] = getattr(self, key)
+        kwargs = [
+            '{k}={v!r}'.format(k=k, v=v)
+            for k, v in sorted(self.__dict__.items())
+            if k not in ('name', 'flags')]
 
-        # we only want to set dest for non-positionals
-        if self.flags:
-            kwargs["dest"] = self.name
-            parser.add_argument(*self.flags, **kwargs)
+        return "GcovrConfigOption({name!r}, [{flags}], {kwargs})".format(
+            name=self.name,
+            flags=', '.join(self.flags),
+            kwargs=', '.join(kwargs),
+        )
+
+
+def argument_parser_setup(parser, default_group):
+    r"""Add all options and groups to the given argparse parser."""
+
+    # setup option groups
+    groups = {}
+    for group_def in GCOVR_CONFIG_OPTION_GROUPS:
+        group = parser.add_argument_group(group_def["name"],
+                                          description=group_def["description"])
+        groups[group_def["key"]] = group
+
+    # create each option value
+    for opt in GCOVR_CONFIG_OPTIONS:
+        group = default_group if opt.group is None else groups[opt.group]
+
+        kwargs = {
+            'action': opt.action,
+            'const': opt.const,
+            'default': SUPPRESS,  # default will be assigned manually
+            'help': opt.help,
+            'metavar': opt.metavar,
+        }
+
+        # To avoid store_const problems, optionally set choices, nargs, type:
+        if opt.choices is not None:
+            kwargs['choices'] = opt.choices
+        if opt.nargs is not None:
+            kwargs['nargs'] = opt.nargs
+        if opt.type is not None:
+            kwargs['type'] = opt.type
+
+        # We only want to set dest and required for non-positionals.
+        if opt.flags:
+            kwargs["dest"] = opt.name
+            kwargs["required"] = opt.required  # only meaningful for flags
+            group.add_argument(*opt.flags, **kwargs)
         else:
-            parser.add_argument(self.name, **kwargs)
+            group.add_argument(opt.name, **kwargs)
 
 
-GCOVR_CONFIG_OPTION_GROUPS = {
-    "output_options": {
+GCOVR_CONFIG_OPTION_GROUPS = [
+    {
+        "key": "output_options",
         "name": "Output Options",
-        "description": ("Gcovr prints a text report by default, "
-                        "but can switch to XML or HTML.")
-    },
-    "filter_options": {
+        "description":
+            "Gcovr prints a text report by default, "
+            "but can switch to XML or HTML.",
+    }, {
+        "key": "filter_options",
         "name": "Filter Options",
-        "description": ("Filters decide which files are included in the report. "
-                        "Any filter must match, and no exclude filter must match. "
-                        "A filter is a regular expression that matches a path. "
-                        "Filter paths use forward slashes, even on Windows.")
-    },
-    "gcov_options": {
+        "description":
+            "Filters decide which files are included in the report. "
+            "Any filter must match, and no exclude filter must match. "
+            "A filter is a regular expression that matches a path. "
+            "Filter paths use forward slashes, even on Windows.",
+    }, {
+        "key": "gcov_options",
         "name": "GCOV Options",
-        "description": ("The 'gcov' tool turns raw coverage files (.gcda and .gcno) "
-                        "into .gcov files that are then processed by gcovr. "
-                        "The gcno files are generated by the compiler. "
-                        "The gcda files are generated when the instrumented program is "
-                        "executed.")
+        "description":
+            "The 'gcov' tool turns raw coverage files (.gcda and .gcno) "
+            "into .gcov files that are then processed by gcovr. "
+            "The gcno files are generated by the compiler. "
+            "The gcda files are generated when the instrumented program is "
+            "executed.",
     },
-}
+]
 
 
 # Style guide for option descriptions:
@@ -142,22 +221,18 @@ GCOVR_CONFIG_OPTION_GROUPS = {
 
 GCOVR_CONFIG_OPTIONS = [
     GcovrConfigOption(
-        "verbose",
-        "-v", "--verbose",
+        "verbose", ["-v", "--verbose"],
         help="Print progress messages. "
              "Please include this output in bug reports.",
         action="store_true",
-        default=False
     ),
     GcovrConfigOption(
-        "root",
-        "-r", "--root",
+        "root", ["-r", "--root"],
         help="The root directory of your source files. "
              "Defaults to '{default!s}', the current directory. "
              "File names are reported relative to this root. "
              "The --root is the default --filter.",
-        action="store",
-        default='.'
+        default='.',
     ),
     GcovrConfigOption(
         'search_paths',
@@ -166,117 +241,92 @@ GCOVR_CONFIG_OPTIONS = [
         nargs='*',
     ),
     GcovrConfigOption(
-        "fail_under_line",
-        "--fail-under-line",
+        "fail_under_line", ["--fail-under-line"],
         type=check_percentage,
         metavar="MIN",
         help="Exit with a status of 2 "
              "if the total line coverage is less than MIN. "
              "Can be ORed with exit status of '--fail-under-branch' option.",
-        action="store",
-        default=0.0
+        default=0.0,
     ),
     GcovrConfigOption(
-        "fail_under_branch",
-        "--fail-under-branch",
+        "fail_under_branch", ["--fail-under-branch"],
         type=check_percentage,
         metavar="MIN",
         help="Exit with a status of 4 "
              "if the total branch coverage is less than MIN. "
              "Can be ORed with exit status of '--fail-under-line' option.",
-        action="store",
-        default=0.0
+        default=0.0,
     ),
     GcovrConfigOption(
-        'source_encoding',
-        '--source-encoding',
+        'source_encoding', ['--source-encoding'],
         help="Select the source file encoding. "
              "Defaults to the system default encoding ({default!s}).",
-        action='store',
-        default=getpreferredencoding()
+        default=getpreferredencoding(),
     ),
     GcovrConfigOption(
-        "output",
-        "-o", "--output",
+        "output", ["-o", "--output"],
         group="output_options",
         help="Print output to this filename. Defaults to stdout. "
              "Required for --html-details.",
-        action="store",
-        default=None
+        default=None,
     ),
     GcovrConfigOption(
-        "show_branch",
-        "-b", "--branches",
+        "show_branch", ["-b", "--branches"],
         group="output_options",
         help="Report the branch coverage instead of the line coverage. "
              "For text report only.",
         action="store_true",
-        default=None
     ),
     GcovrConfigOption(
-        "sort_uncovered",
-        "-u", "--sort-uncovered",
+        "sort_uncovered", ["-u", "--sort-uncovered"],
         group="output_options",
         help="Sort entries by increasing number of uncovered lines. "
              "For text and HTML report.",
         action="store_true",
-        default=None
     ),
     GcovrConfigOption(
-        "sort_percent",
-        "-p", "--sort-percentage",
+        "sort_percent", ["-p", "--sort-percentage"],
         group="output_options",
         help="Sort entries by increasing percentage of uncovered lines. "
              "For text and HTML report.",
         action="store_true",
-        default=None
     ),
     GcovrConfigOption(
-        "xml",
-        "-x", "--xml",
+        "xml", ["-x", "--xml"],
         group="output_options",
         help="Generate a Cobertura XML report.",
         action="store_true",
-        default=False
     ),
     GcovrConfigOption(
-        "prettyxml",
-        "--xml-pretty",
+        "prettyxml", ["--xml-pretty"],
         group="output_options",
         help="Pretty-print the XML report. Implies --xml. Default: {default!s}.",
         action="store_true",
-        default=False
     ),
     GcovrConfigOption(
-        "html",
-        "--html",
+        "html", ["--html"],
         group="output_options",
         help="Generate a HTML report.",
         action="store_true",
-        default=False
     ),
     GcovrConfigOption(
-        "html_details",
-        "--html-details",
+        "html_details", ["--html-details"],
         group="output_options",
         help="Add annotated source code reports to the HTML report. "
              "Requires --output as a basename for the reports. "
              "Implies --html.",
         action="store_true",
-        default=False
     ),
     GcovrConfigOption(
-        "html_title",
-        "--html-title",
+        "html_title", ["--html-title"],
         group="output_options",
         metavar="TITLE",
         help="Use TITLE as title for the HTML report. Default is {default!s}.",
-        action="store",
-        default="Head"
+        default="Head",
     ),
     GcovrConfigOption(
-        "html_medium_threshold",
-        "--html-medium-threshold",
+        "html_medium_threshold", ["--html-medium-threshold"],
         group="output_options",
         type=check_percentage,
         metavar="MEDIUM",
@@ -285,12 +335,10 @@ GCOVR_CONFIG_OPTIONS = [
              "MEDIUM has to be lower than or equal to value of --html-high-threshold. "
              "If MEDIUM is equal to value of --html-high-threshold the report has "
              "only high and low coverage. Default is {default!s}.",
-        action="store",
-        default=75.0
+        default=75.0,
     ),
     GcovrConfigOption(
-        "html_high_threshold",
-        "--html-high-threshold",
+        "html_high_threshold", ["--html-high-threshold"],
         group="output_options",
         type=check_percentage,
         metavar="HIGH",
@@ -299,91 +347,78 @@ GCOVR_CONFIG_OPTIONS = [
              "HIGH has to be greater than or equal to value of --html-medium-threshold. "
              "If HIGH is equal to value of --html-medium-threshold the report has "
              "only high and low coverage. Default is {default!s}.",
-        action="store",
-        default=90.0
+        default=90.0,
     ),
     GcovrConfigOption(
-        "relative_anchors",
-        "--html-absolute-paths",
+        "relative_anchors", ["--html-absolute-paths"],
         group="output_options",
         help="Use absolute paths to link the --html-details reports. "
              "Defaults to relative links.",
         action="store_false",
-        default=True
     ),
     GcovrConfigOption(
-        'html_encoding',
-        '--html-encoding',
+        'html_encoding', ['--html-encoding'],
         group="output_options",
         help="Override the declared HTML report encoding. "
              "Defaults to {default!s}. "
              "See also --source-encoding.",
-        action='store',
-        default='UTF-8'
+        default='UTF-8',
     ),
     GcovrConfigOption(
-        "print_summary",
-        "-s", "--print-summary",
+        "print_summary", ["-s", "--print-summary"],
         group="output_options",
         help="Print a small report to stdout "
              "with line & branch percentage coverage. "
              "This is in addition to other reports. "
              "Default: {default!s}.",
         action="store_true",
-        default=False
     ),
     GcovrConfigOption(
-        "filter",
-        "-f", "--filter",
+        "filter", ["-f", "--filter"],
         group="filter_options",
         help="Keep only source files that match this filter. "
              "Can be specified multiple times. "
              "If no filters are provided, defaults to --root.",
         action="append",
-        default=[]
+        default=[],
     ),
     GcovrConfigOption(
-        "exclude",
-        "-e", "--exclude",
+        "exclude", ["-e", "--exclude"],
         group="filter_options",
         help="Exclude source files that match this filter. "
              "Can be specified multiple times.",
         action="append",
         type=check_non_empty,
-        default=[]
+        default=[],
     ),
     GcovrConfigOption(
-        "gcov_filter",
-        "--gcov-filter",
+        "gcov_filter", ["--gcov-filter"],
         group="filter_options",
         help="Keep only gcov data files that match this filter. "
              "Can be specified multiple times.",
         action="append",
-        default=[]
+        default=[],
     ),
     GcovrConfigOption(
-        "gcov_exclude",
-        "--gcov-exclude",
+        "gcov_exclude", ["--gcov-exclude"],
         group="filter_options",
         help="Exclude gcov data files that match this filter. "
              "Can be specified multiple times.",
         action="append",
-        default=[]
+        default=[],
     ),
     GcovrConfigOption(
-        "exclude_dirs",
-        "--exclude-directories",
+        "exclude_dirs", ["--exclude-directories"],
         group="filter_options",
         help="Exclude directories that match this regex "
              "while searching raw coverage files. "
              "Can be specified multiple times.",
         action="append",
         type=check_non_empty,
-        default=[]
+        default=[],
     ),
     GcovrConfigOption(
-        "gcov_cmd",
-        "--gcov-executable",
+        "gcov_cmd", ["--gcov-executable"],
         group="gcov_options",
         help="Use a particular gcov executable. "
              "Must match the compiler you are using, "
@@ -391,12 +426,10 @@ GCOVR_CONFIG_OPTIONS = [
              "Can include additional arguments. "
              "Defaults to the GCOV environment variable, "
              "or 'gcov': '{default!s}'.",
-        action="store",
-        default=os.environ.get('GCOV', 'gcov')
+        default=os.environ.get('GCOV', 'gcov'),
     ),
     GcovrConfigOption(
-        "exclude_unreachable_branches",
-        "--exclude-unreachable-branches",
+        "exclude_unreachable_branches", ["--exclude-unreachable-branches"],
         group="gcov_options",
         help="Exclude branch coverage with LCOV/GCOV exclude markers. "
              "Additionally, exclude branch coverage from lines "
@@ -404,30 +437,24 @@ GCOVR_CONFIG_OPTIONS = [
              "(often, compiler-generated \"dead\" code). "
              "Default: {default!s}.",
         action="store_true",
-        default=False
     ),
     GcovrConfigOption(
-        "gcov_files",
-        "-g", "--use-gcov-files",
+        "gcov_files", ["-g", "--use-gcov-files"],
         group="gcov_options",
         help="Use existing gcov files for analysis. Default: {default!s}.",
         action="store_true",
-        default=False
     ),
     GcovrConfigOption(
-        "gcov_ignore_parse_errors",
-        '--gcov-ignore-parse-errors',
+        "gcov_ignore_parse_errors", ['--gcov-ignore-parse-errors'],
         group="gcov_options",
         help="Skip lines with parse errors in GCOV files "
              "instead of exiting with an error. "
              "A report will be shown on stderr. "
              "Default: {default!s}.",
         action="store_true",
-        default=False
     ),
     GcovrConfigOption(
-        "objdir",
-        '--object-directory',
+        "objdir", ['--object-directory'],
         group="gcov_options",
         help="Override normal working directory detection. "
              "Gcovr needs to identify the path between gcda files "
@@ -436,36 +463,29 @@ GCOVR_CONFIG_OPTIONS = [
              "This option specifies either "
              "the path from gcc to the gcda file (i.e. gcc's '-o' option), "
              "or the path from the gcda file to gcc's working directory.",
-        action="store",
-        default=None
     ),
     GcovrConfigOption(
-        "keep",
-        "-k", "--keep",
+        "keep", ["-k", "--keep"],
         group="gcov_options",
         help="Keep gcov files after processing. "
              "This applies both to files that were generated by gcovr, "
              "or were supplied via the --use-gcov-files option. "
              "Default: {default!s}.",
         action="store_true",
-        default=False
     ),
     GcovrConfigOption(
-        "delete",
-        "-d", "--delete",
+        "delete", ["-d", "--delete"],
         group="gcov_options",
         help="Delete gcda files after processing. Default: {default!s}.",
         action="store_true",
-        default=False
     ),
     GcovrConfigOption(
-        "gcov_parallel",
-        "-j",
+        "gcov_parallel", ["-j"],
         group="gcov_options",
         help="Set the number of threads to use in parallel.",
         nargs="?",
         const=cpu_count(),
         type=int,
-        default=1
+        default=1,
     )
 ]


### PR DESCRIPTION
Extracts the command line api configuration out into a separate module (configuration.py). The `GcovrConfigOption` classes store all of the necessary information to add themselves to an argparse parser and make that information easily accessible for any future configuration schemes. (The objects produced by `add_argument` are rather opaque.) 

Todo:
 * [ ] Add unit tests (integration tests are probably already covered)

This is a building block for eventually addressing #229 