### PR TITLE
search_file: don't visit the same directory more than once

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -44,5 +44,6 @@ The following developers contributed to gcovr (ordered alphabetically):
     Steven Myint,
     Sylvestre Ledru,
     trapzero,
+    Will Thompson,
     William Hart,
     and possibly others.

--- a/gcovr/tests/linked/Makefile
+++ b/gcovr/tests/linked/Makefile
@@ -39,5 +39,6 @@ links:
 	   ln -s ../../../nested/subdir/A n;\
 	   cd ..;\
 	   ln -s m/n A;\
+	   ln -s . loop;\
 	   cd ..;\
 	fi


### PR DESCRIPTION
The directory tree being scanned may in fact be a directed graph, with
cycles, due to following symbolic links. The kernel imposes a limit on
the number of symbolic links followed in a path, beyond which operations
fail with ELOOP. (According to path_resolution(7), the limit is 40 links
on current Linux.) If the graph is very branchy, it may take a very long
time to fail.

For a real-world example, the Meson build system uses gcovr to provide a
'ninja coverage-xml' target. The systemd project (which uses Meson) has
a test suite which generates a fake sysfs tree, with many circular
references, including 64 self-referential ttyX directories:

    $ ls -l build/test/sys/devices/virtual/tty/tty1/subsystem/tty1
    lrwxrwxrwx 1 wjt wjt 30 Oct  9 12:16 build/test/sys/devices/virtual/tty/tty1/subsystem/tty1 -> ../../devices/virtual/tty/tty1
    $ ls -l build/test/sys/devices/virtual/tty/tty1
    total 12
    -rw-r--r-- 1 wjt wjt    4 Oct  9 12:16 dev
    drwxr-xr-x 2 wjt wjt 4096 Oct  9 12:16 power
    lrwxrwxrwx 1 wjt wjt   21 Oct  9 12:16 subsystem -> ../../../../class/tty
    -rw-r--r-- 1 wjt wjt   16 Oct  9 12:16 uevent
    $ ls -l build/test/sys/devices/virtual/tty/tty1/subsystem/tty1
    lrwxrwxrwx 1 wjt wjt 30 Oct  9 12:16 build/test/sys/devices/virtual/tty/tty1/subsystem/tty1 -> ../../devices/virtual/tty/tty1
    $ readlink -f build/test/sys/devices/virtual/tty/tty1/subsystem/tty1
    /home/wjt/src/endlessm/systemd/build/test/sys/devices/virtual/tty/tty1

Note that each link refers to a directory which contains all the fake
tty trees again. 64 ** 40 is a very large number! On our build server, I
cancelled the build after 16 hours.

Even in less pathological cases, since search_file() only yields
absolute paths, there's no need to visit a file via more than one path.
Maintain a set of (device, inode) pairs for each directory visited, and
skip processing any directory that's been visited before.