### PR TITLE
Added support for JSON summary report output

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -41,6 +41,7 @@ The following developers contributed to gcovr (ordered alphabetically):
     Mikael Salson,
     Mikk Leini,
     Nikolaj Schumacher,
+    Oleksiy Pikalo,
     Piotr Dziwinski,
     Phil Clapham,
     Richard Kjerstadius,

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -62,6 +62,7 @@ Improvements and new features:
    are equivalent. (:issue:`291`)
  - Override gcov locale properly. (:issue:`334`)
  - Make gcov parser more robust when used with GCC 8. (:issue:`315`)
+ - Added -json-sumamry option to generate json summary report. (:issue:`302`)
 
 Known issues:
 
@@ -194,14 +195,14 @@ Internal changes:
 3.1 (6 December 2013)
 ---------------------
 
- - Change to make the -r/--root options define the root directory 
+ - Change to make the -r/--root options define the root directory
    for source files.
  - Fix to apply the -p option when the --html option is used.
  - Adding new option, '--exclude-unreachable-branches' that
    will exclude branches in certain lines from coverage report.
  - Simplifying and standardizing the processing of linked files.
  - Adding tests for deeply nested code, and symbolic links.
- - Add support for multiple —filter options in same manner as —exclude 
+ - Add support for multiple —filter options in same manner as —exclude
    option.
 
 
@@ -213,7 +214,7 @@ Internal changes:
    overrides the environment variable, which overrides the default 'gcov'.
  - Adding an empty "<methods/>" block to <classes/> in the XML output: this
    makes out XML complient with the Cobertura DTD. (#3951)
- - Allow the GCOV environment variable to override the default 'gcov' 
+ - Allow the GCOV environment variable to override the default 'gcov'
    executable.  The default is to search the PATH for 'gcov' if the GCOV
    environment variable is not set. (#3950)
  - Adding support for LCOV-style flags for excluding certain lines from
@@ -292,8 +293,8 @@ Internal changes:
  - Adding timestamp and version attributes to the gcovr XML report (see
    #3877).  It looks like the standard Cobertura output reports number of
    seconds since the epoch for the timestamp and a doted decimal version
-   string.  Now, gcovr reports seconds since the epoch and 
-   "``gcovr ``"+``__version__`` (e.g. "gcovr 2.2") to differentiate it 
+   string.  Now, gcovr reports seconds since the epoch and
+   "``gcovr ``"+``__version__`` (e.g. "gcovr 2.2") to differentiate it
    from a pure Cobertura report.
 
 
@@ -327,4 +328,3 @@ Internal changes:
 
  - Initial release as a separate package.  Earlier versions of gcovr
    were managed within the 'fast' Python package.
-

--- a/gcovr/__main__.py
+++ b/gcovr/__main__.py
@@ -54,10 +54,10 @@ from .workers import Workers
 # generators
 from .cobertura_xml_generator import print_xml_report
 from .html_generator import print_html_report
+from .json_generator import print_json_report, print_json_summary_report
 from .txt_generator import print_text_report
 from .summary_generator import print_summary
 from .sonarqube_generator import print_sonarqube_report
-from .json_generator import print_json_report
 
 
 #
@@ -350,12 +350,20 @@ def print_reports(covdata, options, logger):
             "consider providing output file with `--sonarqube=OUTPUT`.")))
 
     generators.append((
-        lambda: options.json or options.prettyjson,
+        lambda: options.json,
         [options.json],
         print_json_report,
         lambda: logger.warn(
             "JSON output skipped - "
             "consider providing output file with `--json=OUTPUT`.")))
