### PR TITLE
Address Memory usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@ script:
 - test -z "$RUN_LINTER" || flake8 --ignore=E501,W503
 - test -z "$RUN_LINTER" || admin/release_checklist --no-verify-tags 4.1
 - python -m pytest -v --doctest-modules $COVERAGE_OPTS gcovr doc/examples
+- pip install lxml
+- python -m pytest -v --doctest-modules $COVERAGE_OPTS gcovr doc/examples
 - test -z "$COVERAGE_OPTS" || codecov -X gcov search
 - test -z "$BUILD_DOCS" || (cd doc; make html O=-W)
 

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -17,6 +17,7 @@ The following developers contributed to gcovr (ordered alphabetically):
     goriy,
     ja11sop,
     James Reynolds,
+    Jeremy Fixemer,
     Jessica Levine,
     Joel Klinghed,
     John Siirola,

--- a/gcovr/cobertura_xml_generator.py
+++ b/gcovr/cobertura_xml_generator.py
@@ -217,11 +217,12 @@ def print_xml_report(covdata, options):
 
     with smart_open(options.output) as fh:
         if LXML_AVAILABLE:
-            fh.write(
+            print(
                 etree.tostring(root,
                                pretty_print=options.prettyxml,
                                encoding="UTF-8",
                                xml_declaration=True,
-                               doctype="<!DOCTYPE coverage SYSTEM 'http://cobertura.sourceforge.net/xml/coverage-04.dtd'>"))
+                               doctype="<!DOCTYPE coverage SYSTEM 'http://cobertura.sourceforge.net/xml/coverage-04.dtd'>"),
+                file=fh)
         else:
-            fh.write(etree.tostring(root, encoding="UTF-8"))
+            print(etree.tostring(root, encoding="UTF-8"), file=fh)

--- a/gcovr/cobertura_xml_generator.py
+++ b/gcovr/cobertura_xml_generator.py
@@ -31,11 +31,11 @@ def smart_open(filename=None):
     if filename and filename != '-':
         # files in write binary mode for UTF-8
         fh = open(filename, 'wb')
-    elif (sys.version_info > (3,0)):
-        #python 3 wants stdout.buffer for binary output
+    elif (sys.version_info > (3, 0)):
+        # python 3 wants stdout.buffer for binary output
         fh = sys.stdout.buffer
     else:
-        #python2 doesn't care as much, no stdout.buffer
+        # python2 doesn't care as much, no stdout.buffer
         fh = sys.stdout
 
     try:

--- a/gcovr/cobertura_xml_generator.py
+++ b/gcovr/cobertura_xml_generator.py
@@ -9,7 +9,12 @@
 import os
 import sys
 import time
-import xml.dom.minidom
+from contextlib import contextmanager
+
+try:
+    from lxml import etree as ET
+except ImportError:
+    import xml.etree.ElementTree as ET
 
 from .version import __version__
 
@@ -19,6 +24,18 @@ except NameError:
     xrange = range
 
 
+@contextmanager
+def smart_open(filename=None):
+    if filename and filename != '-':
+        fh = open(filename, 'w')
+    else:
+        fh = sys.stdout
+
+    try:
+        yield fh
+    finally:
+        if fh is not sys.stdout:
+            fh.close()
 #
 # Produce an XML report in the Cobertura format
 #
@@ -29,60 +46,63 @@ def print_xml_report(covdata, options):
     lineCovered = 0
 
     for key in covdata.keys():
-        (total, covered, percent) = covdata[key].branch_coverage()
+        (total, covered, _) = covdata[key].branch_coverage()
         branchTotal += total
         branchCovered += covered
 
     for key in covdata.keys():
-        (total, covered, percent) = covdata[key].line_coverage()
+        (total, covered, _) = covdata[key].line_coverage()
         lineTotal += total
         lineCovered += covered
 
