### PR TITLE
Unify absolute path resolution

### DIFF
--- a/gcovr/gcov.py
+++ b/gcovr/gcov.py
@@ -167,14 +167,14 @@ def guess_source_file_name(
 
 def guess_source_file_name_via_aliases(gcovname, currdir, data_fname):
     common_dir = commonpath([data_fname, currdir])
-    fname = os.path.realpath(os.path.join(common_dir, gcovname))
+    fname = os.path.abspath(os.path.join(common_dir, gcovname))
     if os.path.exists(fname):
         return fname
 
     initial_fname = fname
 
     data_fname_dir = os.path.dirname(data_fname)
-    fname = os.path.realpath(os.path.join(data_fname_dir, gcovname))
+    fname = os.path.abspath(os.path.join(data_fname_dir, gcovname))
     if os.path.exists(fname):
         return fname
 

--- a/gcovr/html_generator.py
+++ b/gcovr/html_generator.py
@@ -244,7 +244,7 @@ class RootInfo:
         }
 
         display_filename = (
-            os.path.relpath(os.path.realpath(cdata_fname), self.directory)
+            os.path.relpath(os.path.abspath(cdata_fname), self.directory)
             .replace('\\', '/'))
 
         if link_report is not None:

--- a/gcovr/utils.py
+++ b/gcovr/utils.py
@@ -78,9 +78,9 @@ def commonpath(files):
         return ''
 
     if len(files) == 1:
-        prefix_path = os.path.dirname(os.path.realpath(files[0]))
+        prefix_path = os.path.dirname(os.path.abspath(files[0]))
     else:
-        split_paths = [os.path.realpath(path).split(os.path.sep)
+        split_paths = [os.path.abspath(path).split(os.path.sep)
                        for path in files]
         # We only have to compare the lexicographically minimum and maximum
         # paths to find the common prefix of all, e.g.:
@@ -196,7 +196,7 @@ class Filter(object):
 
 class AbsoluteFilter(Filter):
     def match(self, path):
-        abspath = os.path.realpath(path)
+        abspath = os.path.abspath(path)
         return super(AbsoluteFilter, self).match(abspath)
 
 
@@ -206,7 +206,7 @@ class RelativeFilter(Filter):
         self.root = root
 
     def match(self, path):
-        abspath = os.path.realpath(path)
+        abspath = os.path.abspath(path)
         relpath = os.path.relpath(abspath, self.root)
         return super(RelativeFilter, self).match(relpath)
 
@@ -225,13 +225,13 @@ class AlwaysMatchFilter(Filter):
 
 class DirectoryPrefixFilter(Filter):
     def __init__(self, directory):
-        abspath = os.path.realpath(directory)
+        abspath = os.path.abspath(directory)
         os_independent_dir = abspath.replace(os.path.sep, '/')
         pattern = re.escape(os_independent_dir + '/')
         super(DirectoryPrefixFilter, self).__init__(pattern)
 
     def match(self, path):
-        normpath = os.path.normpath(path)
+        normpath = os.path.abspath(path)
         return super(DirectoryPrefixFilter, self).match(normpath)
 
 


### PR DESCRIPTION
gcovr resolves relative paths to absolute in numerous places by using
os.path.abspath() & os.path.realpath() methods in inconsistent manner.

These methods are used in arbitrarily mixed manner here and there.
In build system with symlinks or drive substitution (Windows) it causes issues.

There is a substantial difference in returned result:
 * os.path.realpath() dereferences and resolves symlinks, whereas
 * os.path.abspath() does not resolves symlinks.

This commit unifies absolute path resolution by using os.path.abspath().

Fixes #365 