### PR TITLE
Set make variable TEST_OPTS as environment variable inside docker.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,10 @@ test:
 doc:
 	cd doc && make html O=-W
 
+docker-qa: export TEST_OPTS := $(TEST_OPTS)
+
 docker-qa: | docker-qa-build
-	docker run --rm -v `pwd`:/gcovr $(QA_CONTAINER)
+	docker run --rm -e TEST_OPTS -v `pwd`:/gcovr $(QA_CONTAINER)
 
 docker-qa-build: admin/Dockerfile.qa requirements.txt doc/requirements.txt
 	docker build --tag $(QA_CONTAINER) --file admin/Dockerfile.qa .


### PR DESCRIPTION
To get the full assertion text or run a specific test you have to set TEST_OPTS. This is not possible if test run inside the docker container.
The option is set as environment variable which is used by the make inside docker.