### PR TITLE
Add path context to filter options in config files

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -38,6 +38,7 @@ The following developers contributed to gcovr (ordered alphabetically):
     Mikk Leini,
     Nikolaj Schumacher,
     Piotr Dziwinski,
+    Richard Kjerstadius,
     Reto Schneider,
     Robert Rosengren,
     Songmin Li,

--- a/doc/source/guide.rst
+++ b/doc/source/guide.rst
@@ -415,6 +415,9 @@ For example, :option:`--filter` can be provided multiple times::
     filter = lib/foo/
     filter = *./main\.cpp
 
+Note that relative filters specified in config files will be interpreted
+relative to the location of the config file itself.
+
 Option arguments are parsed with the following precedence:
 
 -   First the config file is parsed, if any.

--- a/gcovr/__main__.py
+++ b/gcovr/__main__.py
@@ -44,7 +44,7 @@ from .configuration import (
     parse_config_file, parse_config_into_dict)
 from .gcov import (find_existing_gcov_files, find_datafiles,
                    process_existing_gcov_file, process_datafile)
-from .utils import (get_global_stats, build_filter, AlwaysMatchFilter,
+from .utils import (get_global_stats, AlwaysMatchFilter,
                     DirectoryPrefixFilter, Logger)
 from .version import __version__
 from .workers import Workers
@@ -212,17 +212,16 @@ def main(args=None):
 
     if options.exclude_dirs is not None:
         options.exclude_dirs = [
-            build_filter(logger, f) for f in options.exclude_dirs]
+            f.build_filter(logger) for f in options.exclude_dirs]
 
-    options.exclude = [build_filter(logger, f) for f in options.exclude]
-    options.filter = [build_filter(logger, f) for f in options.filter]
+    options.exclude = [f.build_filter(logger) for f in options.exclude]
+    options.filter = [f.build_filter(logger) for f in options.filter]
     if not options.filter:
         options.filter = [DirectoryPrefixFilter(options.root_dir)]
 
     options.gcov_exclude = [
-        build_filter(logger, f) for f in options.gcov_exclude]
-    options.gcov_filter = [
-        build_filter(logger, f) for f in options.gcov_filter]
+        f.build_filter(logger) for f in options.gcov_exclude]
+    options.gcov_filter = [f.build_filter(logger) for f in options.gcov_filter]
     if not options.gcov_filter:
         options.gcov_filter = [AlwaysMatchFilter()]
 

--- a/gcovr/configuration.py
+++ b/gcovr/configuration.py
@@ -16,6 +16,8 @@ import os
 import re
 import sys
 
+from .utils import FilterOption
+
 try:
     from typing import Iterable, Any
 except ImportError:
@@ -290,7 +292,11 @@ def _get_value_from_config_entry(cfg_entry, option):
         value = cfg_entry.value_as_bool
     elif option.type is not None:
         try:
-            value = option.type(cfg_entry.value)
+            if option.type is FilterOption:
+                value = option.type(cfg_entry.value,
+                                    os.path.dirname(cfg_entry.filename))
+            else:
+                value = option.type(cfg_entry.value)
         except (ValueError, ArgumentTypeError) as err:
             raise cfg_entry.error(str(err))
     else:
@@ -549,6 +555,7 @@ GCOVR_CONFIG_OPTIONS = [
              "Can be specified multiple times. "
              "If no filters are provided, defaults to --root.",
         action="append",
+        type=FilterOption,
         default=[],
     ),
     GcovrConfigOption(
@@ -557,7 +564,7 @@ GCOVR_CONFIG_OPTIONS = [
         help="Exclude source files that match this filter. "
              "Can be specified multiple times.",
         action="append",
-        type=check_non_empty,
+        type=FilterOption,
         default=[],
     ),
     GcovrConfigOption(
@@ -566,6 +573,7 @@ GCOVR_CONFIG_OPTIONS = [
         help="Keep only gcov data files that match this filter. "
              "Can be specified multiple times.",
         action="append",
+        type=FilterOption,
         default=[],
     ),
     GcovrConfigOption(
@@ -574,6 +582,7 @@ GCOVR_CONFIG_OPTIONS = [
         help="Exclude gcov data files that match this filter. "
              "Can be specified multiple times.",
         action="append",
+        type=FilterOption,
         default=[],
     ),
     GcovrConfigOption(
@@ -583,7 +592,7 @@ GCOVR_CONFIG_OPTIONS = [
              "while searching raw coverage files. "
              "Can be specified multiple times.",
         action="append",
-        type=check_non_empty,
+        type=FilterOption,
         default=[],
     ),
     GcovrConfigOption(

--- a/gcovr/configuration.py
+++ b/gcovr/configuration.py
@@ -44,12 +44,6 @@ def check_percentage(value):
     return x
 
 
-def check_non_empty(value):
-    if not value:
-        raise ArgumentTypeError("value should not be empty")
-    return value
-
-
 class GcovrConfigOption(object):
     r"""
     Represents a single setting for a gcovr runtime parameter.

--- a/gcovr/tests/test_args.py
+++ b/gcovr/tests/test_args.py
@@ -52,14 +52,14 @@ def test_empty_root(capsys):
 def test_empty_exclude(capsys):
     c = capture(capsys, ['--exclude', ''])
     assert c.out == ''
-    assert 'value should not be empty' in c.err
+    assert 'filter cannot be empty' in c.err
     assert c.exception.code != 0
 
 
 def test_empty_exclude_directories(capsys):
     c = capture(capsys, ['--exclude-directories', ''])
     assert c.out == ''
-    assert 'value should not be empty' in c.err
+    assert 'filter cannot be empty' in c.err
     assert c.exception.code != 0
 
 
@@ -103,7 +103,7 @@ def test_line_threshold_100_1(capsys):
 def test_filter_backslashes_are_detected(capsys):
     c = capture(
         capsys,
-        args=['--filter', r'C:\\foo\moo', '--gcov-exclude', ''],
+        args=['--filter', r'C:\\foo\moo'],
         other_ex=re.error)
     assert c.err.startswith(
         '(WARNING) filters must use forward slashes as path separators\n'


### PR DESCRIPTION
Addresses #300. From the "main" commit message:

> By using a dedicated type for filter options it's possible include the
> path context for a filter. This enables (relative) filters in config
> files to be treated as relative to the location of the config file,
> rather than relative to the current working directory.

Handling and behavior of CLI arguments is the same as before. Do note that the `check_non_empty()` function ended up being unused, so I removed it (in a separate commit though, so easy to roll back).