### PR TITLE
Change relative imports to absolute imports.

### DIFF
--- a/gcovr/__main__.py
+++ b/gcovr/__main__.py
@@ -39,22 +39,22 @@ from os.path import normpath
 from tempfile import mkdtemp
 from shutil import rmtree
 
-from .configuration import (
+from configuration import (
     argument_parser_setup, merge_options_and_set_defaults,
     parse_config_file, parse_config_into_dict, OutputOrDefault)
-from .gcov import (find_existing_gcov_files, find_datafiles,
+from gcov import (find_existing_gcov_files, find_datafiles,
                    process_existing_gcov_file, process_datafile)
-from .utils import (get_global_stats, AlwaysMatchFilter,
+from utils import (get_global_stats, AlwaysMatchFilter,
                     DirectoryPrefixFilter, Logger)
-from .version import __version__
-from .workers import Workers
+from version import __version__
+from workers import Workers
 
 # generators
-from .cobertura_xml_generator import print_xml_report
-from .html_generator import print_html_report
-from .txt_generator import print_text_report
-from .summary_generator import print_summary
-from .sonarqube_generator import print_sonarqube_report
+from cobertura_xml_generator import print_xml_report
+from html_generator import print_html_report
+from txt_generator import print_text_report
+from summary_generator import print_summary
+from sonarqube_generator import print_sonarqube_report
 
 
 #

--- a/gcovr/cobertura_xml_generator.py
+++ b/gcovr/cobertura_xml_generator.py
@@ -10,8 +10,8 @@ import time
 
 from lxml import etree
 
-from .version import __version__
-from .utils import open_binary_for_writing, presentable_filename
+from version import __version__
+from utils import open_binary_for_writing, presentable_filename
 
 
 def print_xml_report(covdata, output_file, options):

--- a/gcovr/configuration.py
+++ b/gcovr/configuration.py
@@ -16,7 +16,7 @@ import os
 import re
 import sys
 
-from .utils import FilterOption
+from utils import FilterOption
 
 try:
     from typing import Iterable, Any

--- a/gcovr/coverage.py
+++ b/gcovr/coverage.py
@@ -6,7 +6,7 @@
 # Copyright 2013 Sandia Corporation
 # This software is distributed under the BSD license.
 
-from .utils import calculate_coverage
+from utils import calculate_coverage
 
 # for type annotations:
 if False: from typing import (  # noqa, pylint: disable=all

--- a/gcovr/gcov.py
+++ b/gcovr/gcov.py
@@ -12,9 +12,9 @@ import subprocess
 import sys
 import io
 
-from .utils import search_file, Logger, commonpath
-from .workers import locked_directory
-from .coverage import FileCoverage
+from utils import search_file, Logger, commonpath
+from workers import locked_directory
+from coverage import FileCoverage
 
 output_re = re.compile(r"[Cc]reating [`'](.*)'$")
 source_re = re.compile(r"[Cc](annot|ould not) open (source|graph|output) file")

--- a/gcovr/html_generator.py
+++ b/gcovr/html_generator.py
@@ -13,9 +13,9 @@ import datetime
 import zlib
 import io
 
-from .version import __version__
-from .utils import commonpath, sort_coverage
-from .coverage import FileCoverage
+from version import __version__
+from utils import commonpath, sort_coverage
+from coverage import FileCoverage
 
 
 class lazy(object):

--- a/gcovr/sonarqube_generator.py
+++ b/gcovr/sonarqube_generator.py
@@ -8,7 +8,7 @@
 
 from lxml import etree
 
-from .utils import open_binary_for_writing, presentable_filename
+from utils import open_binary_for_writing, presentable_filename
 
 
 def print_sonarqube_report(covdata, output_file, options):

--- a/gcovr/summary_generator.py
+++ b/gcovr/summary_generator.py
@@ -12,7 +12,7 @@ Generator of the coverage summary.
 
 import sys
 
-from .utils import get_global_stats
+from utils import get_global_stats
 
 
 def print_summary(covdata):

--- a/gcovr/txt_generator.py
+++ b/gcovr/txt_generator.py
@@ -8,7 +8,7 @@
 
 import sys
 
-from .utils import calculate_coverage, sort_coverage, presentable_filename
+from utils import calculate_coverage, sort_coverage, presentable_filename
 
 
 def print_text_report(covdata, output_file, options):


### PR DESCRIPTION
PEP8:
> Absolute imports are recommended, as they are usually more readable and tend to be better behaved (or at least give better error messages)...

Also something like `python gcovr\gcovr\__main__.py --version` will not work with relative imports.
