### PR TITLE
Compare paths case insensitive #329

### DIFF
--- a/gcovr/tests/exclude-relative/Makefile
+++ b/gcovr/tests/exclude-relative/Makefile
@@ -9,7 +9,9 @@ run: txt xml html sonarqube
 
 coverage.json:
 	./testcase
-	$(GCOVR) -e 'file1.cpp'  --json $@  # use a relative filter here
+	# use a relative filter here
+	# if testcase.exe exists (windows) use wrong case to check caseinsensitive filter
+	$(GCOVR) -e '$(if $(wildcard ./testcase.exe),File1.cpp,file1.cpp)'  --json $@
 
 txt: coverage.json
 	$(GCOVR) -a $< -o coverage.txt

--- a/gcovr/utils.py
+++ b/gcovr/utils.py
@@ -181,7 +181,9 @@ FilterOption.NonEmpty = NonEmptyFilterOption
 class Filter(object):
     def __init__(self, pattern):
         cwd = os.getcwd()
-        is_fs_case_insensitive = os.path.exists(cwd.upper()) and os.path.exists(cwd.lower())
+        # Gueesing if file system is case insensitive.
+        # The working directory is not the root and accessable in upper and lower case.
+        is_fs_case_insensitive = ( cwd != os.path.sep ) and os.path.exists(cwd.upper()) and os.path.exists(cwd.lower())
         flags = 0
         if is_fs_case_insensitive:
             flags |= re.IGNORECASE

--- a/gcovr/utils.py
+++ b/gcovr/utils.py
@@ -181,12 +181,10 @@ FilterOption.NonEmpty = NonEmptyFilterOption
 class Filter(object):
     def __init__(self, pattern):
         cwd = os.getcwd()
-        # Gueesing if file system is case insensitive.
-        # The working directory is not the root and accessable in upper and lower case.
+        # Guessing if file system is case insensitive.
+        # The working directory is not the root and accessible in upper and lower case.
         is_fs_case_insensitive = ( cwd != os.path.sep ) and os.path.exists(cwd.upper()) and os.path.exists(cwd.lower())
-        flags = 0
-        if is_fs_case_insensitive:
-            flags |= re.IGNORECASE
+        flags = re.IGNORECASE if is_fs_case_insensitive else 0
         self.pattern = re.compile(pattern, flags)
 
     def match(self, path):

--- a/gcovr/utils.py
+++ b/gcovr/utils.py
@@ -183,7 +183,7 @@ class Filter(object):
         cwd = os.getcwd()
         # Guessing if file system is case insensitive.
         # The working directory is not the root and accessible in upper and lower case.
-        is_fs_case_insensitive = ( cwd != os.path.sep ) and os.path.exists(cwd.upper()) and os.path.exists(cwd.lower())
+        is_fs_case_insensitive = (cwd != os.path.sep) and os.path.exists(cwd.upper()) and os.path.exists(cwd.lower())
         flags = re.IGNORECASE if is_fs_case_insensitive else 0
         self.pattern = re.compile(pattern, flags)
 

--- a/gcovr/utils.py
+++ b/gcovr/utils.py
@@ -180,7 +180,12 @@ FilterOption.NonEmpty = NonEmptyFilterOption
 
 class Filter(object):
     def __init__(self, pattern):
-        self.pattern = re.compile(pattern)
+        cwd = os.getcwd()
+        is_fs_case_insensitive = os.path.exists(cwd.upper()) and os.path.exists(cwd.lower())
+        flags = 0
+        if is_fs_case_insensitive:
+            flags |= re.IGNORECASE
+        self.pattern = re.compile(pattern, flags)
 
     def match(self, path):
         os_independent_path = path.replace(os.path.sep, '/')


### PR DESCRIPTION
If HOME directory is case insensitive the pattern match is also done case insensitive.
Test for exclude filter adapted to give filename with wrong case if testcase.exe exists in filesystem.