### PR TITLE
Fix warning in console if not -o is used.

### DIFF
--- a/gcovr/__main__.py
+++ b/gcovr/__main__.py
@@ -444,7 +444,7 @@ def print_reports(covdata, options, logger):
         print_text_report(covdata, '-' if default_output is None else default_output.abspath, options)
         default_output = None
 
-    if default_output is not None and not default_output_used:
+    if default_output is not None and default_output.value is not None and not default_output_used:
         logger.warn("--output={!r} option was provided but not used.",
                     default_output.value)
 


### PR DESCRIPTION
Fix warning from test.
```shell
/usr/bin/python3 -m gcovr -d --json main.json
(WARNING) --output=None option was provided but not used.
```