### PR TITLE
Add XML generator for sonarqube generic coverage report

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -26,6 +26,7 @@ The following developers contributed to gcovr (ordered alphabetically):
     libPhipp,
     Lukas Atkinson,
     Luke Woydziak,
+    Leon Ma,
     Marek Kurdej,
     Martin Mraz,
     Matsumoto Taichi,

--- a/README.rst
+++ b/README.rst
@@ -123,7 +123,7 @@ To generate code coverage report for sonarqube:
 
 ::
 
-    gcovr -r . --xml-pretty --sonarqube coverage.xml
+    gcovr -r . --sonarqube coverage.xml
 
 This will create coverage.xml containing the sonarqube generic coverage report described at:
 `<https://docs.sonarqube.org/latest/analysis/generic-test/>`_

--- a/README.rst
+++ b/README.rst
@@ -119,6 +119,15 @@ You can also generate detailed HTML reports:
 
 Gcovr will create one HTML report per source file next to the coverage.html summary.
 
+To generate code coverage report for sonarqube:
+
+::
+
+    gcovr -r . --xml-pretty --sonarqube coverage.xml
+
+This will create coverage.xml containing the sonarqube generic coverage report described at:
+`<https://docs.sonarqube.org/latest/analysis/generic-test/>`_
+
 You should run gcovr from the build directory.
 The ``-r`` option should point to the root of your project.
 This only matters if you have a separate build directory.

--- a/gcovr/__main__.py
+++ b/gcovr/__main__.py
@@ -54,6 +54,7 @@ from .cobertura_xml_generator import print_xml_report
 from .html_generator import print_html_report
 from .txt_generator import print_text_report
 from .summary_generator import print_summary
+from .sonarqube_generator import print_sonarqube_report
 
 
 #
@@ -288,6 +289,9 @@ def main(args=None):
         print_xml_report(covdata, options)
     elif options.html or options.html_details:
         print_html_report(covdata, options)
+    elif options.sonarqube is not None:
+        options.sonarqube = os.path.abspath(options.sonarqube)
+        print_sonarqube_report(covdata, options)
     else:
         print_text_report(covdata, options)
 