-    impl = xml.dom.minidom.getDOMImplementation()
-    docType = impl.createDocumentType(
-        "coverage", None,
-        "http://cobertura.sourceforge.net/xml/coverage-04.dtd"
-    )
-    doc = impl.createDocument(None, "coverage", docType)
-    root = doc.documentElement
-    root.setAttribute(
+    #impl = xml.dom.minidom.getDOMImplementation()
+    #docType = impl.createDocumentType(
+    #    "coverage", None,
+    #    "http://cobertura.sourceforge.net/xml/coverage-04.dtd"
+    #)
+    #doc = impl.createDocument(None, "coverage", docType)
+    #root = doc.documentElement
+    root = ET.Element("coverage")
+    root.set(
         "line-rate", lineTotal == 0 and '0.0'
         or str(float(lineCovered) / lineTotal)
     )
-    root.setAttribute(
+    root.set(
         "branch-rate", branchTotal == 0 and '0.0'
         or str(float(branchCovered) / branchTotal)
     )
-    root.setAttribute(
+    root.set(
         "lines-covered", str(lineCovered)
     )
-    root.setAttribute(
+    root.set(
         "lines-valid", str(lineTotal)
     )
-    root.setAttribute(
+    root.set(
         "branches-covered", str(branchCovered)
     )
-    root.setAttribute(
+    root.set(
         "branches-valid", str(branchTotal)
     )
-    root.setAttribute(
+    root.set(
         "complexity", "0.0"
     )
-    root.setAttribute(
+    root.set(
         "timestamp", str(int(time.time()))
     )
-    root.setAttribute(
+    root.set(
         "version", "gcovr %s" % (__version__,)
     )
 
     # Generate the <sources> element: this is either the root directory
     # (specified by --root), or the CWD.
-    sources = doc.createElement("sources")
-    root.appendChild(sources)
+    #sources = doc.createElement("sources")
+    #root.appendChild(sources)
+    sources = ET.SubElement(root, "sources")
 
     # Generate the coverage output (on a per-package basis)
-    packageXml = doc.createElement("packages")
-    root.appendChild(packageXml)
+    #packageXml = doc.createElement("packages")
+    #root.appendChild(packageXml)
+    packageXml = ET.SubElement(root, "packages")
     packages = {}
     source_dirs = set()
 
@@ -103,14 +123,13 @@ def print_xml_report(covdata, options):
         directory, fname = os.path.split(directory)
 
         package = packages.setdefault(
-            directory, [doc.createElement("package"), {}, 0, 0, 0, 0]
+            directory, [ET.Element("package"), {}, 0, 0, 0, 0]
         )
-        c = doc.createElement("class")
+        c = ET.Element("class")
         # The Cobertura DTD requires a methods section, which isn't
         # trivial to get from gcov (so we will leave it blank)
-        c.appendChild(doc.createElement("methods"))
-        lines = doc.createElement("lines")
-        c.appendChild(lines)
+        ET.SubElement(c, "methods")
+        lines = ET.SubElement(c, "lines")
 
         class_lines = 0
         class_hits = 0
@@ -125,43 +144,43 @@ def print_xml_report(covdata, options):
             if line_cov.is_covered:
                 class_hits += 1
             hits = line_cov.count
-            L = doc.createElement("line")
-            L.setAttribute("number", str(lineno))
-            L.setAttribute("hits", str(hits))
+            L = ET.Element("line")
+            L.set("number", str(lineno))
+            L.set("hits", str(hits))
             branches = line_cov.branches
             if not branches:
-                L.setAttribute("branch", "false")
+                L.set("branch", "false")
             else:
                 b_total, b_hits, coverage = line_cov.branch_coverage()
-                L.setAttribute("branch", "true")
-                L.setAttribute(
+                L.set("branch", "true")
+                L.set(
                     "condition-coverage",
                     "{}% ({}/{})".format(int(coverage), b_hits, b_total)
                 )
-                cond = doc.createElement('condition')
-                cond.setAttribute("number", "0")
-                cond.setAttribute("type", "jump")
-                cond.setAttribute("coverage", "{}%".format(int(coverage)))
+                cond = ET.Element('condition')
+                cond.set("number", "0")
+                cond.set("type", "jump")
+                cond.set("coverage", "{}%".format(int(coverage)))
                 class_branch_hits += b_hits
                 class_branches += float(len(branches))
-                conditions = doc.createElement("conditions")
-                conditions.appendChild(cond)
-                L.appendChild(conditions)
+                conditions = ET.Element("conditions")
+                conditions.append(cond)
+                L.append(conditions)
 
-            lines.appendChild(L)
+            lines.append(L)
 
         className = fname.replace('.', '_')
-        c.setAttribute("name", className)
-        c.setAttribute("filename", os.path.join(directory, fname).replace('\\', '/'))
-        c.setAttribute(
+        c.set("name", className)
+        c.set("filename", os.path.join(directory, fname).replace('\\', '/'))
+        c.set(
             "line-rate",
             str(class_hits / (1.0 * class_lines or 1.0))
         )
-        c.setAttribute(
+        c.set(
             "branch-rate",
             str(class_branch_hits / (1.0 * class_branches or 1.0))
         )
-        c.setAttribute("complexity", "0.0")
+        c.set("complexity", "0.0")
 
         package[1][className] = c
         package[2] += class_hits
@@ -174,47 +193,28 @@ def print_xml_report(covdata, options):
     for packageName in keys:
         packageData = packages[packageName]
         package = packageData[0]
-        packageXml.appendChild(package)
-        classes = doc.createElement("classes")
-        package.appendChild(classes)
+        packageXml.append(package)
+        classes = ET.SubElement(classes, "classes")
         classNames = list(packageData[1].keys())
         classNames.sort()
         for className in classNames:
-            classes.appendChild(packageData[1][className])
-        package.setAttribute("name", packageName.replace(os.sep, '.'))
-        package.setAttribute(
+            classes.append(packageData[1][className])
+        package.set("name", packageName.replace(os.sep, '.'))
+        package.set(
             "line-rate", str(packageData[2] / (1.0 * packageData[3] or 1.0))
         )
-        package.setAttribute(
+        package.set(
             "branch-rate", str(packageData[4] / (1.0 * packageData[5] or 1.0))
         )
-        package.setAttribute("complexity", "0.0")
+        package.set("complexity", "0.0")
 
     # Populate the <sources> element: this is the root directory
-    source = doc.createElement("source")
-    source.appendChild(doc.createTextNode(options.root.strip()))
-    sources.appendChild(source)
+    ET.SubElement(sources, "source").text = options.root.strip()
 
-    if options.prettyxml:
-        import textwrap
-        lines = doc.toprettyxml(" ").split('\n')
-        for i in xrange(len(lines)):
-            n = 0
-            while n < len(lines[i]) and lines[i][n] == " ":
-                n += 1
-            lines[i] = "\n".join(textwrap.wrap(
-                lines[i], 78,
-                break_long_words=False,
-                break_on_hyphens=False,
-                subsequent_indent=" " + n * " "
-            ))
-        xmlString = "\n".join(lines)
-        # print textwrap.wrap(doc.toprettyxml(" "), 80)
-    else:
-        xmlString = doc.toprettyxml(indent="")
-    if options.output is None:
-        sys.stdout.write(xmlString + '\n')
-    else:
-        OUTPUT = open(options.output, 'w')
-        OUTPUT.write(xmlString + '\n')
-        OUTPUT.close()
+
+    with smart_open(options.output) as fh:
+        ET.write(fh,
+            pretty_print=options.prettyxml,
+            encoding="UTF-8",
+            xml_declaration=True,
+            doctype="<!DOCTYPE coverage SYSTEM 'http://cobertura.sourceforge.net/xml/coverage-03.dtd'>")

--- a/gcovr/cobertura_xml_generator.py
+++ b/gcovr/cobertura_xml_generator.py
@@ -41,6 +41,8 @@ def smart_open(filename=None):
 #
 # Produce an XML report in the Cobertura format
 #
+
+
 def print_xml_report(covdata, options):
     branchTotal = 0
     branchCovered = 0
@@ -57,13 +59,13 @@ def print_xml_report(covdata, options):
         lineTotal += total
         lineCovered += covered
 
-    #impl = xml.dom.minidom.getDOMImplementation()
-    #docType = impl.createDocumentType(
-    #    "coverage", None,
-    #    "http://cobertura.sourceforge.net/xml/coverage-04.dtd"
-    #)
-    #doc = impl.createDocument(None, "coverage", docType)
-    #root = doc.documentElement
+    # impl = xml.dom.minidom.getDOMImplementation()
+    # docType = impl.createDocumentType(
+    #     "coverage", None,
+    #     "http://cobertura.sourceforge.net/xml/coverage-04.dtd"
+    # )
+    # doc = impl.createDocument(None, "coverage", docType)
+    # root = doc.documentElement
     root = etree.Element("coverage")
     root.set(
         "line-rate", lineTotal == 0 and '0.0'
@@ -97,13 +99,13 @@ def print_xml_report(covdata, options):
 
     # Generate the <sources> element: this is either the root directory
     # (specified by --root), or the CWD.
-    #sources = doc.createElement("sources")
-    #root.appendChild(sources)
+    # sources = doc.createElement("sources")
+    # root.appendChild(sources)
     sources = etree.SubElement(root, "sources")
 
     # Generate the coverage output (on a per-package basis)
-    #packageXml = doc.createElement("packages")
-    #root.appendChild(packageXml)
+    # packageXml = doc.createElement("packages")
+    # root.appendChild(packageXml)
     packageXml = etree.SubElement(root, "packages")
     packages = {}
     source_dirs = set()
@@ -213,14 +215,13 @@ def print_xml_report(covdata, options):
     # Populate the <sources> element: this is the root directory
     etree.SubElement(sources, "source").text = options.root.strip()
 
-
     with smart_open(options.output) as fh:
-        if LXML_AVAILABLE :
-            print >>fh, etree.tostring(root,
-                pretty_print=options.prettyxml,
-                encoding="UTF-8",
-                xml_declaration=True,
-                doctype="<!DOCTYPE coverage SYSTEM 'http://cobertura.sourceforge.net/xml/coverage-04.dtd'>")
-        else :
+        if LXML_AVAILABLE:
+            print >>fh, \
+                etree.tostring(root,
+                               pretty_print=options.prettyxml,
+                               encoding="UTF-8",
+                               xml_declaration=True,
+                               doctype="<!DOCTYPE coverage SYSTEM 'http://cobertura.sourceforge.net/xml/coverage-04.dtd'>")
+        else:
             print >>fh, etree.tostring(root, encoding="UTF-8")
-

--- a/gcovr/cobertura_xml_generator.py
+++ b/gcovr/cobertura_xml_generator.py
@@ -217,11 +217,11 @@ def print_xml_report(covdata, options):
 
     with smart_open(options.output) as fh:
         if LXML_AVAILABLE:
-            print >>fh, \
+            fh.write(
                 etree.tostring(root,
                                pretty_print=options.prettyxml,
                                encoding="UTF-8",
                                xml_declaration=True,
-                               doctype="<!DOCTYPE coverage SYSTEM 'http://cobertura.sourceforge.net/xml/coverage-04.dtd'>")
+                               doctype="<!DOCTYPE coverage SYSTEM 'http://cobertura.sourceforge.net/xml/coverage-04.dtd'>"))
         else:
-            print >>fh, etree.tostring(root, encoding="UTF-8")
+            fh.write(etree.tostring(root, encoding="UTF-8"))

--- a/gcovr/cobertura_xml_generator.py
+++ b/gcovr/cobertura_xml_generator.py
@@ -220,7 +220,7 @@ def print_xml_report(covdata, options):
                 pretty_print=options.prettyxml,
                 encoding="UTF-8",
                 xml_declaration=True,
-                doctype="<!DOCTYPE coverage SYSTEM 'http://cobertura.sourceforge.net/xml/coverage-03.dtd'>")
+                doctype="<!DOCTYPE coverage SYSTEM 'http://cobertura.sourceforge.net/xml/coverage-04.dtd'>")
         else :
             print >>fh, etree.tostring(root, encoding="UTF-8")
 

--- a/gcovr/cobertura_xml_generator.py
+++ b/gcovr/cobertura_xml_generator.py
@@ -29,8 +29,13 @@ except NameError:
 @contextmanager
 def smart_open(filename=None):
     if filename and filename != '-':
-        fh = open(filename, 'w')
+        # files in write binary mode for UTF-8
+        fh = open(filename, 'wb')
+    elif (sys.version_info > (3,0)):
+        #python 3 wants stdout.buffer for binary output
+        fh = sys.stdout.buffer
     else:
+        #python2 doesn't care as much, no stdout.buffer
         fh = sys.stdout
 
     try:
@@ -217,12 +222,11 @@ def print_xml_report(covdata, options):
 
     with smart_open(options.output) as fh:
         if LXML_AVAILABLE:
-            print(
+            fh.write(
                 etree.tostring(root,
                                pretty_print=options.prettyxml,
                                encoding="UTF-8",
                                xml_declaration=True,
-                               doctype="<!DOCTYPE coverage SYSTEM 'http://cobertura.sourceforge.net/xml/coverage-04.dtd'>"),
-                file=fh)
+                               doctype="<!DOCTYPE coverage SYSTEM 'http://cobertura.sourceforge.net/xml/coverage-04.dtd'>"))
         else:
-            print(etree.tostring(root, encoding="UTF-8"), file=fh)
+            fh.write(etree.tostring(root, encoding="UTF-8"))


### PR DESCRIPTION
RE: https://github.com/gcovr/gcovr/issues/1

As suggested somewhere (regarding gcovr on the Linux kernel), detecting and using the lxml etree instead of pure python etree to bring down memory usage. 

We were trying to use this on our private codebase in a size restricted container and it failed due to memory. With this change it works  (memory saving is at least 3x).  

lxml may also be faster (possibly partially addressing the speed issue, although it is still DOM, not STREAM as suggested so still doesn't fully address that issue)