+
+    generators.append((
+        lambda: options.json_summary,
+        [options.json_summary],
+        print_json_summary_report,
+        lambda: logger.warn(
+            "JSON summary output skipped - "
+            "consider providing output file with `--json-summary=OUTPUT`.")))
 
     generators.append((
         lambda: not reports_were_written,

--- a/gcovr/configuration.py
+++ b/gcovr/configuration.py
@@ -611,9 +611,20 @@ GCOVR_CONFIG_OPTIONS = [
         const=OutputOrDefault(None),
     ),
     GcovrConfigOption(
+        "json_summary", ["--json-summary"],
+        group="output_options",
+        metavar='OUTPUT',
+        help="Generate a JSON summary report."
+             "OUTPUT is optional and defaults to --output.",
+        nargs='?',
+        type=OutputOrDefault,
+        default=None,
+        const=OutputOrDefault(None),
+    ),
+    GcovrConfigOption(
         "prettyjson", ["--json-pretty"],
         group="output_options",
-        help="Pretty-print the JSON report. Implies --json. Default: {default!s}.",
+        help="Pretty-print the JSON report. Default: {default!s}.",
         action="store_true",
     ),
     GcovrConfigOption(

--- a/gcovr/tests/add_coverages/Makefile
+++ b/gcovr/tests/add_coverages/Makefile
@@ -8,15 +8,15 @@ all:
 	$(CXX) $(CFLAGS) -DBAR -c main.cpp -o main_bar.o
 	$(CXX) $(CFLAGS) main_bar.o bar.o -o testcase_bar
 
-run: txt xml html sonarqube json
+run: txt xml html sonarqube json json_summary
 
 json_foo:
 	./testcase_foo
-	$(GCOVR) -d --json-pretty -o coverage_foo.json
+	$(GCOVR) -d --json --json-pretty -o coverage_foo.json
 
 json_bar:
 	./testcase_bar
-	$(GCOVR) -d --json coverage_bar.json
+	$(GCOVR) -d --json -o coverage_bar.json
 
 txt: json_foo json_bar
 	$(GCOVR) -a coverage_foo.json -a coverage_bar.json -o coverage.txt
@@ -31,10 +31,14 @@ sonarqube: json_foo json_bar
 	$(GCOVR) -a coverage_foo.json -a coverage_bar.json --sonarqube sonarqube.xml
 
 json: json_foo json_bar
-	$(GCOVR) -a 'coverage_*.json' --json-pretty -o coverage.json
+	$(GCOVR) -a 'coverage_*.json' --json --json-pretty -o coverage.json
+
+json_summary: json_foo json_bar
+	$(GCOVR) -a 'coverage_*.json' --json-summary --json-pretty -o summary_coverage.json
 
 clean:
 	rm -f testcase_*
 	rm -f *.gc*
 	rm -f *.o
-	rm -f coverage.txt coverage.xml coverage*.html sonarqube.xml coverage*.json
+	rm -f coverage.txt coverage.xml coverage*.html sonarqube.xml coverage*.json \
+	      summary_coverage.json

--- a/gcovr/tests/add_coverages/reference/summary_coverage.json
+++ b/gcovr/tests/add_coverages/reference/summary_coverage.json
@@ -1,0 +1,27 @@
+{
+    "covered": 13,
+    "current_working_directory": ".",
+    "files": [
+        {
+            "covered": 4,
+            "file": "bar.cpp",
+            "percent": 100.0,
+            "total": 4
+        },
+        {
+            "covered": 4,
+            "file": "foo.cpp",
+            "percent": 100.0,
+            "total": 4
+        },
+        {
+            "covered": 5,
+            "file": "main.cpp",
+            "percent": 100.0,
+            "total": 5
+        }
+    ],
+    "gcovr/format_version": 0.1,
+    "percent": 100.0,
+    "total": 13
+}

--- a/gcovr/tests/bad++char/Makefile
+++ b/gcovr/tests/bad++char/Makefile
@@ -1,7 +1,7 @@
 all:
 	$(CXX) -fprofile-arcs -ftest-coverage -fPIC main.cpp -o testcase
 
-run: txt xml html sonarqube json
+run: txt xml html sonarqube json json_summary
 
 txt:
 	./testcase
@@ -22,7 +22,11 @@ sonarqube:
 json:
 	# pass
 
+json_summary:
+	./testcase
+	$(GCOVR) -d --json-summary --json-pretty -o summary_coverage.json
+
 clean:
 	rm -f testcase
 	rm -f *.gc*
-	rm -f coverage.txt coverage.xml coverage*.html sonarqube.xml
+	rm -f coverage.txt coverage.xml coverage*.html sonarqube.xml summary_coverage.json

--- a/gcovr/tests/bad++char/reference/summary_coverage.json
+++ b/gcovr/tests/bad++char/reference/summary_coverage.json
@@ -1,0 +1,15 @@
+{
+    "covered": 7,
+    "current_working_directory": ".",
+    "files": [
+        {
+            "covered": 7,
+            "file": "main.cpp",
+            "percent": 87.5,
+            "total": 8
+        }
+    ],
+    "gcovr/format_version": 0.1,
+    "percent": 87.5,
+    "total": 8
+}

--- a/gcovr/tests/cmake_oos/Makefile
+++ b/gcovr/tests/cmake_oos/Makefile
@@ -12,7 +12,7 @@ all:
 	mkdir -p build
 	cd build && $(CMAKE) .. && make
 
-run: txt xml html sonarqube json
+run: txt xml html sonarqube json json_summary
 
 txt:
 	cd build && ./gcovrtest
@@ -33,7 +33,9 @@ sonarqube:
 json:
 	# pass
 
+json_summary:
+	# pass
+
 clean:
 	rm -rf build
 	rm -f coverage.txt coverage.xml coverage*.html sonarqube.xml
-

--- a/gcovr/tests/dot/Makefile
+++ b/gcovr/tests/dot/Makefile
@@ -10,7 +10,7 @@ all:
 	$(CXX) $(CFLAGS) -c .subdir/B/main.cpp -o .subdir/B/main.o
 	$(CXX) $(CFLAGS) .subdir/A/file1.o .subdir/A/file2.o .subdir/A/file3.o .subdir/A/file4.o .subdir/A/C/file5.o .subdir/A/C/D/file6.o .subdir/B/main.o -o .subdir/testcase
 
-run: txt xml html sonarqube json
+run: txt xml html sonarqube json json_summary
 
 txt:
 	./.subdir/testcase
@@ -29,6 +29,9 @@ sonarqube:
 	$(GCOVR) -r . -d --sonarqube sonarqube.xml
 
 json:
+	# pass
+
+json_summary:
 	# pass
 
 clean:

--- a/gcovr/tests/excl-branch/Makefile
+++ b/gcovr/tests/excl-branch/Makefile
@@ -1,7 +1,7 @@
 all:
 	$(CXX) -fprofile-arcs -ftest-coverage -fPIC main.cpp -o testcase
 
-run: txt xml html sonarqube json
+run: txt xml html sonarqube json json_summary
 
 txt:
 	./testcase
@@ -20,6 +20,9 @@ sonarqube:
 	$(GCOVR) --exclude-unreachable-branches -b -d --sonarqube sonarqube.xml
 
 json:
+	# pass
+
+json_summary:
 	# pass
 
 clean:

--- a/gcovr/tests/excl-line/Makefile
+++ b/gcovr/tests/excl-line/Makefile
@@ -1,7 +1,7 @@
 all:
 	$(CXX) -fprofile-arcs -ftest-coverage -fPIC main.cpp -o testcase
 
-run: txt xml html sonarqube json
+run: txt xml html sonarqube json json_summary
 
 txt:
 	./testcase
@@ -21,6 +21,10 @@ sonarqube:
 
 json:
 	# pass
+
+json_summary:
+	# pass
+
 
 clean:
 	rm -f testcase

--- a/gcovr/tests/exclude-directories-relative/Makefile
+++ b/gcovr/tests/exclude-directories-relative/Makefile
@@ -6,7 +6,7 @@ all:
 	$(CXX) $(CFLAGS) -c b/main.cpp -o build/b/main.o
 	$(CXX) $(CFLAGS) build/b/main.o build/a/file1.o -o testcase
 
-run: txt xml html sonarqube json
+run: txt xml html sonarqube json json_summary
 
 GCOVR_TEST_OPTIONS = --exclude-directories 'build/a'
 
@@ -27,6 +27,9 @@ sonarqube:
 	$(GCOVR) $(GCOVR_TEST_OPTIONS) -d --sonarqube sonarqube.xml
 
 json:
+	# pass
+
+json_summary:
 	# pass
 
 clean:

--- a/gcovr/tests/exclude-relative/Makefile
+++ b/gcovr/tests/exclude-relative/Makefile
@@ -5,7 +5,7 @@ all:
 	$(CXX) $(CFLAGS) -c main.cpp -o main.o
 	$(CXX) $(CFLAGS) main.o file1.o -o testcase
 
-run: txt xml html sonarqube json
+run: txt xml html sonarqube json  json_summary
 
 GCOVR_TEST_OPTIONS = -e 'file1.cpp'  # use a relative filter here
 
@@ -26,6 +26,9 @@ sonarqube:
 	$(GCOVR) $(GCOVR_TEST_OPTIONS) -d --sonarqube sonarqube.xml
 
 json:
+	# pass
+
+json_summary:
 	# pass
 
 clean:

--- a/gcovr/tests/exclude-throw-branches/Makefile
+++ b/gcovr/tests/exclude-throw-branches/Makefile
@@ -1,7 +1,7 @@
 all:
 	$(CXX) -fprofile-arcs -ftest-coverage -fPIC main.cpp -o testcase
 
-run: txt xml html sonarqube json
+run: txt xml html sonarqube json json_summary
 
 txt:
 	./testcase
@@ -24,6 +24,9 @@ sonarqube:
 	$(GCOVR) -d --exclude-throw-branches --sonarqube sonarqube-excl-throw.xml
 
 json:
+	# pass
+
+json_summary:
 	# pass
 
 clean:

--- a/gcovr/tests/filter-absolute/Makefile
+++ b/gcovr/tests/filter-absolute/Makefile
@@ -16,7 +16,7 @@ all:
 	$(CXX) $(CFLAGS) -c main.cpp -o main.o
 	$(CXX) $(CFLAGS) main.o file1.o -o testcase
 
-run: txt xml html sonarqube json
+run: txt xml html sonarqube json json_summary
 
 txt:
 	./testcase
@@ -36,6 +36,9 @@ sonarqube:
 	$(GCOVR) $(GCOVR_TEST_OPTIONS) -d --sonarqube sonarqube.xml
 
 json:
+	# pass
+
+json_summary:
 	# pass
 
 clean:

--- a/gcovr/tests/filter-relative-lib/Makefile
+++ b/gcovr/tests/filter-relative-lib/Makefile
@@ -6,7 +6,7 @@ all: links
 	cd project; $(CXX) $(CFLAGS) -c relevant-library/src/yes.cpp -o yes.o
 	cd project; $(CXX) $(CFLAGS) main.o no.o yes.o -o testcase
 
-run: txt xml html sonarqube json
+run: txt xml html sonarqube json json_summary
 
 # the src/ filter is provided by the project/gcovr.cfg configuration file
 GCOVR_TEST_OPTIONS = -f '\.\./external-library/src'
@@ -28,6 +28,9 @@ sonarqube:
 	cd project; $(GCOVR) $(GCOVR_TEST_OPTIONS) -d --sonarqube ../sonarqube.xml
 
 json:
+	# pass
+
+json_summary:
 	# pass
 
 links:

--- a/gcovr/tests/filter-relative/Makefile
+++ b/gcovr/tests/filter-relative/Makefile
@@ -5,7 +5,7 @@ all:
 	$(CXX) $(CFLAGS) -c main.cpp -o main.o
 	$(CXX) $(CFLAGS) main.o file1.o -o testcase
 
-run: txt xml html sonarqube json
+run: txt xml html sonarqube json json_summary
 
 GCOVR_TEST_OPTIONS = -f 'main.cpp'  # use a relative filter here
 
@@ -26,6 +26,9 @@ sonarqube:
 	$(GCOVR) $(GCOVR_TEST_OPTIONS) -d --sonarqube sonarqube.xml
 
 json:
+	# pass
+
+json_summary:
 	# pass
 
 clean:

--- a/gcovr/tests/html-encoding-cp1252/Makefile
+++ b/gcovr/tests/html-encoding-cp1252/Makefile
@@ -1,7 +1,7 @@
 all:
 	$(CXX) -fprofile-arcs -ftest-coverage -fPIC main.cpp -o testcase
 
-run: txt xml html sonarqube json
+run: txt xml html sonarqube json json_summary
 
 txt:
 	# pass
@@ -17,6 +17,9 @@ sonarqube:
 	# pass
 
 json:
+	# pass
+
+json_summary:
 	# pass
 
 clean:

--- a/gcovr/tests/html-encoding-iso-8859-15/Makefile
+++ b/gcovr/tests/html-encoding-iso-8859-15/Makefile
@@ -1,7 +1,7 @@
 all:
 	$(CXX) -fprofile-arcs -ftest-coverage -fPIC main.cpp -o testcase
 
-run: txt xml html sonarqube json
+run: txt xml html sonarqube json json_summary
 
 txt:
 	# pass
@@ -17,6 +17,9 @@ sonarqube:
 	# pass
 
 json:
+	# pass
+
+json_summary:
 	# pass
 
 clean:

--- a/gcovr/tests/html-high-75/Makefile
+++ b/gcovr/tests/html-high-75/Makefile
@@ -1,7 +1,7 @@
 all:
 	$(CXX) -fprofile-arcs -ftest-coverage -fPIC main.cpp -o testcase
 
-run: txt xml html sonarqube json
+run: txt xml html sonarqube json json_summary
 
 txt:
 	# pass
@@ -17,6 +17,9 @@ sonarqube:
 	# pass
 
 json:
+	# pass
+
+json_summary:
 	# pass
 
 clean:

--- a/gcovr/tests/html-medium-50/Makefile
+++ b/gcovr/tests/html-medium-50/Makefile
@@ -1,7 +1,7 @@
 all:
 	$(CXX) -fprofile-arcs -ftest-coverage -fPIC main.cpp -o testcase
 
-run: txt xml html sonarqube json
+run: txt xml html sonarqube json json_summary
 
 txt:
 	# pass
@@ -17,6 +17,9 @@ sonarqube:
 	# pass
 
 json:
+	# pass
+
+json_summary:
 	# pass
 
 clean:

--- a/gcovr/tests/html-title-empty/Makefile
+++ b/gcovr/tests/html-title-empty/Makefile
@@ -1,7 +1,7 @@
 all:
 	$(CXX) -fprofile-arcs -ftest-coverage -fPIC main.cpp -o testcase
 
-run: txt xml html sonarqube json
+run: txt xml html sonarqube json json_summary
 
 txt:
 	# pass
@@ -17,6 +17,9 @@ sonarqube:
 	# pass
 
 json:
+	# pass
+
+json_summary:
 	# pass
 
 clean:

--- a/gcovr/tests/html-title/Makefile
+++ b/gcovr/tests/html-title/Makefile
@@ -1,7 +1,7 @@
 all:
 	$(CXX) -fprofile-arcs -ftest-coverage -fPIC main.cpp -o testcase
 
-run: txt xml html sonarqube json
+run: txt xml html sonarqube json json_summary
 
 txt:
 	# pass
@@ -17,6 +17,9 @@ sonarqube:
 	# pass
 
 json:
+	# pass
+
+json_summary:
 	# pass
 
 clean:

--- a/gcovr/tests/linked/Makefile
+++ b/gcovr/tests/linked/Makefile
@@ -11,7 +11,7 @@ all: links
 	$(CXX) $(CFLAGS) -c subdir/B/main.cpp -o subdir/B/main.o
 	$(CXX) $(CFLAGS) subdir/A/file1.o subdir/A/file2.o subdir/A/file3.o subdir/A/file4.o subdir/A/C/file5.o subdir/m/n/C/D/file6.o subdir/A/file7.o subdir/B/main.o -o subdir/testcase
 
-run: txt xml html sonarqube json
+run: txt xml html sonarqube json json_summary
 
 txt:
 	./subdir/testcase
@@ -30,6 +30,9 @@ sonarqube:
 	$(GCOVR) -d --sonarqube sonarqube.xml
 
 json:
+	# pass
+
+json_summary:
 	# pass
 
 clean:

--- a/gcovr/tests/nested/Makefile
+++ b/gcovr/tests/nested/Makefile
@@ -11,7 +11,7 @@ all:
 	$(CXX) $(CFLAGS) -c subdir/B/main.cpp -o subdir/B/main.o
 	$(CXX) $(CFLAGS) subdir/A/file1.o subdir/A/file2.o subdir/A/file3.o subdir/A/file4.o subdir/A/C/file5.o subdir/A/C/D/file6.o subdir/A/file7.o subdir/B/main.o -o subdir/testcase
 
-run: txt xml html sonarqube json
+run: txt xml html sonarqube json json_summary
 
 txt:
 	./subdir/testcase
@@ -30,6 +30,9 @@ sonarqube:
 	$(GCOVR) -r subdir -d --sonarqube sonarqube.xml
 
 json:
+	# pass
+
+json_summary:
 	# pass
 
 clean:

--- a/gcovr/tests/nested2-use-existing/Makefile
+++ b/gcovr/tests/nested2-use-existing/Makefile
@@ -8,7 +8,7 @@ all:
 	$(CXX) $(CFLAGS) -c subdir/B/main.cpp -o subdir/B/main.o
 	$(CXX) $(CFLAGS) subdir/B/main.o subdir/A/file1.o subdir/A/file2.o subdir/A/file3.o subdir/A/file4.o subdir/A/C/file5.o subdir/A/C/D/file6.o subdir/A/file7.o  -o subdir/B/testcase -lgcov
 
-run: txt xml html sonarqube json
+run: txt xml html sonarqube json json_summary
 
 txt:
 	./subdir/B/testcase
@@ -37,6 +37,9 @@ sonarqube:
 	$(GCOVR) -r subdir -g -k --sonarqube sonarqube.xml .
 
 json:
+	# pass
+
+json_summary:
 	# pass
 
 clean:

--- a/gcovr/tests/nested2/Makefile
+++ b/gcovr/tests/nested2/Makefile
@@ -5,7 +5,7 @@ all:
 	$(CXX) $(CFLAGS) -c subdir/B/main.cpp -o subdir/B/main.o
 	$(CXX) $(CFLAGS) subdir/B/main.o subdir/A/file1.o subdir/A/file2.o subdir/A/file3.o subdir/A/file4.o subdir/A/C/file5.o subdir/A/C/D/file6.o subdir/A/file7.o  -o subdir/B/testcase -lgcov
 
-run: txt xml html sonarqube json
+run: txt xml html sonarqube json json_summary
 
 txt:
 	./subdir/B/testcase
@@ -24,6 +24,9 @@ sonarqube:
 	$(GCOVR) -r subdir -d --sonarqube sonarqube.xml
 
 json:
+	# pass
+
+json_summary:
 	# pass
 
 clean:

--- a/gcovr/tests/nested3/Makefile
+++ b/gcovr/tests/nested3/Makefile
@@ -13,7 +13,7 @@ all:
 	cd subdir; $(CXX) $(CFLAGS) -c B/main.cpp -o ../objs/main.o
 	cd subdir; $(CXX) $(CFLAGS) ../objs/file1.o ../objs/file2.o ../objs/file3.o ../objs/file4.o ../objs/file5.o ../objs/file6.o ../objs/file7.o ../objs/main.o -o ./testcase
 
-run: txt xml html sonarqube json
+run: txt xml html sonarqube json json_summary
 
 txt:
 	./subdir/testcase
@@ -32,6 +32,9 @@ sonarqube:
 	$(GCOVR) -r subdir --object-directory objs -d --sonarqube sonarqube.xml
 
 json:
+	# pass
+
+json_summary:
 	# pass
 
 clean:

--- a/gcovr/tests/nobranch/Makefile
+++ b/gcovr/tests/nobranch/Makefile
@@ -1,7 +1,7 @@
 all:
 	$(CXX) -fprofile-arcs -ftest-coverage -fPIC main.cpp -o testcase
 
-run: txt xml html sonarqube json
+run: txt xml html sonarqube json json_summary
 
 txt:
 	./testcase
@@ -20,6 +20,9 @@ sonarqube:
 	$(GCOVR) -d --fail-under-branch 100.0 --sonarqube sonarqube.xml
 
 json:
+	# pass
+
+json_summary:
 	# pass
 
 clean:

--- a/gcovr/tests/oos/Makefile
+++ b/gcovr/tests/oos/Makefile
@@ -6,7 +6,7 @@ all:
 	$(CXX) $(CFLAGS) -c src/main.cpp -o build/main.o
 	$(CXX) $(CFLAGS) build/main.o build/file1.o -o build/testcase
 
-run: txt xml html sonarqube json
+run: txt xml html sonarqube json json_summary
 
 GCOVR_TEST_OPTIONS =
 
@@ -29,6 +29,10 @@ sonarqube:
 json:
 	# pass
 
+json_summary:
+	build/testcase
+	$(GCOVR) $(GCOVR_TEST_OPTIONS) -d --json-summary -o summary_coverage.json
+
 clean:
 	rm -f build/*
-	rm -f coverage.txt coverage.xml coverage*.html sonarqube.xml
+	rm -f coverage.txt coverage.xml coverage*.html sonarqube.xml summary_coverage.json

--- a/gcovr/tests/oos2/Makefile
+++ b/gcovr/tests/oos2/Makefile
@@ -6,7 +6,7 @@ all:
 	cd build; $(CXX) $(CFLAGS) -c ../src/main.cpp  -o main.o
 	cd build; $(CXX) $(CFLAGS) main.o file1.o -o testcase
 
-run: txt xml html sonarqube json
+run: txt xml html sonarqube json json_summary
 
 GCOVR_TEST_OPTIONS = -r ../src .
 
@@ -27,6 +27,9 @@ sonarqube:
 	cd build; $(GCOVR) $(GCOVR_TEST_OPTIONS) -d --sonarqube ../sonarqube.xml
 
 json:
+	# pass
+
+json_summary:
 	# pass
 
 clean:

--- a/gcovr/tests/print-summary/Makefile
+++ b/gcovr/tests/print-summary/Makefile
@@ -19,6 +19,8 @@ sonarqube:
 
 json:
 
+json_summary:
+
 clean:
 	rm -f testcase
 	rm -f *.gc*

--- a/gcovr/tests/shared_lib/Makefile
+++ b/gcovr/tests/shared_lib/Makefile
@@ -36,7 +36,7 @@ all:
 	$(CXX) $(CFLAGS) $(SOFLAGS) obj/libs.o -o lib/libs.$(DYNLIB_EXT)
 	$(MAKE) -C testApp
 
-run: txt xml html sonarqube json
+run: txt xml html sonarqube json json_summary
 
 txt:
 ifeq ($(BASE_OS),MSYS_NT)
@@ -71,6 +71,9 @@ endif
 	$(GCOVR) -d --sonarqube sonarqube.xml
 
 json:
+	# pass
+
+json_summary:
 	# pass
 
 clean:

--- a/gcovr/tests/simple1-stdout/Makefile
+++ b/gcovr/tests/simple1-stdout/Makefile
@@ -1,7 +1,7 @@
 all:
 	$(CXX) -fprofile-arcs -ftest-coverage -fPIC main.cpp -o testcase
 
-run: txt xml html sonarqube json
+run: txt xml html sonarqube json json_summary
 
 txt:
 	./testcase
@@ -21,7 +21,11 @@ sonarqube:
 json:
 	# pass
 
+json_summary:
+	./testcase
+	$(GCOVR) -d --json-summary --json-pretty > summary_coverage.json
+
 clean:
 	rm -f testcase
 	rm -f *.gc*
-	rm -f coverage.txt coverage.xml coverage*.html
+	rm -f coverage.txt coverage.xml coverage*.html summary_coverage.json

--- a/gcovr/tests/simple1-stdout/reference/summary_coverage.json
+++ b/gcovr/tests/simple1-stdout/reference/summary_coverage.json
@@ -1,0 +1,15 @@
+{
+    "covered": 8,
+    "current_working_directory": ".",
+    "files": [
+        {
+            "covered": 8,
+            "file": "main.cpp",
+            "percent": 80.0,
+            "total": 10
+        }
+    ],
+    "gcovr/format_version": 0.1,
+    "percent": 80.0,
+    "total": 10
+}

--- a/gcovr/tests/simple1/Makefile
+++ b/gcovr/tests/simple1/Makefile
@@ -1,7 +1,7 @@
 all:
 	$(CXX) -fprofile-arcs -ftest-coverage -fPIC main.cpp -o testcase
 
-run: txt xml html sonarqube json
+run: txt xml html sonarqube json json_summary
 
 txt:
 	./testcase
@@ -23,10 +23,15 @@ sonarqube:
 	./testcase
 	$(GCOVR) -d --sonarqube sonarqube.xml
 
+
+json_summary:
+	./testcase
+	$(GCOVR) -d --json-summary --json-pretty -o summary_coverage.json
+
 json:
 	# pass
 
 clean:
 	rm -f testcase
 	rm -f *.gc*
-	rm -f coverage.txt coverage.xml coverage*.html sonarqube.xml
+	rm -f coverage.txt coverage.xml coverage*.html sonarqube.xml summary_coverage.json

--- a/gcovr/tests/simple1/reference/summary_coverage.json
+++ b/gcovr/tests/simple1/reference/summary_coverage.json
@@ -1,0 +1,15 @@
+{
+    "covered": 8,
+    "current_working_directory": ".",
+    "files": [
+        {
+            "covered": 8,
+            "file": "main.cpp",
+            "percent": 80.0,
+            "total": 10
+        }
+    ],
+    "gcovr/format_version": 0.1,
+    "percent": 80.0,
+    "total": 10
+}

--- a/gcovr/tests/sort-percentage/Makefile
+++ b/gcovr/tests/sort-percentage/Makefile
@@ -8,7 +8,7 @@ all:
 	$(CXX) $(CFLAGS) -c main.cpp -o main.o
 	$(CXX) $(CFLAGS) main.o file1.o file2.o file3.o file4.o -o testcase
 
-run: txt xml html sonarqube json
+run: txt xml html sonarqube json json_summary
 
 GCOVR_TEST_OPTIONS = --sort-percentage
 
@@ -26,6 +26,9 @@ sonarqube:
 	# pass
 
 json:
+	# pass
+
+json_summary:
 	# pass
 
 clean:

--- a/gcovr/tests/sort-uncovered/Makefile
+++ b/gcovr/tests/sort-uncovered/Makefile
@@ -8,7 +8,7 @@ all:
 	$(CXX) $(CFLAGS) -c main.cpp -o main.o
 	$(CXX) $(CFLAGS) main.o file1.o file2.o file3.o file4.o -o testcase
 
-run: txt xml html sonarqube json
+run: txt xml html sonarqube json json_summary
 
 GCOVR_TEST_OPTIONS = --sort-uncovered
 
@@ -26,6 +26,9 @@ sonarqube:
 	# pass
 
 json:
+	# pass
+
+json_summary:
 	# pass
 
 clean:

--- a/gcovr/tests/source-encoding-cp1252/Makefile
+++ b/gcovr/tests/source-encoding-cp1252/Makefile
@@ -1,7 +1,7 @@
 all:
 	$(CXX) -fprofile-arcs -ftest-coverage -fPIC --encoding cp1252 main.cpp -o testcase
 
-run: txt xml html sonarqube json
+run: txt xml html sonarqube json json_summary
 
 txt:
 	# pass
@@ -17,6 +17,9 @@ sonarqube:
 	# pass
 
 json:
+	# pass
+
+json_summary:
 	# pass
 
 clean:

--- a/gcovr/tests/source-encoding-utf8/Makefile
+++ b/gcovr/tests/source-encoding-utf8/Makefile
@@ -1,7 +1,7 @@
 all:
 	$(CXX) -fprofile-arcs -ftest-coverage -fPIC main.cpp -o testcase
 
-run: txt xml html sonarqube json
+run: txt xml html sonarqube json json_summary
 
 txt:
 	# pass
@@ -18,6 +18,10 @@ sonarqube:
 
 json:
 	# pass
+
+json_summary:
+	# pass
+
 
 clean:
 	rm -f testcase

--- a/gcovr/tests/test_gcovr.py
+++ b/gcovr/tests/test_gcovr.py
@@ -87,14 +87,17 @@ SCRUBBERS = dict(
     xml=scrub_xml,
     html=scrub_html,
     sonarqube=scrub_xml,
-    json=lambda x: x)
+    json=lambda x: x,
+    json_summary=lambda x: x)
 
 OUTPUT_PATTERN = dict(
     txt='coverage.txt',
     xml='coverage.xml',
     html='coverage*.html',
     sonarqube='sonarqube.xml',
-    json='coverage*.json')
+    json='coverage*.json',
+    json_summary='summary_coverage.json'
+)
 
 ASSERT_EQUALS = dict(
     xml=assert_xml_equals,
@@ -102,7 +105,8 @@ ASSERT_EQUALS = dict(
 
 
 @pytest.mark.parametrize('name', findtests(basedir))
-@pytest.mark.parametrize('format', ['txt', 'xml', 'html', 'sonarqube', 'json'])
+@pytest.mark.parametrize('format', ['txt', 'xml', 'html', 'sonarqube', 'json',
+                                    'json_summary'])
 def test_build(name, format):
     scrub = SCRUBBERS[format]
     output_pattern = OUTPUT_PATTERN[format]

--- a/gcovr/tests/threaded/Makefile
+++ b/gcovr/tests/threaded/Makefile
@@ -11,7 +11,7 @@ all:
 	$(CXX) $(CFLAGS) -c subdir/B/main.cpp -o subdir/B/main.o
 	$(CXX) $(CFLAGS) subdir/A/file1.o subdir/A/file2.o subdir/A/file3.o subdir/A/file4.o subdir/A/C/file5.o subdir/A/C/D/file6.o subdir/A/file7.o subdir/B/main.o -o subdir/testcase
 
-run: txt xml html sonarqube json
+run: txt xml html sonarqube json json_summary
 
 txt:
 	./subdir/testcase
@@ -30,6 +30,9 @@ sonarqube:
 	$(GCOVR) -j 4 -r subdir -d --sonarqube sonarqube.xml
 
 json:
+	# pass
+
+json_summary:
 	# pass
 
 clean:

--- a/gcovr/tests/update-data/Makefile
+++ b/gcovr/tests/update-data/Makefile
@@ -3,7 +3,7 @@ all:
 	$(CC) -fprofile-arcs -ftest-coverage -fPIC -c update-data.c -o update-data.o
 	$(CXX) -fprofile-arcs -ftest-coverage -fPIC -o testcase main.o update-data.o
 
-run: txt xml html sonarqube json
+run: txt xml html sonarqube json json_summary
 
 txt:
 	./testcase
@@ -22,6 +22,9 @@ sonarqube:
 	$(GCOVR) -d --sonarqube sonarqube.xml
 
 json:
+	# pass
+
+json_summary:
 	# pass
 
 clean:

--- a/gcovr/tests/use-existing/Makefile
+++ b/gcovr/tests/use-existing/Makefile
@@ -3,7 +3,7 @@ GCOV ?= gcov
 all:
 	$(CXX) -fprofile-arcs -ftest-coverage -fPIC main.cpp -o testcase
 
-run: txt xml html sonarqube json
+run: txt xml html sonarqube json json_summary
 
 txt:
 	./testcase
@@ -26,6 +26,9 @@ sonarqube:
 	$(GCOVR) -v -g -d --sonarqube sonarqube.xml
 
 json:
+	# pass
+
+json_summary:
 	# pass
 
 clean:

--- a/gcovr/tests/wspace/Makefile
+++ b/gcovr/tests/wspace/Makefile
@@ -1,7 +1,7 @@
 all:
 	cd 'src code'; $(CXX) -fprofile-arcs -ftest-coverage -fPIC main.cpp -o testcase
 
-run: txt xml html sonarqube json
+run: txt xml html sonarqube json json_summary
 
 txt:
 	cd 'src code'; ./testcase
@@ -14,6 +14,9 @@ xml html sonarqube:
 		--html-details coverage.html --sonarqube sonarqube.xml
 
 json:
+	# pass
+
+json_summary:
 	# pass
 
 clean:


### PR DESCRIPTION
JSON output allows pushing basic coverage data for processing using
other downstream tools or storing in DB. Currently text report has
special formatting for filenames, and XML output does not some key
information (total covered / total lines) to be useful for additional
processing.

If there is interest in this kind of reporting, I will update tests and documentation.