### PR TITLE
Extensions and fixes for json_generator

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -12,7 +12,7 @@ The following developers contributed to gcovr (ordered alphabetically):
     Attie Grande,
     Bernhard Breinbauer,
     Carlos Jenkins,
-    Cezary Gapiński
+    Cezary Gapiński,
     Christian Taedcke,
     Dave George,
     Dom Postorivo,

--- a/doc/source/guide.rst
+++ b/doc/source/guide.rst
@@ -339,6 +339,11 @@ Next, merge the json files and generate the desired report::
 
     gcovr --add-tracefile run-1.json --add-tracefile run-2.json --html-details coverage.html
 
+You can also use unix style wildcards to merge the json files without
+duplicating :option:`gcovr --add-tracefile`. With this option you have to
+place your pathnames with wildcards in double quotation marks::
+
+    gcovr --add-tracefile "run-*.json" --html-details coverage.html
 
 The gcovr Command
 -----------------

--- a/gcovr/__main__.py
+++ b/gcovr/__main__.py
@@ -38,6 +38,7 @@ from argparse import ArgumentParser
 from os.path import normpath
 from tempfile import mkdtemp
 from shutil import rmtree
+from glob import glob
 
 from .configuration import (
     argument_parser_setup, merge_options_and_set_defaults,
@@ -259,13 +260,17 @@ def main(args=None):
 def collect_coverage_from_tracefiles(covdata, options, logger):
     datafiles = set()
 
-    for trace_file in options.add_tracefile:
-        if not os.path.exists(normpath(trace_file)):
+    for trace_files_regex in options.add_tracefile:
+        trace_files = glob(trace_files_regex, recursive=True)
+        if not trace_files:
             logger.error(
                 "Bad --add-tracefile option.\n"
                 "\tThe specified file does not exist.")
             sys.exit(1)
-        datafiles.add(trace_file)
+        else:
+            for trace_file in trace_files:
+                datafiles.add(normpath(trace_file))
+
     options.root_dir = os.path.abspath(options.root)
     gcovr_json_files_to_coverage(datafiles, covdata, options)
 

--- a/gcovr/configuration.py
+++ b/gcovr/configuration.py
@@ -421,6 +421,9 @@ GCOVR_CONFIG_OPTIONS = [
              "Coverage files contains source files structure relative "
              "to root directory. Those structures are combined "
              "in the output relative to the current root directory. "
+             "Unix style wildcards can be used to add the pathnames "
+             "matching a specified pattern. In this case pattern "
+             "must be set in double quotation marks. "
              "Option can be specified multiple times. "
              "When option is used gcov is not run to collect "
              "the new coverage data.",

--- a/gcovr/json_generator.py
+++ b/gcovr/json_generator.py
@@ -41,8 +41,8 @@ def print_json_report(covdata, output_file, options):
     else:
         write_json = functools.partial(write_json, sort_keys=True)
 
-    if options.output:
-        with open(options.output, 'w') as output:
+    if output_file is not None:
+        with open(output_file, 'w') as output:
             write_json(gcovr_json_root, output)
     else:
         write_json(gcovr_json_root, sys.stdout)

--- a/gcovr/tests/add_coverages/Makefile
+++ b/gcovr/tests/add_coverages/Makefile
@@ -31,7 +31,7 @@ sonarqube: json_foo json_bar
 	$(GCOVR) -a coverage_foo.json -a coverage_bar.json --sonarqube sonarqube.xml
 
 json: json_foo json_bar
-	$(GCOVR) -a coverage_foo.json -a coverage_bar.json --json-pretty -o coverage.json
+	$(GCOVR) -a 'coverage_*.json' --json-pretty -o coverage.json
 
 clean:
 	rm -f testcase_*

--- a/gcovr/tests/add_coverages/Makefile
+++ b/gcovr/tests/add_coverages/Makefile
@@ -16,7 +16,7 @@ json_foo:
 
 json_bar:
 	./testcase_bar
-	$(GCOVR) -d --json -o coverage_bar.json
+	$(GCOVR) -d --json coverage_bar.json
 
 txt: json_foo json_bar
 	$(GCOVR) -a coverage_foo.json -a coverage_bar.json -o coverage.txt


### PR DESCRIPTION
In this PR I try to:
- solve problem with generating output report when '--output' option is missing for json_generator
- add feature suggested in issue #338 about adding wildcards to '--add-tracefile' option

I need a review for the second feature, because I am not sure whether is correctly implemented or should be done totally different.