--- a/gcovr/configuration.py
+++ b/gcovr/configuration.py
@@ -543,6 +543,12 @@ GCOVR_CONFIG_OPTIONS = [
         action="store_true",
     ),
     GcovrConfigOption(
+        "sonarqube", ["--sonarqube"],
+        group="output_options",
+        help="Generate sonarqube generic coverage report in this file name.",
+        default=None,
+    ),
+    GcovrConfigOption(
         "filter", ["-f", "--filter"],
         group="filter_options",
         help="Keep only source files that match this filter. "

--- a/gcovr/sonarqube_generator.py
+++ b/gcovr/sonarqube_generator.py
@@ -69,23 +69,7 @@ def print_sonarqube_report(covdata, options):
 
         root.appendChild(fileNode)
 
-    if options.prettyxml:
-        import textwrap
-        lines = doc.toprettyxml(" ").split('\n')
-        for i in xrange(len(lines)):
-            n = 0
-            while n < len(lines[i]) and lines[i][n] == " ":
-                n += 1
-            lines[i] = "\n".join(textwrap.wrap(
-                lines[i], 78,
-                break_long_words=False,
-                break_on_hyphens=False,
-                subsequent_indent=" " + n * " "
-            ))
-        xmlString = "\n".join(lines)
-        # print textwrap.wrap(doc.toprettyxml(" "), 80)
-    else:
-        xmlString = doc.toprettyxml(indent="")
+    xmlString = doc.toprettyxml(indent="")
 
     OUTPUT = open(options.sonarqube, 'w')
     OUTPUT.write(xmlString + '\n')

--- a/gcovr/sonarqube_generator.py
+++ b/gcovr/sonarqube_generator.py
@@ -1,0 +1,92 @@
+# -*- coding:utf-8 -*-
+
+# This file is part of gcovr <http://gcovr.com/>.
+#
+# Copyright 2013-2018 the gcovr authors
+# Copyright 2013 Sandia Corporation
+# This software is distributed under the BSD license.
+
+import os
+import xml.dom.minidom
+
+try:
+    xrange
+except NameError:
+    xrange = range
+
+
+#
+# Produce an XML report in the Sonarqube generic coverage format
+#
+def print_sonarqube_report(covdata, options):
+
+    impl = xml.dom.minidom.getDOMImplementation()
+    doc = impl.createDocument(None, "coverage", None)
+    root = doc.documentElement
+    root.setAttribute("version", "1")
+    source_dirs = set()
+
+    for f in sorted(covdata):
+        data = covdata[f]
+        directory = options.root_filter.sub('', f)
+        if f.endswith(directory):
+            src_path = f[:-1 * len(directory)]
+            if len(src_path) > 0:
+                while directory.startswith(os.path.sep):
+                    src_path += os.path.sep
+                    directory = directory[len(os.path.sep):]
+                source_dirs.add(src_path)
+        else:
+            # Do no truncation if the filter does not start matching at
+            # the beginning of the string
+            directory = f
+        directory, fname = os.path.split(directory)
+
+        fileNode = doc.createElement("file")
+
+        filename = os.path.join(directory, fname).replace('\\', '/')
+        fileNode.setAttribute("path", filename)
+
+        for lineno in sorted(data.lines):
+            line_cov = data.lines[lineno]
+            if not line_cov.is_covered and not line_cov.is_uncovered:
+                continue
+
+            L = doc.createElement("lineToCover")
+            L.setAttribute("lineNumber", str(lineno))
+            if line_cov.is_covered:
+                L.setAttribute("covered", "true")
+            else:
+                L.setAttribute("covered", "false")
+
+            branches = line_cov.branches
+            if branches:
+                b_total, b_hits, coverage = line_cov.branch_coverage()
+                L.setAttribute("branchesToCover", str(b_total))
+                L.setAttribute("coveredBranches", str(b_hits))
+
+            fileNode.appendChild(L)
+
+        root.appendChild(fileNode)
+
+    if options.prettyxml:
+        import textwrap
+        lines = doc.toprettyxml(" ").split('\n')
+        for i in xrange(len(lines)):
+            n = 0
+            while n < len(lines[i]) and lines[i][n] == " ":
+                n += 1
+            lines[i] = "\n".join(textwrap.wrap(
+                lines[i], 78,
+                break_long_words=False,
+                break_on_hyphens=False,
+                subsequent_indent=" " + n * " "
+            ))
+        xmlString = "\n".join(lines)
+        # print textwrap.wrap(doc.toprettyxml(" "), 80)
+    else:
+        xmlString = doc.toprettyxml(indent="")
+
+    OUTPUT = open(options.sonarqube, 'w')
+    OUTPUT.write(xmlString + '\n')
+    OUTPUT.close()

--- a/gcovr/tests/bad++char/Makefile
+++ b/gcovr/tests/bad++char/Makefile
@@ -1,7 +1,7 @@
 all:
 	$(CXX) -fprofile-arcs -ftest-coverage -fPIC main.cpp -o testcase
 
-run: txt xml html
+run: txt xml html sonarqube
 
 txt:
 	./testcase
@@ -15,7 +15,11 @@ html:
 	./testcase
 	$(GCOVR) -d --html-details -o coverage.html
 
+sonarqube:
+	./testcase
+	$(GCOVR) -d --sonarqube sonarqube.xml
+
 clean:
 	rm -f testcase
 	rm -f *.gc*
-	rm -f coverage.txt coverage.xml coverage*.html
+	rm -f coverage.txt coverage.xml coverage*.html sonarqube.xml

--- a/gcovr/tests/bad++char/reference/sonarqube.xml
+++ b/gcovr/tests/bad++char/reference/sonarqube.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+<coverage version="1">
+<file path="main.cpp">
+<lineToCover covered="true" lineNumber="4"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="5"/>
+<lineToCover covered="false" lineNumber="6"/>
+<lineToCover covered="true" lineNumber="8"/>
+<lineToCover covered="true" lineNumber="13"/>
+<lineToCover covered="true" lineNumber="14"/>
+<lineToCover covered="true" lineNumber="16"/>
+<lineToCover branchesToCover="4" covered="true" coveredBranches="2" lineNumber="17"/>
+</file>
+</coverage>
+

--- a/gcovr/tests/cmake_oos/Makefile
+++ b/gcovr/tests/cmake_oos/Makefile
@@ -12,7 +12,7 @@ all:
 	mkdir -p build
 	cd build && $(CMAKE) .. && make
 
-run: txt xml html
+run: txt xml html sonarqube
 
 txt:
 	cd build && ./gcovrtest
@@ -26,7 +26,11 @@ html:
 	cd build && ./gcovrtest
 	$(GCOVR) -d --html-details -o coverage.html
 
+sonarqube:
+	cd build && ./gcovrtest
+	$(GCOVR) -d --sonarqube sonarqube.xml
+
 clean:
 	rm -rf build
-	rm -f coverage.txt coverage.xml coverage*.html
+	rm -f coverage.txt coverage.xml coverage*.html sonarqube.xml
 

--- a/gcovr/tests/cmake_oos/reference/sonarqube.xml
+++ b/gcovr/tests/cmake_oos/reference/sonarqube.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+<coverage version="1">
+<file path="main.cpp">
+<lineToCover covered="true" lineNumber="4"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="5"/>
+<lineToCover covered="false" lineNumber="6"/>
+<lineToCover covered="true" lineNumber="8"/>
+<lineToCover covered="true" lineNumber="13"/>
+<lineToCover covered="true" lineNumber="14"/>
+<lineToCover covered="true" lineNumber="16"/>
+<lineToCover branchesToCover="4" covered="true" coveredBranches="2" lineNumber="17"/>
+</file>
+</coverage>
+

--- a/gcovr/tests/dot/Makefile
+++ b/gcovr/tests/dot/Makefile
@@ -10,7 +10,7 @@ all:
 	$(CXX) $(CFLAGS) -c .subdir/B/main.cpp -o .subdir/B/main.o
 	$(CXX) $(CFLAGS) .subdir/A/file1.o .subdir/A/file2.o .subdir/A/file3.o .subdir/A/file4.o .subdir/A/C/file5.o .subdir/A/C/D/file6.o .subdir/B/main.o -o .subdir/testcase
 
-run: txt xml html
+run: txt xml html sonarqube
 
 txt:
 	./.subdir/testcase
@@ -24,8 +24,12 @@ html:
 	./.subdir/testcase
 	$(GCOVR) -r . -d --html-details -o coverage.html
 
+sonarqube:
+	./.subdir/testcase
+	$(GCOVR) -r . -d --sonarqube sonarqube.xml
+
 clean:
 	rm -f ./.subdir/testcase
 	rm -f .*.gc* */*.gc* .*/*/*.gc* .*/*/*/*.gc* .*/*/*/*/*.gc*
 	rm -f .*.o .*/*.o .*/*/*.o .*/*/*/*.o .*/*/*/*/*.o
-	rm -f coverage.txt coverage.xml coverage*.html
+	rm -f coverage.txt coverage.xml coverage*.html sonarqube.xml

--- a/gcovr/tests/dot/reference/sonarqube.xml
+++ b/gcovr/tests/dot/reference/sonarqube.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" ?>
+<coverage version="1">
+<file path=".subdir/A/C/D/file6.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="3"/>
+<lineToCover covered="false" lineNumber="4"/>
+<lineToCover covered="true" lineNumber="6"/>
+</file>
+<file path=".subdir/A/C/file5.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="3"/>
+<lineToCover covered="false" lineNumber="4"/>
+<lineToCover covered="true" lineNumber="6"/>
+</file>
+<file path=".subdir/A/file1.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="3"/>
+<lineToCover covered="false" lineNumber="4"/>
+<lineToCover covered="true" lineNumber="6"/>
+</file>
+<file path=".subdir/A/file2.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover covered="true" lineNumber="3"/>
+<lineToCover covered="true" lineNumber="4"/>
+<lineToCover covered="true" lineNumber="5"/>
+<lineToCover covered="false" lineNumber="8"/>
+<lineToCover covered="false" lineNumber="10"/>
+<lineToCover covered="false" lineNumber="11"/>
+</file>
+<file path=".subdir/A/file3.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover covered="true" lineNumber="3"/>
+<lineToCover covered="true" lineNumber="4"/>
+<lineToCover covered="true" lineNumber="5"/>
+<lineToCover covered="false" lineNumber="8"/>
+<lineToCover covered="false" lineNumber="10"/>
+<lineToCover covered="false" lineNumber="11"/>
+</file>
+<file path=".subdir/A/file4.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="3"/>
+<lineToCover covered="true" lineNumber="4"/>
+<lineToCover covered="false" lineNumber="6"/>
+</file>
+<file path=".subdir/B/main.cpp">
+<lineToCover covered="true" lineNumber="11"/>
+<lineToCover covered="true" lineNumber="12"/>
+<lineToCover covered="true" lineNumber="13"/>
+<lineToCover covered="true" lineNumber="14"/>
+<lineToCover covered="true" lineNumber="15"/>
+<lineToCover covered="true" lineNumber="16"/>
+<lineToCover covered="true" lineNumber="17"/>
+<lineToCover covered="true" lineNumber="19"/>
+<lineToCover branchesToCover="4" covered="true" coveredBranches="2" lineNumber="20"/>
+</file>
+</coverage>
+

--- a/gcovr/tests/excl-branch/Makefile
+++ b/gcovr/tests/excl-branch/Makefile
@@ -1,7 +1,7 @@
 all:
 	$(CXX) -fprofile-arcs -ftest-coverage -fPIC main.cpp -o testcase
 
-run: txt xml html
+run: txt xml html sonarqube
 
 txt:
 	./testcase
@@ -15,7 +15,11 @@ html:
 	./testcase
 	$(GCOVR) --exclude-unreachable-branches -b -d --html-details -o coverage.html
 
+sonarqube:
+	./testcase
+	$(GCOVR) --exclude-unreachable-branches -b -d --sonarqube sonarqube.xml
+
 clean:
 	rm -f testcase
 	rm -f *.gc*
-	rm -f coverage.txt coverage.xml coverage*.html
+	rm -f coverage.txt coverage.xml coverage*.html sonarqube.xml

--- a/gcovr/tests/excl-branch/reference/sonarqube.xml
+++ b/gcovr/tests/excl-branch/reference/sonarqube.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" ?>
+<coverage version="1">
+<file path="main.cpp">
+<lineToCover covered="true" lineNumber="7"/>
+<lineToCover covered="true" lineNumber="8"/>
+<lineToCover covered="true" lineNumber="9"/>
+<lineToCover covered="true" lineNumber="10"/>
+<lineToCover covered="true" lineNumber="16"/>
+<lineToCover branchesToCover="4" covered="true" coveredBranches="4" lineNumber="17"/>
+<lineToCover covered="true" lineNumber="18"/>
+<lineToCover covered="true" lineNumber="20"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="21"/>
+<lineToCover covered="false" lineNumber="22"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="23"/>
+<lineToCover covered="false" lineNumber="24"/>
+<lineToCover covered="true" lineNumber="35"/>
+<lineToCover covered="true" lineNumber="46"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="2" lineNumber="47"/>
+<lineToCover covered="true" lineNumber="48"/>
+<lineToCover covered="true" lineNumber="61"/>
+<lineToCover covered="true" lineNumber="62"/>
+</file>
+</coverage>
+

--- a/gcovr/tests/excl-line/Makefile
+++ b/gcovr/tests/excl-line/Makefile
@@ -1,7 +1,7 @@
 all:
 	$(CXX) -fprofile-arcs -ftest-coverage -fPIC main.cpp -o testcase
 
-run: txt xml html
+run: txt xml html sonarqube
 
 txt:
 	./testcase
@@ -15,7 +15,11 @@ html:
 	./testcase
 	$(GCOVR) -d --html-details -o coverage.html
 
+sonarqube:
+	./testcase
+	$(GCOVR) -d --sonarqube sonarqube.xml
+
 clean:
 	rm -f testcase
 	rm -f *.gc*
-	rm -f coverage.txt coverage.xml coverage*.html
+	rm -f coverage.txt coverage.xml coverage*.html sonarqube.xml

--- a/gcovr/tests/excl-line/reference/sonarqube.xml
+++ b/gcovr/tests/excl-line/reference/sonarqube.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+<coverage version="1">
+<file path="main.cpp">
+<lineToCover covered="true" lineNumber="4"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="5"/>
+<lineToCover covered="false" lineNumber="6"/>
+<lineToCover covered="true" lineNumber="20"/>
+<lineToCover covered="true" lineNumber="21"/>
+<lineToCover covered="true" lineNumber="23"/>
+<lineToCover branchesToCover="4" covered="true" coveredBranches="2" lineNumber="24"/>
+</file>
+</coverage>
+

--- a/gcovr/tests/exclude-directories-relative/Makefile
+++ b/gcovr/tests/exclude-directories-relative/Makefile
@@ -6,7 +6,7 @@ all:
 	$(CXX) $(CFLAGS) -c b/main.cpp -o build/b/main.o
 	$(CXX) $(CFLAGS) build/b/main.o build/a/file1.o -o testcase
 
-run: txt xml html
+run: txt xml html sonarqube
 
 GCOVR_TEST_OPTIONS = --exclude-directories 'build/a'
 
@@ -22,7 +22,11 @@ html:
 	./testcase
 	$(GCOVR) $(GCOVR_TEST_OPTIONS) -d --html-details -o coverage.html
 
+sonarqube:
+	./testcase
+	$(GCOVR) $(GCOVR_TEST_OPTIONS) -d --sonarqube sonarqube.xml
+
 clean:
 	rm -f testcase
 	rm -rf build  # remove *.gc* *.o
-	rm -f coverage.txt coverage.xml coverage*.html
+	rm -f coverage.txt coverage.xml coverage*.html sonarqube.xml

--- a/gcovr/tests/exclude-directories-relative/reference/sonarqube.xml
+++ b/gcovr/tests/exclude-directories-relative/reference/sonarqube.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+<coverage version="1">
+<file path="b/main.cpp">
+<lineToCover covered="true" lineNumber="5"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="6"/>
+<lineToCover covered="false" lineNumber="7"/>
+<lineToCover covered="true" lineNumber="9"/>
+<lineToCover covered="true" lineNumber="14"/>
+<lineToCover covered="true" lineNumber="15"/>
+<lineToCover covered="true" lineNumber="17"/>
+<lineToCover branchesToCover="4" covered="true" coveredBranches="2" lineNumber="18"/>
+</file>
+</coverage>
+

--- a/gcovr/tests/exclude-relative/Makefile
+++ b/gcovr/tests/exclude-relative/Makefile
@@ -5,7 +5,7 @@ all:
 	$(CXX) $(CFLAGS) -c main.cpp -o main.o
 	$(CXX) $(CFLAGS) main.o file1.o -o testcase
 
-run: txt xml html
+run: txt xml html sonarqube
 
 GCOVR_TEST_OPTIONS = -e 'file1.cpp'  # use a relative filter here
 
@@ -21,7 +21,11 @@ html:
 	./testcase
 	$(GCOVR) $(GCOVR_TEST_OPTIONS) -d --html-details -o coverage.html
 
+sonarqube:
+	./testcase
+	$(GCOVR) $(GCOVR_TEST_OPTIONS) -d --sonarqube sonarqube.xml
+
 clean:
 	rm -f testcase
 	rm -f *.gc* *.o
-	rm -f coverage.txt coverage.xml coverage*.html
+	rm -f coverage.txt coverage.xml coverage*.html sonarqube.xml

--- a/gcovr/tests/exclude-relative/reference/sonarqube.xml
+++ b/gcovr/tests/exclude-relative/reference/sonarqube.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+<coverage version="1">
+<file path="main.cpp">
+<lineToCover covered="true" lineNumber="5"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="6"/>
+<lineToCover covered="false" lineNumber="7"/>
+<lineToCover covered="true" lineNumber="9"/>
+<lineToCover covered="true" lineNumber="14"/>
+<lineToCover covered="true" lineNumber="15"/>
+<lineToCover covered="true" lineNumber="17"/>
+<lineToCover branchesToCover="4" covered="true" coveredBranches="2" lineNumber="18"/>
+</file>
+</coverage>
+

--- a/gcovr/tests/exclude-throw-branches/Makefile
+++ b/gcovr/tests/exclude-throw-branches/Makefile
@@ -1,7 +1,7 @@
 all:
 	$(CXX) -fprofile-arcs -ftest-coverage -fPIC main.cpp -o testcase
 
-run: txt xml html
+run: txt xml html sonarqube
 
 txt:
 	./testcase
@@ -18,8 +18,12 @@ html:
 	$(GCOVR)    --html-details                          -o coverage-throw.html
 	$(GCOVR) -d --html-details --exclude-throw-branches -o coverage-excl-throw.html
 
+sonarqube:
+	./testcase
+	$(GCOVR)			     --sonarqube sonarqube-throw.xml
+	$(GCOVR) -d --exclude-throw-branches --sonarqube sonarqube-excl-throw.xml
 
 clean:
 	rm -f testcase
 	rm -f *.gc*
-	rm -f coverage-*.txt coverage-*.xml coverage-*.html
+	rm -f coverage-*.txt coverage-*.xml coverage-*.html sonarqube.xml

--- a/gcovr/tests/exclude-throw-branches/Makefile
+++ b/gcovr/tests/exclude-throw-branches/Makefile
@@ -26,4 +26,4 @@ sonarqube:
 clean:
 	rm -f testcase
 	rm -f *.gc*
-	rm -f coverage-*.txt coverage-*.xml coverage-*.html sonarqube.xml
+	rm -f coverage-*.txt coverage-*.xml coverage-*.html sonarqube-*.xml

--- a/gcovr/tests/exclude-throw-branches/reference/sonarqube-excl-throw.xml
+++ b/gcovr/tests/exclude-throw-branches/reference/sonarqube-excl-throw.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" ?>
+<coverage version="1">
+<file path="main.cpp">
+<lineToCover covered="true" lineNumber="3"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="2" lineNumber="4"/>
+<lineToCover branchesToCover="1" covered="true" coveredBranches="1" lineNumber="5"/>
+<lineToCover covered="true" lineNumber="7"/>
+<lineToCover covered="true" lineNumber="16"/>
+<lineToCover covered="true" lineNumber="17"/>
+<lineToCover covered="true" lineNumber="21"/>
+<lineToCover covered="true" lineNumber="22"/>
+<lineToCover covered="true" lineNumber="24"/>
+<lineToCover covered="true" lineNumber="25"/>
+<lineToCover branchesToCover="1" covered="true" coveredBranches="0" lineNumber="28"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="0" lineNumber="29"/>
+<lineToCover covered="true" lineNumber="30"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="33"/>
+<lineToCover branchesToCover="1" covered="true" coveredBranches="1" lineNumber="36"/>
+<lineToCover covered="false" lineNumber="37"/>
+<lineToCover covered="false" lineNumber="38"/>
+<lineToCover branchesToCover="1" covered="true" coveredBranches="1" lineNumber="41"/>
+<lineToCover covered="true" lineNumber="43"/>
+<lineToCover covered="true" lineNumber="47"/>
+<lineToCover covered="true" lineNumber="48"/>
+</file>
+</coverage>
+

--- a/gcovr/tests/exclude-throw-branches/reference/sonarqube-throw.xml
+++ b/gcovr/tests/exclude-throw-branches/reference/sonarqube-throw.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" ?>
+<coverage version="1">
+<file path="main.cpp">
+<lineToCover covered="true" lineNumber="3"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="2" lineNumber="4"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="5"/>
+<lineToCover covered="true" lineNumber="7"/>
+<lineToCover covered="true" lineNumber="16"/>
+<lineToCover covered="true" lineNumber="17"/>
+<lineToCover covered="true" lineNumber="21"/>
+<lineToCover covered="true" lineNumber="22"/>
+<lineToCover covered="true" lineNumber="24"/>
+<lineToCover covered="true" lineNumber="25"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="28"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="0" lineNumber="29"/>
+<lineToCover covered="true" lineNumber="30"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="33"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="36"/>
+<lineToCover covered="false" lineNumber="37"/>
+<lineToCover covered="false" lineNumber="38"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="41"/>
+<lineToCover covered="true" lineNumber="43"/>
+<lineToCover covered="true" lineNumber="47"/>
+<lineToCover covered="true" lineNumber="48"/>
+</file>
+</coverage>
+

--- a/gcovr/tests/filter-absolute/Makefile
+++ b/gcovr/tests/filter-absolute/Makefile
@@ -16,7 +16,7 @@ all:
 	$(CXX) $(CFLAGS) -c main.cpp -o main.o
 	$(CXX) $(CFLAGS) main.o file1.o -o testcase
 
-run: txt xml html
+run: txt xml html sonarqube
 
 txt:
 	./testcase
@@ -31,7 +31,11 @@ html:
 	./testcase
 	$(GCOVR) $(GCOVR_TEST_OPTIONS) -d --html-details -o coverage.html
 
+sonarqube:
+	./testcase
+	$(GCOVR) $(GCOVR_TEST_OPTIONS) -d --sonarqube sonarqube.xml
+
 clean:
 	rm -f testcase
 	rm -f *.gc* *.o
-	rm -f coverage.txt coverage.xml coverage*.html
+	rm -f coverage.txt coverage.xml coverage*.html sonarqube.xml

--- a/gcovr/tests/filter-absolute/reference/sonarqube.xml
+++ b/gcovr/tests/filter-absolute/reference/sonarqube.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+<coverage version="1">
+<file path="main.cpp">
+<lineToCover covered="true" lineNumber="5"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="6"/>
+<lineToCover covered="false" lineNumber="7"/>
+<lineToCover covered="true" lineNumber="9"/>
+<lineToCover covered="true" lineNumber="14"/>
+<lineToCover covered="true" lineNumber="15"/>
+<lineToCover covered="true" lineNumber="17"/>
+<lineToCover branchesToCover="4" covered="true" coveredBranches="2" lineNumber="18"/>
+</file>
+</coverage>
+

--- a/gcovr/tests/filter-relative-lib/Makefile
+++ b/gcovr/tests/filter-relative-lib/Makefile
@@ -32,5 +32,5 @@ links:
 	   test -d relevant-library || ln -sT ../external-library relevant-library
 
 clean:
-	cd project; rm -f testcase *.gc* *.o relevant-library
+	cd project; rm -f testcase *.gc* *.o; rm -rf relevant-library
 	rm -f coverage.txt coverage.xml coverage*.html sonarqube.xml

--- a/gcovr/tests/filter-relative-lib/Makefile
+++ b/gcovr/tests/filter-relative-lib/Makefile
@@ -6,7 +6,7 @@ all: links
 	cd project; $(CXX) $(CFLAGS) -c relevant-library/src/yes.cpp -o yes.o
 	cd project; $(CXX) $(CFLAGS) main.o no.o yes.o -o testcase
 
-run: txt xml html
+run: txt xml html sonarqube
 
 # the src/ filter is provided by the project/gcovr.cfg configuration file
 GCOVR_TEST_OPTIONS = -f '\.\./external-library/src'
@@ -23,10 +23,14 @@ html:
 	cd project; ./testcase
 	cd project; $(GCOVR) $(GCOVR_TEST_OPTIONS) -d --html-details -o ../coverage.html
 
+sonarqube:
+	cd project; ./testcase
+	cd project; $(GCOVR) $(GCOVR_TEST_OPTIONS) -d --sonarqube ../sonarqube.xml
+
 links:
 	cd project; \
 	   test -d relevant-library || ln -sT ../external-library relevant-library
 
 clean:
 	cd project; rm -f testcase *.gc* *.o relevant-library
-	rm -f coverage.txt coverage.xml coverage*.html
+	rm -f coverage.txt coverage.xml coverage*.html sonarqube.xml

--- a/gcovr/tests/filter-relative-lib/reference/sonarqube.xml
+++ b/gcovr/tests/filter-relative-lib/reference/sonarqube.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+<coverage version="1">
+<file path="src/main.cpp">
+<lineToCover covered="true" lineNumber="4"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="6"/>
+<lineToCover covered="false" lineNumber="7"/>
+<lineToCover covered="true" lineNumber="10"/>
+</file>
+</coverage>
+

--- a/gcovr/tests/filter-relative-lib/reference/sonarqube.xml
+++ b/gcovr/tests/filter-relative-lib/reference/sonarqube.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" ?>
 <coverage version="1">
+<file path="relevant-library/src/yes.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover covered="true" lineNumber="2"/>
+</file>
 <file path="src/main.cpp">
 <lineToCover covered="true" lineNumber="4"/>
 <lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="6"/>

--- a/gcovr/tests/filter-relative/Makefile
+++ b/gcovr/tests/filter-relative/Makefile
@@ -5,7 +5,7 @@ all:
 	$(CXX) $(CFLAGS) -c main.cpp -o main.o
 	$(CXX) $(CFLAGS) main.o file1.o -o testcase
 
-run: txt xml html
+run: txt xml html sonarqube
 
 GCOVR_TEST_OPTIONS = -f 'main.cpp'  # use a relative filter here
 
@@ -21,7 +21,11 @@ html:
 	./testcase
 	$(GCOVR) $(GCOVR_TEST_OPTIONS) -d --html-details -o coverage.html
 
+sonarqube:
+	./testcase
+	$(GCOVR) $(GCOVR_TEST_OPTIONS) -d --sonarqube sonarqube.xml
+
 clean:
 	rm -f testcase
 	rm -f *.gc* *.o
-	rm -f coverage.txt coverage.xml coverage*.html
+	rm -f coverage.txt coverage.xml coverage*.html sonarqube.xml

--- a/gcovr/tests/filter-relative/reference/sonarqube.xml
+++ b/gcovr/tests/filter-relative/reference/sonarqube.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+<coverage version="1">
+<file path="main.cpp">
+<lineToCover covered="true" lineNumber="5"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="6"/>
+<lineToCover covered="false" lineNumber="7"/>
+<lineToCover covered="true" lineNumber="9"/>
+<lineToCover covered="true" lineNumber="14"/>
+<lineToCover covered="true" lineNumber="15"/>
+<lineToCover covered="true" lineNumber="17"/>
+<lineToCover branchesToCover="4" covered="true" coveredBranches="2" lineNumber="18"/>
+</file>
+</coverage>
+

--- a/gcovr/tests/html-encoding-cp1252/Makefile
+++ b/gcovr/tests/html-encoding-cp1252/Makefile
@@ -1,7 +1,7 @@
 all:
 	$(CXX) -fprofile-arcs -ftest-coverage -fPIC main.cpp -o testcase
 
-run: txt xml html
+run: txt xml html sonarqube
 
 txt:
 	# pass
@@ -12,6 +12,9 @@ xml:
 html:
 	./testcase
 	$(GCOVR) -d --html-details -o coverage.html --source-encoding utf8 --html-encoding cp1252
+
+sonarqube:
+	# pass
 
 clean:
 	rm -f testcase

--- a/gcovr/tests/html-encoding-iso-8859-15/Makefile
+++ b/gcovr/tests/html-encoding-iso-8859-15/Makefile
@@ -1,7 +1,7 @@
 all:
 	$(CXX) -fprofile-arcs -ftest-coverage -fPIC main.cpp -o testcase
 
-run: txt xml html
+run: txt xml html sonarqube
 
 txt:
 	# pass
@@ -12,6 +12,9 @@ xml:
 html:
 	./testcase
 	$(GCOVR) -d --html-details -o coverage.html --source-encoding utf8 --html-encoding iso-8859-15
+
+sonarqube:
+	# pass
 
 clean:
 	rm -f testcase

--- a/gcovr/tests/html-high-75/Makefile
+++ b/gcovr/tests/html-high-75/Makefile
@@ -1,7 +1,7 @@
 all:
 	$(CXX) -fprofile-arcs -ftest-coverage -fPIC main.cpp -o testcase
 
-run: txt xml html
+run: txt xml html sonarqube
 
 txt:
 	# pass
@@ -12,6 +12,9 @@ xml:
 html:
 	./testcase
 	$(GCOVR) -d --html-details --html-high-threshold=75.0 -o coverage.html
+
+sonarqube:
+	# pass
 
 clean:
 	rm -f testcase

--- a/gcovr/tests/html-medium-50/Makefile
+++ b/gcovr/tests/html-medium-50/Makefile
@@ -1,7 +1,7 @@
 all:
 	$(CXX) -fprofile-arcs -ftest-coverage -fPIC main.cpp -o testcase
 
-run: txt xml html
+run: txt xml html sonarqube
 
 txt:
 	# pass
@@ -12,6 +12,9 @@ xml:
 html:
 	./testcase
 	$(GCOVR) -d --html-details --html-medium-threshold=50.0 -o coverage.html
+
+sonarqube:
+	# pass
 
 clean:
 	rm -f testcase

--- a/gcovr/tests/html-title-empty/Makefile
+++ b/gcovr/tests/html-title-empty/Makefile
@@ -1,7 +1,7 @@
 all:
 	$(CXX) -fprofile-arcs -ftest-coverage -fPIC main.cpp -o testcase
 
-run: txt xml html
+run: txt xml html sonarqube
 
 txt:
 	# pass
@@ -12,6 +12,9 @@ xml:
 html:
 	./testcase
 	$(GCOVR) -d --html-details --html-title="" -o coverage.html
+
+sonarqube:
+	# pass
 
 clean:
 	rm -f testcase

--- a/gcovr/tests/html-title/Makefile
+++ b/gcovr/tests/html-title/Makefile
@@ -1,7 +1,7 @@
 all:
 	$(CXX) -fprofile-arcs -ftest-coverage -fPIC main.cpp -o testcase
 
-run: txt xml html
+run: txt xml html sonarqube
 
 txt:
 	# pass
@@ -12,6 +12,9 @@ xml:
 html:
 	./testcase
 	$(GCOVR) -d --html-details --html-title="Title of report" -o coverage.html
+
+sonarqube:
+	# pass
 
 clean:
 	rm -f testcase

--- a/gcovr/tests/linked/Makefile
+++ b/gcovr/tests/linked/Makefile
@@ -11,7 +11,7 @@ all: links
 	$(CXX) $(CFLAGS) -c subdir/B/main.cpp -o subdir/B/main.o
 	$(CXX) $(CFLAGS) subdir/A/file1.o subdir/A/file2.o subdir/A/file3.o subdir/A/file4.o subdir/A/C/file5.o subdir/m/n/C/D/file6.o subdir/A/file7.o subdir/B/main.o -o subdir/testcase
 
-run: txt xml html
+run: txt xml html sonarqube
 
 txt:
 	./subdir/testcase
@@ -25,9 +25,13 @@ html:
 	./subdir/testcase
 	$(GCOVR) -d --html-details -o coverage.html
 
+sonarqube:
+	./subdir/testcase
+	$(GCOVR) -d --sonarqube sonarqube.xml
+
 clean:
 	rm -Rf subdir
-	rm -f coverage.txt coverage.xml coverage*.html
+	rm -f coverage.txt coverage.xml coverage*.html sonarqube.xml
 
 links:
 	if ! [ -d "subdir" ]; then\

--- a/gcovr/tests/linked/reference/sonarqube.xml
+++ b/gcovr/tests/linked/reference/sonarqube.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" ?>
+<coverage version="1">
+<file path="subdir/A/C/file5.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="3"/>
+<lineToCover covered="false" lineNumber="4"/>
+<lineToCover covered="true" lineNumber="6"/>
+</file>
+<file path="subdir/A/file1.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="3"/>
+<lineToCover covered="false" lineNumber="4"/>
+<lineToCover covered="true" lineNumber="6"/>
+</file>
+<file path="subdir/A/file2.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover covered="true" lineNumber="3"/>
+<lineToCover covered="true" lineNumber="4"/>
+<lineToCover covered="true" lineNumber="5"/>
+<lineToCover covered="false" lineNumber="8"/>
+<lineToCover covered="false" lineNumber="10"/>
+<lineToCover covered="false" lineNumber="11"/>
+</file>
+<file path="subdir/A/file3.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover covered="true" lineNumber="3"/>
+<lineToCover covered="true" lineNumber="4"/>
+<lineToCover covered="true" lineNumber="5"/>
+<lineToCover covered="false" lineNumber="8"/>
+<lineToCover covered="false" lineNumber="10"/>
+<lineToCover branchesToCover="2" covered="false" coveredBranches="0" lineNumber="11"/>
+<lineToCover covered="false" lineNumber="12"/>
+<lineToCover covered="false" lineNumber="14"/>
+</file>
+<file path="subdir/A/file4.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="3"/>
+<lineToCover covered="true" lineNumber="4"/>
+<lineToCover covered="false" lineNumber="6"/>
+</file>
+<file path="subdir/A/file7.cpp">
+<lineToCover covered="false" lineNumber="1"/>
+<lineToCover covered="false" lineNumber="3"/>
+</file>
+<file path="subdir/B/main.cpp">
+<lineToCover covered="true" lineNumber="12"/>
+<lineToCover covered="true" lineNumber="13"/>
+<lineToCover covered="true" lineNumber="14"/>
+<lineToCover covered="true" lineNumber="15"/>
+<lineToCover covered="true" lineNumber="16"/>
+<lineToCover covered="true" lineNumber="17"/>
+<lineToCover covered="true" lineNumber="18"/>
+<lineToCover covered="true" lineNumber="20"/>
+<lineToCover branchesToCover="4" covered="true" coveredBranches="2" lineNumber="21"/>
+</file>
+<file path="subdir/m/n/C/D/file6.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="3"/>
+<lineToCover covered="false" lineNumber="4"/>
+<lineToCover covered="true" lineNumber="6"/>
+</file>
+</coverage>
+

--- a/gcovr/tests/nested/Makefile
+++ b/gcovr/tests/nested/Makefile
@@ -11,7 +11,7 @@ all:
 	$(CXX) $(CFLAGS) -c subdir/B/main.cpp -o subdir/B/main.o
 	$(CXX) $(CFLAGS) subdir/A/file1.o subdir/A/file2.o subdir/A/file3.o subdir/A/file4.o subdir/A/C/file5.o subdir/A/C/D/file6.o subdir/A/file7.o subdir/B/main.o -o subdir/testcase
 
-run: txt xml html
+run: txt xml html sonarqube
 
 txt:
 	./subdir/testcase
@@ -25,8 +25,12 @@ html:
 	./subdir/testcase
 	$(GCOVR) -r subdir -d --html-details -o coverage.html
 
+sonarqube:
+	./subdir/testcase
+	$(GCOVR) -r subdir -d --sonarqube sonarqube.xml
+
 clean:
 	rm -f ./subdir/testcase
 	rm -f *.gc* */*.gc* */*/*.gc* */*/*/*.gc* */*/*/*/*.gc*
 	rm -f *.o */*.o */*/*.o */*/*/*.o */*/*/*/*.o
-	rm -f coverage.txt coverage.xml coverage*.html
+	rm -f coverage.txt coverage.xml coverage*.html sonarqube.xml

--- a/gcovr/tests/nested/reference/sonarqube.xml
+++ b/gcovr/tests/nested/reference/sonarqube.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" ?>
+<coverage version="1">
+<file path="A/C/D/file6.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="3"/>
+<lineToCover covered="false" lineNumber="4"/>
+<lineToCover covered="true" lineNumber="6"/>
+</file>
+<file path="A/C/file5.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="3"/>
+<lineToCover covered="false" lineNumber="4"/>
+<lineToCover covered="true" lineNumber="6"/>
+</file>
+<file path="A/file1.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="3"/>
+<lineToCover covered="false" lineNumber="4"/>
+<lineToCover covered="true" lineNumber="6"/>
+</file>
+<file path="A/file2.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover covered="true" lineNumber="3"/>
+<lineToCover covered="true" lineNumber="4"/>
+<lineToCover covered="true" lineNumber="5"/>
+<lineToCover covered="false" lineNumber="8"/>
+<lineToCover covered="false" lineNumber="10"/>
+<lineToCover covered="false" lineNumber="11"/>
+</file>
+<file path="A/file3.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover covered="true" lineNumber="3"/>
+<lineToCover covered="true" lineNumber="4"/>
+<lineToCover covered="true" lineNumber="5"/>
+<lineToCover covered="false" lineNumber="8"/>
+<lineToCover covered="false" lineNumber="10"/>
+<lineToCover branchesToCover="2" covered="false" coveredBranches="0" lineNumber="11"/>
+<lineToCover covered="false" lineNumber="12"/>
+<lineToCover covered="false" lineNumber="14"/>
+</file>
+<file path="A/file4.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="3"/>
+<lineToCover covered="true" lineNumber="4"/>
+<lineToCover covered="false" lineNumber="6"/>
+</file>
+<file path="A/file7.cpp">
+<lineToCover covered="false" lineNumber="1"/>
+<lineToCover covered="false" lineNumber="3"/>
+</file>
+<file path="B/main.cpp">
+<lineToCover covered="true" lineNumber="12"/>
+<lineToCover covered="true" lineNumber="13"/>
+<lineToCover covered="true" lineNumber="14"/>
+<lineToCover covered="true" lineNumber="15"/>
+<lineToCover covered="true" lineNumber="16"/>
+<lineToCover covered="true" lineNumber="17"/>
+<lineToCover covered="true" lineNumber="18"/>
+<lineToCover covered="true" lineNumber="20"/>
+<lineToCover branchesToCover="4" covered="true" coveredBranches="2" lineNumber="21"/>
+</file>
+</coverage>
+

--- a/gcovr/tests/nested2-use-existing/Makefile
+++ b/gcovr/tests/nested2-use-existing/Makefile
@@ -8,7 +8,7 @@ all:
 	$(CXX) $(CFLAGS) -c subdir/B/main.cpp -o subdir/B/main.o
 	$(CXX) $(CFLAGS) subdir/B/main.o subdir/A/file1.o subdir/A/file2.o subdir/A/file3.o subdir/A/file4.o subdir/A/C/file5.o subdir/A/C/D/file6.o subdir/A/file7.o  -o subdir/B/testcase -lgcov
 
-run: txt xml html
+run: txt xml html sonarqube
 
 txt:
 	./subdir/B/testcase
@@ -28,8 +28,14 @@ html:
 	$(GCOV) --branch-counts --branch-probabilities --preserve-paths subdir/B/main.o
 	$(GCOVR) -r subdir -g -k --html-details -o coverage.html .
 
+sonarqube:
+	./subdir/B/testcase
+	make -C subdir/A coverage
+	$(GCOV) --branch-counts --branch-probabilities --preserve-paths subdir/B/main.o
+	$(GCOVR) -r subdir -g -k --sonarqube sonarqube.xml .
+
 clean:
 	rm -f ./subdir/B/testcase subdir/lib.a
 	rm -f *.gc* */*.gc* */*/*.gc* */*/*/*.gc* */*/*/*/*.gc*
 	rm -f *.o */*.o */*/*.o */*/*/*.o */*/*/*/*.o
-	rm -f coverage.txt coverage.xml coverage*.html
+	rm -f coverage.txt coverage.xml coverage*.html sonarqube.xml

--- a/gcovr/tests/nested2-use-existing/reference/sonarqube.xml
+++ b/gcovr/tests/nested2-use-existing/reference/sonarqube.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" ?>
+<coverage version="1">
+<file path="A/C/D/file6.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="3"/>
+<lineToCover covered="false" lineNumber="4"/>
+<lineToCover covered="true" lineNumber="6"/>
+</file>
+<file path="A/C/file5.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="3"/>
+<lineToCover covered="false" lineNumber="4"/>
+<lineToCover covered="true" lineNumber="6"/>
+</file>
+<file path="A/file1.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="3"/>
+<lineToCover covered="false" lineNumber="4"/>
+<lineToCover covered="true" lineNumber="6"/>
+</file>
+<file path="A/file2.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover covered="true" lineNumber="3"/>
+<lineToCover covered="true" lineNumber="4"/>
+<lineToCover covered="true" lineNumber="5"/>
+<lineToCover covered="false" lineNumber="8"/>
+<lineToCover covered="false" lineNumber="10"/>
+<lineToCover covered="false" lineNumber="11"/>
+</file>
+<file path="A/file3.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover covered="true" lineNumber="3"/>
+<lineToCover covered="true" lineNumber="4"/>
+<lineToCover covered="true" lineNumber="5"/>
+<lineToCover covered="false" lineNumber="8"/>
+<lineToCover covered="false" lineNumber="10"/>
+<lineToCover branchesToCover="2" covered="false" coveredBranches="0" lineNumber="11"/>
+<lineToCover covered="false" lineNumber="12"/>
+<lineToCover covered="false" lineNumber="14"/>
+</file>
+<file path="A/file4.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="3"/>
+<lineToCover covered="true" lineNumber="4"/>
+<lineToCover covered="false" lineNumber="6"/>
+</file>
+<file path="A/file7.cpp">
+<lineToCover covered="false" lineNumber="1"/>
+<lineToCover covered="false" lineNumber="3"/>
+</file>
+<file path="B/main.cpp">
+<lineToCover covered="true" lineNumber="12"/>
+<lineToCover covered="true" lineNumber="13"/>
+<lineToCover covered="true" lineNumber="14"/>
+<lineToCover covered="true" lineNumber="15"/>
+<lineToCover covered="true" lineNumber="16"/>
+<lineToCover covered="true" lineNumber="17"/>
+<lineToCover covered="true" lineNumber="18"/>
+<lineToCover covered="true" lineNumber="20"/>
+<lineToCover branchesToCover="4" covered="true" coveredBranches="2" lineNumber="21"/>
+</file>
+</coverage>
+

--- a/gcovr/tests/nested2/Makefile
+++ b/gcovr/tests/nested2/Makefile
@@ -5,7 +5,7 @@ all:
 	$(CXX) $(CFLAGS) -c subdir/B/main.cpp -o subdir/B/main.o
 	$(CXX) $(CFLAGS) subdir/B/main.o subdir/A/file1.o subdir/A/file2.o subdir/A/file3.o subdir/A/file4.o subdir/A/C/file5.o subdir/A/C/D/file6.o subdir/A/file7.o  -o subdir/B/testcase -lgcov
 
-run: txt xml html
+run: txt xml html sonarqube
 
 txt:
 	./subdir/B/testcase
@@ -19,8 +19,12 @@ html:
 	./subdir/B/testcase
 	$(GCOVR) -r subdir -d --html-details -o coverage.html
 
+sonarqube:
+	./subdir/B/testcase
+	$(GCOVR) -r subdir -d --sonarqube sonarqube.xml
+
 clean:
 	rm -f ./subdir/B/testcase subdir/lib.a
 	rm -f *.gc* */*.gc* */*/*.gc* */*/*/*.gc* */*/*/*/*.gc*
 	rm -f *.o */*.o */*/*.o */*/*/*.o */*/*/*/*.o
-	rm -f coverage.txt coverage.xml coverage*.html
+	rm -f coverage.txt coverage.xml coverage*.html sonarqube.xml

--- a/gcovr/tests/nested2/reference/sonarqube.xml
+++ b/gcovr/tests/nested2/reference/sonarqube.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" ?>
+<coverage version="1">
+<file path="A/C/D/file6.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="3"/>
+<lineToCover covered="false" lineNumber="4"/>
+<lineToCover covered="true" lineNumber="6"/>
+</file>
+<file path="A/C/file5.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="3"/>
+<lineToCover covered="false" lineNumber="4"/>
+<lineToCover covered="true" lineNumber="6"/>
+</file>
+<file path="A/file1.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="3"/>
+<lineToCover covered="false" lineNumber="4"/>
+<lineToCover covered="true" lineNumber="6"/>
+</file>
+<file path="A/file2.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover covered="true" lineNumber="3"/>
+<lineToCover covered="true" lineNumber="4"/>
+<lineToCover covered="true" lineNumber="5"/>
+<lineToCover covered="false" lineNumber="8"/>
+<lineToCover covered="false" lineNumber="10"/>
+<lineToCover covered="false" lineNumber="11"/>
+</file>
+<file path="A/file3.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover covered="true" lineNumber="3"/>
+<lineToCover covered="true" lineNumber="4"/>
+<lineToCover covered="true" lineNumber="5"/>
+<lineToCover covered="false" lineNumber="8"/>
+<lineToCover covered="false" lineNumber="10"/>
+<lineToCover branchesToCover="2" covered="false" coveredBranches="0" lineNumber="11"/>
+<lineToCover covered="false" lineNumber="12"/>
+<lineToCover covered="false" lineNumber="14"/>
+</file>
+<file path="A/file4.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="3"/>
+<lineToCover covered="true" lineNumber="4"/>
+<lineToCover covered="false" lineNumber="6"/>
+</file>
+<file path="A/file7.cpp">
+<lineToCover covered="false" lineNumber="1"/>
+<lineToCover covered="false" lineNumber="3"/>
+</file>
+<file path="B/main.cpp">
+<lineToCover covered="true" lineNumber="12"/>
+<lineToCover covered="true" lineNumber="13"/>
+<lineToCover covered="true" lineNumber="14"/>
+<lineToCover covered="true" lineNumber="15"/>
+<lineToCover covered="true" lineNumber="16"/>
+<lineToCover covered="true" lineNumber="17"/>
+<lineToCover covered="true" lineNumber="18"/>
+<lineToCover covered="true" lineNumber="20"/>
+<lineToCover branchesToCover="4" covered="true" coveredBranches="2" lineNumber="21"/>
+</file>
+</coverage>
+

--- a/gcovr/tests/nested3/Makefile
+++ b/gcovr/tests/nested3/Makefile
@@ -13,7 +13,7 @@ all:
 	cd subdir; $(CXX) $(CFLAGS) -c B/main.cpp -o ../objs/main.o
 	cd subdir; $(CXX) $(CFLAGS) ../objs/file1.o ../objs/file2.o ../objs/file3.o ../objs/file4.o ../objs/file5.o ../objs/file6.o ../objs/file7.o ../objs/main.o -o ./testcase
 
-run: txt xml html
+run: txt xml html sonarqube
 
 txt:
 	./subdir/testcase
@@ -27,8 +27,12 @@ html:
 	./subdir/testcase
 	$(GCOVR) -r subdir --object-directory objs -d --html-details -o coverage.html
 
+sonarqube:
+	./subdir/testcase
+	$(GCOVR) -r subdir --object-directory objs -d --sonarqube sonarqube.xml
+
 clean:
 	rm -f ./subdir/testcase
 	rm -f *.gc* */*.gc* */*/*.gc* */*/*/*.gc* */*/*/*/*.gc*
 	rm -f *.o */*.o */*/*.o */*/*/*.o */*/*/*/*.o
-	rm -f coverage.txt coverage.xml coverage*.html
+	rm -f coverage.txt coverage.xml coverage*.html sonarqube.xml

--- a/gcovr/tests/nested3/reference/sonarqube.xml
+++ b/gcovr/tests/nested3/reference/sonarqube.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" ?>
+<coverage version="1">
+<file path="A/C/D/file6.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="3"/>
+<lineToCover covered="false" lineNumber="4"/>
+<lineToCover covered="true" lineNumber="6"/>
+</file>
+<file path="A/C/file5.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="3"/>
+<lineToCover covered="false" lineNumber="4"/>
+<lineToCover covered="true" lineNumber="6"/>
+</file>
+<file path="A/file1.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="3"/>
+<lineToCover covered="false" lineNumber="4"/>
+<lineToCover covered="true" lineNumber="6"/>
+</file>
+<file path="A/file2.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover covered="true" lineNumber="3"/>
+<lineToCover covered="true" lineNumber="4"/>
+<lineToCover covered="true" lineNumber="5"/>
+<lineToCover covered="false" lineNumber="8"/>
+<lineToCover covered="false" lineNumber="10"/>
+<lineToCover covered="false" lineNumber="11"/>
+</file>
+<file path="A/file3.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover covered="true" lineNumber="3"/>
+<lineToCover covered="true" lineNumber="4"/>
+<lineToCover covered="true" lineNumber="5"/>
+<lineToCover covered="false" lineNumber="8"/>
+<lineToCover covered="false" lineNumber="10"/>
+<lineToCover branchesToCover="2" covered="false" coveredBranches="0" lineNumber="11"/>
+<lineToCover covered="false" lineNumber="12"/>
+<lineToCover covered="false" lineNumber="14"/>
+</file>
+<file path="A/file4.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="3"/>
+<lineToCover covered="true" lineNumber="4"/>
+<lineToCover covered="false" lineNumber="6"/>
+</file>
+<file path="A/file7.cpp">
+<lineToCover covered="false" lineNumber="1"/>
+<lineToCover covered="false" lineNumber="3"/>
+</file>
+<file path="B/main.cpp">
+<lineToCover covered="true" lineNumber="12"/>
+<lineToCover covered="true" lineNumber="13"/>
+<lineToCover covered="true" lineNumber="14"/>
+<lineToCover covered="true" lineNumber="15"/>
+<lineToCover covered="true" lineNumber="16"/>
+<lineToCover covered="true" lineNumber="17"/>
+<lineToCover covered="true" lineNumber="18"/>
+<lineToCover covered="true" lineNumber="20"/>
+<lineToCover branchesToCover="4" covered="true" coveredBranches="2" lineNumber="21"/>
+</file>
+</coverage>
+

--- a/gcovr/tests/nobranch/Makefile
+++ b/gcovr/tests/nobranch/Makefile
@@ -1,7 +1,7 @@
 all:
 	$(CXX) -fprofile-arcs -ftest-coverage -fPIC main.cpp -o testcase
 
-run: txt xml html
+run: txt xml html sonarqube
 
 txt:
 	./testcase
@@ -15,7 +15,11 @@ html:
 	./testcase
 	$(GCOVR) -d --fail-under-branch 100.0 --html-details -o coverage.html
 
+sonarqube:
+	./testcase
+	$(GCOVR) -d --fail-under-branch 100.0 --sonarqube sonarqube.xml
+
 clean:
 	rm -f testcase
 	rm -f *.gc*
-	rm -f coverage.txt coverage.xml coverage*.html
+	rm -f coverage.txt coverage.xml coverage*.html sonarqube.xml

--- a/gcovr/tests/nobranch/reference/sonarqube.xml
+++ b/gcovr/tests/nobranch/reference/sonarqube.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<coverage version="1">
+<file path="main.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover covered="true" lineNumber="2"/>
+</file>
+</coverage>
+

--- a/gcovr/tests/oos/Makefile
+++ b/gcovr/tests/oos/Makefile
@@ -6,7 +6,7 @@ all:
 	$(CXX) $(CFLAGS) -c src/main.cpp -o build/main.o
 	$(CXX) $(CFLAGS) build/main.o build/file1.o -o build/testcase
 
-run: txt xml html
+run: txt xml html sonarqube
 
 GCOVR_TEST_OPTIONS =
 
@@ -22,6 +22,10 @@ html:
 	build/testcase
 	$(GCOVR) $(GCOVR_TEST_OPTIONS) -d --html-details -o coverage.html
 
+sonarqube:
+	build/testcase
+	$(GCOVR) $(GCOVR_TEST_OPTIONS) -d --sonarqube sonarqube.xml
+
 clean:
 	rm -f build/*
-	rm -f coverage.txt coverage.xml coverage*.html
+	rm -f coverage.txt coverage.xml coverage*.html sonarqube.xml

--- a/gcovr/tests/oos/reference/sonarqube.xml
+++ b/gcovr/tests/oos/reference/sonarqube.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" ?>
+<coverage version="1">
+<file path="src/file1.cpp">
+<lineToCover covered="true" lineNumber="2"/>
+<lineToCover covered="true" lineNumber="4"/>
+</file>
+<file path="src/main.cpp">
+<lineToCover covered="true" lineNumber="5"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="6"/>
+<lineToCover covered="false" lineNumber="7"/>
+<lineToCover covered="true" lineNumber="9"/>
+<lineToCover covered="true" lineNumber="14"/>
+<lineToCover covered="true" lineNumber="15"/>
+<lineToCover covered="true" lineNumber="17"/>
+<lineToCover branchesToCover="4" covered="true" coveredBranches="2" lineNumber="18"/>
+</file>
+</coverage>
+

--- a/gcovr/tests/oos2/Makefile
+++ b/gcovr/tests/oos2/Makefile
@@ -6,7 +6,7 @@ all:
 	cd build; $(CXX) $(CFLAGS) -c ../src/main.cpp  -o main.o
 	cd build; $(CXX) $(CFLAGS) main.o file1.o -o testcase
 
-run: txt xml html
+run: txt xml html sonarqube
 
 GCOVR_TEST_OPTIONS = -r ../src .
 
@@ -22,6 +22,10 @@ html:
 	build/testcase
 	cd build; $(GCOVR) $(GCOVR_TEST_OPTIONS) -d --html-details -o ../coverage.html
 
+sonarqube:
+	build/testcase
+	cd build; $(GCOVR) $(GCOVR_TEST_OPTIONS) -d --sonarqube ../sonarqube.xml
+
 clean:
 	rm -f build/*
-	rm -f coverage.txt coverage.xml coverage*.html
+	rm -f coverage.txt coverage.xml coverage*.html sonarqube.xml

--- a/gcovr/tests/oos2/reference/sonarqube.xml
+++ b/gcovr/tests/oos2/reference/sonarqube.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" ?>
+<coverage version="1">
+<file path="file1.cpp">
+<lineToCover covered="true" lineNumber="2"/>
+<lineToCover covered="true" lineNumber="4"/>
+</file>
+<file path="main.cpp">
+<lineToCover covered="true" lineNumber="5"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="6"/>
+<lineToCover covered="false" lineNumber="7"/>
+<lineToCover covered="true" lineNumber="9"/>
+<lineToCover covered="true" lineNumber="14"/>
+<lineToCover covered="true" lineNumber="15"/>
+<lineToCover covered="true" lineNumber="17"/>
+<lineToCover branchesToCover="4" covered="true" coveredBranches="2" lineNumber="18"/>
+</file>
+</coverage>
+

--- a/gcovr/tests/print-summary/Makefile
+++ b/gcovr/tests/print-summary/Makefile
@@ -15,6 +15,8 @@ xml:
 
 html:
 
+sonarqube:
+
 clean:
 	rm -f testcase
 	rm -f *.gc*

--- a/gcovr/tests/shared_lib/Makefile
+++ b/gcovr/tests/shared_lib/Makefile
@@ -36,7 +36,7 @@ all:
 	$(CXX) $(CFLAGS) $(SOFLAGS) obj/libs.o -o lib/libs.$(DYNLIB_EXT)
 	$(MAKE) -C testApp
 
-run: txt xml html
+run: txt xml html sonarqube
 
 txt:
 ifeq ($(BASE_OS),MSYS_NT)
@@ -62,8 +62,16 @@ else
 endif
 	$(GCOVR) -d --html-details -o coverage.html
 
+sonarqube:
+ifeq ($(BASE_OS),MSYS_NT)
+	PATH="`pwd`/lib:${PATH}" testApp/test/a.out
+else
+	LD_LIBRARY_PATH=`pwd`/lib testApp/test/a.out
+endif
+	$(GCOVR) -d --sonarqube sonarqube.xml
+
 clean:
 	rm -rf obj
 	rm -f lib/*.$(DYNLIB_EXT)
-	rm -f coverage.xml coverage.txt coverage*.html
+	rm -f coverage.xml coverage.txt coverage*.html sonarqube.xml
 	$(MAKE) -C testApp clean

--- a/gcovr/tests/shared_lib/reference/sonarqube.xml
+++ b/gcovr/tests/shared_lib/reference/sonarqube.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" ?>
+<coverage version="1">
+<file path="lib/lib.cpp">
+<lineToCover covered="true" lineNumber="3"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="5"/>
+<lineToCover covered="true" lineNumber="6"/>
+<lineToCover covered="false" lineNumber="8"/>
+<lineToCover branchesToCover="4" covered="true" coveredBranches="2" lineNumber="9"/>
+</file>
+<file path="testApp/tmp.cpp">
+<lineToCover covered="true" lineNumber="3"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="5"/>
+<lineToCover covered="false" lineNumber="6"/>
+<lineToCover covered="true" lineNumber="8"/>
+<lineToCover covered="true" lineNumber="9"/>
+</file>
+</coverage>
+

--- a/gcovr/tests/simple1-stdout/Makefile
+++ b/gcovr/tests/simple1-stdout/Makefile
@@ -1,7 +1,7 @@
 all:
 	$(CXX) -fprofile-arcs -ftest-coverage -fPIC main.cpp -o testcase
 
-run: txt xml html
+run: txt xml html sonarqube
 
 txt:
 	./testcase
@@ -14,6 +14,9 @@ xml:
 html:
 	./testcase
 	$(GCOVR) -d --html-details > coverage.html
+
+sonarqube:
+	# pass
 
 clean:
 	rm -f testcase

--- a/gcovr/tests/simple1/Makefile
+++ b/gcovr/tests/simple1/Makefile
@@ -1,7 +1,7 @@
 all:
 	$(CXX) -fprofile-arcs -ftest-coverage -fPIC main.cpp -o testcase
 
-run: txt xml html
+run: txt xml html sonarqube
 
 txt:
 	./testcase
@@ -19,7 +19,11 @@ html:
 	./testcase
 	$(GCOVR) -d --html-details -o coverage.html
 
+sonarqube:
+	./testcase
+	$(GCOVR) -d --sonarqube sonarqube.xml
+
 clean:
 	rm -f testcase
 	rm -f *.gc*
-	rm -f coverage.txt coverage.xml coverage*.html
+	rm -f coverage.txt coverage.xml coverage*.html sonarqube.xml

--- a/gcovr/tests/simple1/reference/sonarqube.xml
+++ b/gcovr/tests/simple1/reference/sonarqube.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+<coverage version="1">
+<file path="main.cpp">
+<lineToCover covered="true" lineNumber="4"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="5"/>
+<lineToCover covered="false" lineNumber="6"/>
+<lineToCover covered="true" lineNumber="8"/>
+<lineToCover covered="true" lineNumber="13"/>
+<lineToCover covered="true" lineNumber="14"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="18"/>
+<lineToCover covered="false" lineNumber="19"/>
+<lineToCover covered="true" lineNumber="25"/>
+<lineToCover branchesToCover="4" covered="true" coveredBranches="2" lineNumber="26"/>
+</file>
+</coverage>
+

--- a/gcovr/tests/simple1/reference/sonarqube.xml
+++ b/gcovr/tests/simple1/reference/sonarqube.xml
@@ -6,9 +6,9 @@
 <lineToCover covered="false" lineNumber="6"/>
 <lineToCover covered="true" lineNumber="8"/>
 <lineToCover covered="true" lineNumber="13"/>
-<lineToCover covered="true" lineNumber="14"/>
+<lineToCover covered="true" lineNumber="17"/>
 <lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="18"/>
-<lineToCover covered="false" lineNumber="19"/>
+<lineToCover covered="false" lineNumber="22"/>
 <lineToCover covered="true" lineNumber="25"/>
 <lineToCover branchesToCover="4" covered="true" coveredBranches="2" lineNumber="26"/>
 </file>

--- a/gcovr/tests/sort-percentage/Makefile
+++ b/gcovr/tests/sort-percentage/Makefile
@@ -8,7 +8,7 @@ all:
 	$(CXX) $(CFLAGS) -c main.cpp -o main.o
 	$(CXX) $(CFLAGS) main.o file1.o file2.o file3.o file4.o -o testcase
 
-run: txt xml html
+run: txt xml html sonarqube
 
 GCOVR_TEST_OPTIONS = --sort-percentage
 
@@ -21,6 +21,9 @@ xml:
 html:
 	./testcase
 	$(GCOVR) $(GCOVR_TEST_OPTIONS) -d --html-details -o coverage.html
+
+sonarqube:
+	# pass
 
 clean:
 	rm -f testcase

--- a/gcovr/tests/sort-uncovered/Makefile
+++ b/gcovr/tests/sort-uncovered/Makefile
@@ -8,7 +8,7 @@ all:
 	$(CXX) $(CFLAGS) -c main.cpp -o main.o
 	$(CXX) $(CFLAGS) main.o file1.o file2.o file3.o file4.o -o testcase
 
-run: txt xml html
+run: txt xml html sonarqube
 
 GCOVR_TEST_OPTIONS = --sort-uncovered
 
@@ -21,6 +21,9 @@ xml:
 html:
 	./testcase
 	$(GCOVR) $(GCOVR_TEST_OPTIONS) -d --html-details -o coverage.html
+
+sonarqube:
+	# pass
 
 clean:
 	rm -f testcase

--- a/gcovr/tests/source-encoding-cp1252/Makefile
+++ b/gcovr/tests/source-encoding-cp1252/Makefile
@@ -1,7 +1,7 @@
 all:
 	$(CXX) -fprofile-arcs -ftest-coverage -fPIC --encoding cp1252 main.cpp -o testcase
 
-run: txt xml html
+run: txt xml html sonarqube
 
 txt:
 	# pass
@@ -12,6 +12,9 @@ xml:
 html:
 	./testcase
 	$(GCOVR) -d --html-details -o coverage.html --source-encoding cp1252
+
+sonarqube:
+	# pass
 
 clean:
 	rm -f testcase

--- a/gcovr/tests/source-encoding-utf8/Makefile
+++ b/gcovr/tests/source-encoding-utf8/Makefile
@@ -1,7 +1,7 @@
 all:
 	$(CXX) -fprofile-arcs -ftest-coverage -fPIC main.cpp -o testcase
 
-run: txt xml html
+run: txt xml html sonarqube
 
 txt:
 	# pass
@@ -12,6 +12,9 @@ xml:
 html:
 	./testcase
 	$(GCOVR) -d --html-details -o coverage.html --source-encoding utf8
+
+sonarqube:
+	# pass
 
 clean:
 	rm -f testcase

--- a/gcovr/tests/test_gcovr.py
+++ b/gcovr/tests/test_gcovr.py
@@ -85,19 +85,21 @@ def find_reference_files(pattern):
 SCRUBBERS = dict(
     txt=scrub_txt,
     xml=scrub_xml,
-    html=scrub_html)
+    html=scrub_html,
+    sonarqube=scrub_xml)
 
 OUTPUT_PATTERN = dict(
     txt='coverage.txt',
     xml='coverage.xml',
-    html='coverage*.html')
+    html='coverage*.html',
+    sonarqube='sonarqube.xml')
 
 ASSERT_EQUALS = dict(
     xml=assert_xml_equals)
 
 
 @pytest.mark.parametrize('name', findtests(basedir))
-@pytest.mark.parametrize('format', ['txt', 'xml', 'html'])
+@pytest.mark.parametrize('format', ['txt', 'xml', 'html', 'sonarqube'])
 def test_build(name, format):
     scrub = SCRUBBERS[format]
     output_pattern = OUTPUT_PATTERN[format]

--- a/gcovr/tests/threaded/Makefile
+++ b/gcovr/tests/threaded/Makefile
@@ -11,7 +11,7 @@ all:
 	$(CXX) $(CFLAGS) -c subdir/B/main.cpp -o subdir/B/main.o
 	$(CXX) $(CFLAGS) subdir/A/file1.o subdir/A/file2.o subdir/A/file3.o subdir/A/file4.o subdir/A/C/file5.o subdir/A/C/D/file6.o subdir/A/file7.o subdir/B/main.o -o subdir/testcase
 
-run: txt xml html
+run: txt xml html sonarqube
 
 txt:
 	./subdir/testcase
@@ -25,8 +25,12 @@ html:
 	./subdir/testcase
 	$(GCOVR) -j 4 -r subdir -d --html-details -o coverage.html
 
+sonarqube:
+	./subdir/testcase
+	$(GCOVR) -j 4 -r subdir -d --sonarqube sonarqube.xml
+
 clean:
 	rm -f ./subdir/testcase
 	rm -f *.gc* */*.gc* */*/*.gc* */*/*/*.gc* */*/*/*/*.gc*
 	rm -f *.o */*.o */*/*.o */*/*/*.o */*/*/*/*.o
-	rm -f coverage.txt coverage.xml coverage*.html
+	rm -f coverage.txt coverage.xml coverage*.html sonarqube.xml

--- a/gcovr/tests/threaded/reference/sonarqube.xml
+++ b/gcovr/tests/threaded/reference/sonarqube.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" ?>
+<coverage version="1">
+<file path="A/C/D/file6.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="3"/>
+<lineToCover covered="false" lineNumber="4"/>
+<lineToCover covered="true" lineNumber="6"/>
+</file>
+<file path="A/C/file5.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="3"/>
+<lineToCover covered="false" lineNumber="4"/>
+<lineToCover covered="true" lineNumber="6"/>
+</file>
+<file path="A/file1.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="3"/>
+<lineToCover covered="false" lineNumber="4"/>
+<lineToCover covered="true" lineNumber="6"/>
+</file>
+<file path="A/file2.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover covered="true" lineNumber="3"/>
+<lineToCover covered="true" lineNumber="4"/>
+<lineToCover covered="true" lineNumber="5"/>
+<lineToCover covered="false" lineNumber="8"/>
+<lineToCover covered="false" lineNumber="10"/>
+<lineToCover covered="false" lineNumber="11"/>
+</file>
+<file path="A/file3.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover covered="true" lineNumber="3"/>
+<lineToCover covered="true" lineNumber="4"/>
+<lineToCover covered="true" lineNumber="5"/>
+<lineToCover covered="false" lineNumber="8"/>
+<lineToCover covered="false" lineNumber="10"/>
+<lineToCover branchesToCover="2" covered="false" coveredBranches="0" lineNumber="11"/>
+<lineToCover covered="false" lineNumber="12"/>
+<lineToCover covered="false" lineNumber="14"/>
+</file>
+<file path="A/file4.cpp">
+<lineToCover covered="true" lineNumber="1"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="3"/>
+<lineToCover covered="true" lineNumber="4"/>
+<lineToCover covered="false" lineNumber="6"/>
+</file>
+<file path="A/file7.cpp">
+<lineToCover covered="false" lineNumber="1"/>
+<lineToCover covered="false" lineNumber="3"/>
+</file>
+<file path="B/main.cpp">
+<lineToCover covered="true" lineNumber="12"/>
+<lineToCover covered="true" lineNumber="13"/>
+<lineToCover covered="true" lineNumber="14"/>
+<lineToCover covered="true" lineNumber="15"/>
+<lineToCover covered="true" lineNumber="16"/>
+<lineToCover covered="true" lineNumber="17"/>
+<lineToCover covered="true" lineNumber="18"/>
+<lineToCover covered="true" lineNumber="20"/>
+<lineToCover branchesToCover="4" covered="true" coveredBranches="2" lineNumber="21"/>
+</file>
+</coverage>
+

--- a/gcovr/tests/update-data/Makefile
+++ b/gcovr/tests/update-data/Makefile
@@ -3,7 +3,7 @@ all:
 	$(CC) -fprofile-arcs -ftest-coverage -fPIC -c update-data.c -o update-data.o
 	$(CXX) -fprofile-arcs -ftest-coverage -fPIC -o testcase main.o update-data.o
 
-run: txt xml html
+run: txt xml html sonarqube
 
 txt:
 	./testcase
@@ -17,8 +17,12 @@ html:
 	./testcase
 	$(GCOVR) -d --html-details -o coverage.html
 
+sonarqube:
+	./testcase
+	$(GCOVR) -d --sonarqube sonarqube.xml
+
 clean:
 	rm -f testcase
 	rm -f *.gc*
 	rm -f *.o
-	rm -f coverage.txt coverage.xml coverage*.html
+	rm -f coverage.txt coverage.xml coverage*.html sonarqube.xml

--- a/gcovr/tests/update-data/reference/sonarqube.xml
+++ b/gcovr/tests/update-data/reference/sonarqube.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" ?>
+<coverage version="1">
+<file path="main.cpp">
+<lineToCover covered="true" lineNumber="3"/>
+<lineToCover covered="true" lineNumber="5"/>
+<lineToCover covered="true" lineNumber="6"/>
+<lineToCover covered="true" lineNumber="7"/>
+</file>
+<file path="update-data.c">
+<lineToCover covered="true" lineNumber="3"/>
+<lineToCover covered="true" lineNumber="5"/>
+</file>
+<file path="update-data.h">
+<lineToCover covered="true" lineNumber="7"/>
+<lineToCover covered="true" lineNumber="9"/>
+<lineToCover covered="true" lineNumber="12"/>
+<lineToCover covered="true" lineNumber="14"/>
+<lineToCover covered="true" lineNumber="17"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="2" lineNumber="19"/>
+<lineToCover covered="true" lineNumber="20"/>
+<lineToCover covered="true" lineNumber="23"/>
+</file>
+</coverage>
+

--- a/gcovr/tests/use-existing/Makefile
+++ b/gcovr/tests/use-existing/Makefile
@@ -3,7 +3,7 @@ GCOV ?= gcov
 all:
 	$(CXX) -fprofile-arcs -ftest-coverage -fPIC main.cpp -o testcase
 
-run: txt xml html
+run: txt xml html sonarqube
 
 txt:
 	./testcase
@@ -20,7 +20,12 @@ html:
 	$(GCOV) *.gcda --branch-counts --branch-probabilities --preserve-paths
 	$(GCOVR) -v -g -d --html-details -o coverage.html
 
+sonarqube:
+	./testcase
+	$(GCOV) *.gcda --branch-counts --branch-probabilities --preserve-paths
+	$(GCOVR) -v -g -d --sonarqube sonarqube.xml
+
 clean:
 	rm -f testcase
 	rm -f *.gc*
-	rm -f coverage.txt coverage.xml coverage*.html
+	rm -f coverage.txt coverage.xml coverage*.html sonarqube.xml

--- a/gcovr/tests/use-existing/reference/sonarqube.xml
+++ b/gcovr/tests/use-existing/reference/sonarqube.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+<coverage version="1">
+<file path="main.cpp">
+<lineToCover covered="true" lineNumber="4"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="5"/>
+<lineToCover covered="false" lineNumber="6"/>
+<lineToCover covered="true" lineNumber="8"/>
+<lineToCover covered="true" lineNumber="13"/>
+<lineToCover covered="true" lineNumber="14"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="18"/>
+<lineToCover covered="false" lineNumber="19"/>
+<lineToCover covered="true" lineNumber="25"/>
+<lineToCover branchesToCover="4" covered="true" coveredBranches="2" lineNumber="26"/>
+</file>
+</coverage>
+

--- a/gcovr/tests/use-existing/reference/sonarqube.xml
+++ b/gcovr/tests/use-existing/reference/sonarqube.xml
@@ -8,7 +8,7 @@
 <lineToCover covered="true" lineNumber="13"/>
 <lineToCover covered="true" lineNumber="17"/>
 <lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="18"/>
-<lineToCover covered="false" lineNumber="22/>
+<lineToCover covered="false" lineNumber="22"/>
 <lineToCover covered="true" lineNumber="25"/>
 <lineToCover branchesToCover="4" covered="true" coveredBranches="2" lineNumber="26"/>
 </file>

--- a/gcovr/tests/use-existing/reference/sonarqube.xml
+++ b/gcovr/tests/use-existing/reference/sonarqube.xml
@@ -6,9 +6,9 @@
 <lineToCover covered="false" lineNumber="6"/>
 <lineToCover covered="true" lineNumber="8"/>
 <lineToCover covered="true" lineNumber="13"/>
-<lineToCover covered="true" lineNumber="14"/>
+<lineToCover covered="true" lineNumber="17"/>
 <lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="18"/>
-<lineToCover covered="false" lineNumber="19"/>
+<lineToCover covered="false" lineNumber="22/>
 <lineToCover covered="true" lineNumber="25"/>
 <lineToCover branchesToCover="4" covered="true" coveredBranches="2" lineNumber="26"/>
 </file>

--- a/gcovr/tests/wspace/Makefile
+++ b/gcovr/tests/wspace/Makefile
@@ -1,7 +1,7 @@
 all:
 	cd 'src code'; $(CXX) -fprofile-arcs -ftest-coverage -fPIC main.cpp -o testcase
 
-run: txt xml html
+run: txt xml html sonarqube
 
 txt:
 	cd 'src code'; ./testcase
@@ -15,7 +15,11 @@ html:
 	cd 'src code'; ./testcase
 	$(GCOVR) -r 'src code' -d --html-details -o coverage.html
 
+sonarqube:
+	cd 'src code'; ./testcase
+	$(GCOVR) -r 'src code' -d --sonarqube sonarqube.xml
+
 clean:
 	rm -f */testcase
 	rm -f */*.gc*
-	rm -f coverage.txt coverage.xml coverage*.html
+	rm -f coverage.txt coverage.xml coverage*.html sonarqube.xml

--- a/gcovr/tests/wspace/reference/sonarqube.xml
+++ b/gcovr/tests/wspace/reference/sonarqube.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+<coverage version="1">
+<file path="main.cpp">
+<lineToCover covered="true" lineNumber="4"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="5"/>
+<lineToCover covered="false" lineNumber="6"/>
+<lineToCover covered="true" lineNumber="8"/>
+<lineToCover covered="true" lineNumber="13"/>
+<lineToCover covered="true" lineNumber="14"/>
+<lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="18"/>
+<lineToCover covered="false" lineNumber="19"/>
+<lineToCover covered="true" lineNumber="25"/>
+<lineToCover branchesToCover="4" covered="true" coveredBranches="2" lineNumber="26"/>
+</file>
+</coverage>
+

--- a/gcovr/tests/wspace/reference/sonarqube.xml
+++ b/gcovr/tests/wspace/reference/sonarqube.xml
@@ -6,9 +6,9 @@
 <lineToCover covered="false" lineNumber="6"/>
 <lineToCover covered="true" lineNumber="8"/>
 <lineToCover covered="true" lineNumber="13"/>
-<lineToCover covered="true" lineNumber="14"/>
+<lineToCover covered="true" lineNumber="17"/>
 <lineToCover branchesToCover="2" covered="true" coveredBranches="1" lineNumber="18"/>
-<lineToCover covered="false" lineNumber="19"/>
+<lineToCover covered="false" lineNumber="22"/>
 <lineToCover covered="true" lineNumber="25"/>
 <lineToCover branchesToCover="4" covered="true" coveredBranches="2" lineNumber="26"/>
 </file>


### PR DESCRIPTION
Add command line option '--sonarqube' with output report file name to generate sonarqube generic coverage report as described in https://docs.sonarqube.org/latest/analysis/generic-test/