### PR TITLE
Extend test framework for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
 script:
 - test -z "$RUN_LINTER" || make lint
 - test -z "$RUN_LINTER" || admin/release_checklist --no-verify-tags --no-verify-docs-next-version 4.2
-- make test TEST_OPTS="$COVERAGE_OPTS"
+- make test TEST_OPTS="$COVERAGE_OPTS --archive_differences"
 - test -z "$COVERAGE_OPTS" || codecov -X gcov search
 - test -z "$BUILD_DOCS" || make doc
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,11 @@ Internal changes:
  - Extend tests to use an unified diff in the assert. Add test options `--generate-reference`,
    `--update_reference` and `--skip_clean`. (:issue:`374`)
  - Set make variable TEST_OPTS as environment variable inside docker. (:issue: `372`)
+ - Extend test framework for CI (:issue:`392`):
+
+   - Extend test option `--update_reference` for all formats.
+   - New option `--archive_differences` to save the different files as ZIP.
+     Use this ZIP as artifact in AppVeyor.
 
 4.2 (6 November 2019)
 ---------------------

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,9 +28,11 @@ install:
 build: off
 
 test_script:
-  - '%MAKE% test PYTHON=python TEST_OPTS="--cov=gcovr --cov-branch"'
+  - '%MAKE% test PYTHON=python TEST_OPTS="--cov=gcovr --cov-branch --archive_differences"'
   - 'codecov -X gcov search'
 
+on_failure:
+  - 'appveyor PushArtifact gcovr/tests/diff.zip'
 
 notifications:
   - provider: Webhook

--- a/gcovr/tests/.gitignore
+++ b/gcovr/tests/.gitignore
@@ -1,4 +1,8 @@
-# ignore all HTML and CSS files
+# Ignore output files
+coverage*.txt
+coverage*.json
+coverage*.xml
+sonarqube*.xml
 *.html
 *.css
 # except in reference directories
@@ -15,6 +19,10 @@
 .coverage
 *.gcda
 *.gcno
+*.gcov
 .tox
 nosetests.xml
 testcase
+
+# Differences
+diff.zip

--- a/gcovr/tests/add_coverages/.gitignore
+++ b/gcovr/tests/add_coverages/.gitignore
@@ -1,0 +1,2 @@
+# Ignore the generated executables
+testcase_*

--- a/gcovr/tests/conftest.py
+++ b/gcovr/tests/conftest.py
@@ -2,4 +2,5 @@
 def pytest_addoption(parser):  # pragma: no cover
     parser.addoption("--generate_reference", action="store_true", help="Generate the reference")
     parser.addoption("--update_reference", action="store_true", help="Update the reference")
+    parser.addoption("--archive_differences", action="store_true", help="Archive the different files")
     parser.addoption("--skip_clean", action="store_true", help="Skip the clean after the test")

--- a/gcovr/tests/filter-relative-lib/project/.gitignore
+++ b/gcovr/tests/filter-relative-lib/project/.gitignore
@@ -1,0 +1,2 @@
+# Ignore the linked directory
+relevant-library

--- a/gcovr/tests/linked/.gitignore
+++ b/gcovr/tests/linked/.gitignore
@@ -1,0 +1,2 @@
+# Ignore the linked directory
+subdir

--- a/gcovr/tests/shared_lib/testApp/.gitignore
+++ b/gcovr/tests/shared_lib/testApp/.gitignore
@@ -1,0 +1,2 @@
+# Ignore the output directory
+test

--- a/gcovr/tests/test_gcovr.py
+++ b/gcovr/tests/test_gcovr.py
@@ -123,7 +123,7 @@ def pytest_generate_tests(metafunc):
 
     collected_params = []
 
-    if archive_differences:  # pragma no cover
+    if archive_differences:  # pragma: no cover
         diffs_zip = os.path.join(basedir, 'diff.zip')
         # Create an empty ZIP
         zipfile.ZipFile(diffs_zip, mode='w').close()
@@ -273,7 +273,7 @@ def test_build(compiled, format, available_targets, generate_reference, update_r
             if archive_differences:
                 diffs_zip = os.path.join('..', 'diff.zip')
                 with zipfile.ZipFile(diffs_zip, mode='a') as f:
-                    f.write(coverage_file, os.path.join(name, coverage_file).replace(os.path.sep, '/'))
+                    f.write(coverage_file, os.path.join(name, 'reference', coverage_file).replace(os.path.sep, '/'))
 
     diff_is_empty = len(whole_diff_output) == 0
     assert diff_is_empty, "Diff output:\n" + "".join(whole_diff_output)


### PR DESCRIPTION
- Extend test option --update_reference for all formats.
- New option --archive_differences to save the different fileas as ZIP. Use this ZIP as artifact in AppVeyor.

The first commit is with a difference to test it in the CI.