### PR TITLE
Extend documentation for relative filters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,15 +40,15 @@ Documentation:
 
 Internal changes:
 
- - Support multiple output patterns in integration tests (:issue:`383`)
- - Extend tests to use an unified diff in the assert. Add test options `--generate_reference`,
-   `--update_reference` and `--skip_clean`. (:issue:`374`)
- - Set make variable TEST_OPTS as environment variable inside docker. (:issue:`372`)
  - Enable :option:`--filter` and :option:`--exclude` for :ref:`Combining tracefiles <combining_tracefiles>`. (:issue:`373`)
- - Extend test framework for CI (:issue:`392`):
+ - Extend test framework for CI:
 
+   - Set make variable TEST_OPTS as environment variable inside docker. (:issue:`372`)
+   - Extend tests to use an unified diff in the assert. Add test options `--generate_reference`,
+     `--update_reference` and `--skip_clean`. (:issue:`374`)
+   - Support multiple output patterns in integration tests. (:issue:`383`)
    - New option `--archive_differences` to save the different files as ZIP.
-     Use this ZIP as artifact in AppVeyor.
+     Use this ZIP as artifact in AppVeyor.  (:issue:`392`)
 
 4.2 (6 November 2019)
 ---------------------

--- a/doc/source/guide.rst
+++ b/doc/source/guide.rst
@@ -538,7 +538,9 @@ Always use forward slashes ``/`` as path separators, even on Windows:
 If the filter looks like an absolute path,
 it is matched against an absolute path.
 Otherwise, the filter is matched against a relative path,
-where that path is relative to the current directory.
+where that path is relative to the current directory
+or if defined in a configuration file to the directory of the file.
+
 Examples of relative filters:
 
 -   ``--filter subdir/`` matches only that subdirectory

--- a/gcovr/configuration.py
+++ b/gcovr/configuration.py
@@ -469,7 +469,13 @@ GCOVR_CONFIG_OPTION_GROUPS = [
             "Filters decide which files are included in the report. "
             "Any filter must match, and no exclude filter must match. "
             "A filter is a regular expression that matches a path. "
-            "Filter paths use forward slashes, even on Windows.",
+            "Filter paths use forward slashes, even on Windows. "
+            "If the filter looks like an absolute path "
+            "it is matched against an absolute path. "
+            "Otherwise, the filter is matched against a relative path, "
+            "where that path is relative to the current directory "
+            "or if defined in a configuration file to the directory of the file.",
+
     }, {
         "key": "gcov_options",
         "name": "GCOV Options",
@@ -805,6 +811,8 @@ GCOVR_CONFIG_OPTIONS = [
         group="filter_options",
         help="Keep only source files that match this filter. "
              "Can be specified multiple times. "
+             "Relative filters are relative to the current working directory "
+             "or if defined in a configuration file. "
              "If no filters are provided, defaults to --root.",
         action="append",
         type=FilterOption,

--- a/gcovr/tests/add_coverages/Makefile
+++ b/gcovr/tests/add_coverages/Makefile
@@ -48,4 +48,4 @@ clean:
 	rm -f testcase_*
 	rm -f *.gc*
 	rm -f *.o
-	rm -f coverage*.* sonarqube*.* summary_coverage.json
+	rm -f coverage*.* sonarqube*.* summary_coverage.json coveralls.json

--- a/gcovr/tests/exclude-lines-by-pattern/Makefile
+++ b/gcovr/tests/exclude-lines-by-pattern/Makefile
@@ -26,4 +26,4 @@ coveralls:
 clean:
 	rm -f testcase
 	rm -f *.gc*
-	rm -f coverage.txt coverage.xml coverage*.html coverage.css sonarqube.xml
+	rm -f coverage.txt coverage.xml coverage*.html coverage.css sonarqube.xml coveralls.json

--- a/gcovr/utils.py
+++ b/gcovr/utils.py
@@ -144,7 +144,7 @@ def calculate_coverage(covered, total, nan_value=0.0):
 
 
 class FilterOption(object):
-    def __init__(self, regex, path_context=None):
+    def __init__(self, regex, path_context=os.getcwd()):
         self.regex = regex
         self.path_context = path_context
 
@@ -163,9 +163,7 @@ class FilterOption(object):
         if os.path.isabs(self.regex):
             return AbsoluteFilter(self.regex)
         else:
-            path_context = (self.path_context if self.path_context is not None
-                            else os.getcwd())
-            return RelativeFilter(path_context, self.regex)
+            return RelativeFilter(self.path_context, self.regex)
 
 
 class NonEmptyFilterOption(FilterOption):


### PR DESCRIPTION
Update documentation for relative filters in configuration files.
Extend the help output for the filter section with directory used for relative filters.
Closes #319.