### PR TITLE
Add --csv output

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,7 @@ The ``gcovr`` command can produce different kinds of coverage reports:
 -  ``--xml``: machine readable XML reports in Cobertura_ format
 -  ``--sonarqube``: machine readable XML reports in Sonarqube format
 -  ``--json``: JSON report with source files structure and coverage
+-  ``--csv``: CSV report summarizing the coverage of each file
 
 Thus, gcovr can be viewed
 as a command-line alternative to the lcov_ utility, which runs gcov

--- a/gcovr/__main__.py
+++ b/gcovr/__main__.py
@@ -55,6 +55,7 @@ from .workers import Workers
 from .cobertura_xml_generator import print_xml_report
 from .html_generator import print_html_report
 from .txt_generator import print_text_report
+from .csv_generator import print_csv_report
 from .summary_generator import print_summary
 from .sonarqube_generator import print_sonarqube_report
 from .json_generator import print_json_report
@@ -368,6 +369,14 @@ def print_reports(covdata, options, logger):
             lambda: logger.warn(
                 "JSON output skipped - "
                 "consider providing output file with `--json=OUTPUT`.")))
+
+    if options.csv:
+        generators.append((
+            [options.csv],
+            print_csv_report,
+            lambda: logger.warn(
+                "CSV output skipped - "
+                "consider providing output file with `--csv=OUTPUT`.")))
 
     reports_were_written = False
     default_output = OutputOrDefault(options.output)

--- a/gcovr/configuration.py
+++ b/gcovr/configuration.py
@@ -683,6 +683,17 @@ GCOVR_CONFIG_OPTIONS = [
         action="store_true",
     ),
     GcovrConfigOption(
+        "csv", ["--csv"],
+        group="output_options",
+        metavar='OUTPUT',
+        help="Generate a CSV summary report. "
+             "OUTPUT is optional and defaults to --output.",
+        nargs='?',
+        type=OutputOrDefault,
+        default=None,
+        const=OutputOrDefault(None),
+    ),
+    GcovrConfigOption(
         "filter", ["-f", "--filter"],
         group="filter_options",
         help="Keep only source files that match this filter. "

--- a/gcovr/csv_generator.py
+++ b/gcovr/csv_generator.py
@@ -1,0 +1,47 @@
+# -*- coding:utf-8 -*-
+
+# This file is part of gcovr <http://gcovr.com/>.
+#
+# Copyright 2013-2018 the gcovr authors
+# Copyright 2013 Sandia Corporation
+# This software is distributed under the BSD license.
+
+import sys
+import csv
+
+from .utils import sort_coverage, presentable_filename
+
+
+def print_csv_report(covdata, output_file, options):
+    """produce gcovr csv report"""
+    if output_file:
+        with open(output_file, 'w') as fh:
+            _real_print_csv_report(covdata, fh, options)
+    else:
+        _real_print_csv_report(covdata, sys.stdout, options)
+
+
+def _real_print_csv_report(covdata, OUTPUT, options):
+    keys = sort_coverage(
+        covdata, show_branch=options.show_branch,
+        by_num_uncovered=options.sort_uncovered,
+        by_percent_uncovered=options.sort_percent)
+
+    def fixup_percent(percent):
+        # output csv percent values in range [0,1.0]
+        return percent / 100 if percent is not None else None
+
+    def _summarize_file_coverage(coverage):
+        filename = presentable_filename(
+            coverage.filename, root_filter=options.root_filter)
+
+        branch_total, branch_covered, branch_percent = coverage.branch_coverage()
+        line_total, line_covered, line_percent = coverage.line_coverage()
+        return (filename, line_total, line_covered, fixup_percent(line_percent),
+                branch_total, branch_covered, fixup_percent(branch_percent))
+
+    writer = csv.writer(OUTPUT)
+    writer.writerow(('filename', 'line_total', 'line_covered', 'line_percent',
+                     'branch_total', 'branch_covered', 'branch_percent'))
+    for key in keys:
+        writer.writerow(_summarize_file_coverage(covdata[key]))

--- a/gcovr/tests/csv/Makefile
+++ b/gcovr/tests/csv/Makefile
@@ -1,0 +1,28 @@
+all:
+	$(CXX) -fprofile-arcs -ftest-coverage -fPIC main.cpp -o testcase
+
+run: csv txt xml html sonarqube json
+
+csv:
+	./testcase
+	$(GCOVR) -d --csv -o coverage.csv
+
+txt:
+	# pass
+
+xml:
+	# pass
+
+html:
+	# pass
+
+sonarqube:
+	# pass
+
+json:
+	# pass
+
+clean:
+	rm -f testcase
+	rm -f *.gc*
+	#rm -f coverage*.csv

--- a/gcovr/tests/csv/coverage.csv
+++ b/gcovr/tests/csv/coverage.csv
@@ -1,0 +1,2 @@
+filename,line_total,line_covered,line_percent,branch_total,branch_covered,branch_percent
+main.cpp,2,2,1.0,0,0,

--- a/gcovr/tests/csv/main.cpp
+++ b/gcovr/tests/csv/main.cpp
@@ -1,0 +1,4 @@
+
+int main() {
+    return 0;
+}

--- a/gcovr/tests/csv/reference/coverage.csv
+++ b/gcovr/tests/csv/reference/coverage.csv
@@ -1,0 +1,2 @@
+filename,line_total,line_covered,line_percent,branch_total,branch_covered,branch_percent
+main.cpp,2,2,1.0,0,0,

--- a/gcovr/tests/test_gcovr.py
+++ b/gcovr/tests/test_gcovr.py
@@ -39,6 +39,14 @@ def scrub_txt(contents):
     return RE_TXT_WHITESPACE.sub('', contents)
 
 
+def scrub_csv(contents):
+    contents = contents.replace("\r", "")
+    contents = contents.replace("\n\n", "\n")
+    # Replace windows file separator for html reports generated in Windows
+    contents = contents.replace('\\', '/')
+    return contents
+
+
 def scrub_xml(contents):
     contents = RE_DECIMAL.sub(lambda m: str(round(float(m.group(1)), 5)), contents)
     contents = RE_XML_ATTRS.sub(r'\1=""', contents)
@@ -96,7 +104,7 @@ def compiled(request, name):
     assert run(['make', 'clean'], cwd=path)
 
 
-KNOWN_FORMATS = ['txt', 'xml', 'html', 'sonarqube', 'json']
+KNOWN_FORMATS = ['txt', 'xml', 'html', 'sonarqube', 'json', 'csv']
 
 
 def pytest_generate_tests(metafunc):
@@ -178,14 +186,16 @@ SCRUBBERS = dict(
     xml=scrub_xml,
     html=scrub_html,
     sonarqube=scrub_xml,
-    json=lambda x: x)
+    json=lambda x: x,
+    csv=scrub_csv)
 
 OUTPUT_PATTERN = dict(
     txt='coverage.txt',
     xml='coverage.xml',
     html='coverage*.html',
     sonarqube='sonarqube.xml',
-    json='coverage*.json')
+    json='coverage*.json',
+    csv='coverage.csv')
 
 ASSERT_EQUALS = dict(
     xml=assert_xml_equals,


### PR DESCRIPTION
This adds a summarized CSV output format.
It includes only the totals/covered/percent per file, without details on the covered lines/branches.
