### PR TITLE
Fix GitHub language statistics

### DIFF
--- a/gcovr/tests/.gitattributes
+++ b/gcovr/tests/.gitattributes
@@ -7,6 +7,6 @@
 # See also: https://github.com/github/linguist
 # (While linguist-generated might be appropriate here,
 # that attribute would also suppress diffs on GH. Can't have that!)
-*/reference/coverage*.html linguist-detectable=false
-*/reference/coverage*.xml  linguist-detectable=false
-*/reference/coverage*.txt  linguist-detectable=false
+*/reference/*/coverage*.html linguist-detectable=false
+*/reference/*/coverage*.xml  linguist-detectable=false
+*/reference/*/coverage*.txt  linguist-detectable=false


### PR DESCRIPTION
Because of adding references for the different compiler versions  the pattern must be changed. at the moment gcovr language is detected as html because of the refernce data.