### PR TITLE
Add script for copyright header.

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright 2013-2018 the gcovr authors
+Copyright 2013-2021 the gcovr authors
 Copyright 2013 Sandia Corporation. Under the terms of Contract DE-AC04-
 94AL85000 with Sandia Corporation, the U.S. Government retains certain
 rights in this software.

--- a/README.rst
+++ b/README.rst
@@ -146,7 +146,7 @@ License
 
 .. begin license
 
-Copyright 2013-2018 the gcovr authors
+Copyright 2013-2021 the gcovr authors
 
 Copyright 2013 Sandia Corporation.
 Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/admin/add_copyright.py
+++ b/admin/add_copyright.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env PYTHONPATH=./gcovr python3
+
+# -*- coding:utf-8 -*-
+
+#  ************************** Copyrights and license ***************************
+#
+# This file is part of gcovr 4.2, a parsing and reporting tool for gcov.
+# https://gcovr.com/en/stable
+#
+# _____________________________________________________________________________
+#
+# Copyright (c) 2021 Spacetown <michael.foerderer@gmx.de>
+# and possibly others.
+# Copyright (c) 2013 Sandia Corporation.
+# This software is distributed under the BSD License.
+# Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+# the U.S. Government retains certain rights in this software.
+# For more information, see the README.rst file.
+#
+# ****************************************************************************
+
+import os
+import re
+import subprocess
+
+import version
+
+REGEX_EMAIL = re.compile(r"\d+\+([^@]+)@users\.noreply\.github\.com")
+HEADER_END = (
+    " ****************************************************************************"
+)
+
+
+def getLicenseSection(filename, comment_char="#"):
+    yield comment_char + "  ************************** Copyrights and license ***************************"
+    yield comment_char
+    yield comment_char + " This file is part of gcovr {}, a parsing and reporting tool for gcov.".format(
+        version.__version__
+    )
+    yield comment_char + " https://gcovr.com/en/stable"
+    yield comment_char
+    yield comment_char + " _____________________________________________________________________________"
+    yield comment_char
+    for name, year in getContributors(filename):
+        yield comment_char + " Copyright (c) " + year + " " + name
+    yield comment_char + " and possibly others."
+    yield comment_char + " Copyright (c) 2013 Sandia Corporation."
+    yield comment_char + " This software is distributed under the BSD License."
+    yield comment_char + " Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,"
+    yield comment_char + " the U.S. Government retains certain rights in this software."
+    yield comment_char + " For more information, see the README.rst file."
+    yield comment_char
+    yield comment_char + HEADER_END
+
+
+def getContributors(filename, sortBy="end"):
+    yearsOfContributions = dict()
+    emailByName = dict()
+    newMailByOldMail = dict()
+    nameByEmail = dict()
+    newNameByOldName = dict()
+    for line in subprocess.check_output(
+        ["git", "log", "--format=format:%ad|%an|%ae", "--date=short", "--", filename],
+        universal_newlines=True,
+    ).split("\n"):
+        (date, name, email) = line.split("|")
+        year = date[:4]
+        key = "{} <{}>".format(name, email)
+        # User name is unknown, check if it was changed...
+        if key not in yearsOfContributions:
+            # User name is already known --> Get matching email address
+            if name in emailByName:
+                newMailByOldMail[email] = emailByName[name]  # Save changed email address
+                email = newMailByOldMail[email]
+            # Email address is already known --> Get matching user name
+            elif email in nameByEmail:
+                newNameByOldName[name] = nameByEmail[email]  # Save changed user name
+                name = newNameByOldName[name]
+            # User name is already known --> Get matching email address
+            elif email in newMailByOldMail:
+                email = newMailByOldMail[email]
+                name = nameByEmail[email]
+            # User name is already known --> Get matching email address
+            elif name in newNameByOldName:
+                name = newNameByOldName[name]
+                email = emailByName[name]
+            else:
+                # Try to get the user name from the mail address
+                match = REGEX_EMAIL.match(email)
+                if match is not None:
+                    if match.group(1) in emailByName:
+                        name = match.group(1)
+                        email = emailByName[name]
+            # Update the key
+            key = "{} <{}>".format(name, email)
+
+            emailByName[name] = email
+            nameByEmail[email] = name
+        email = emailByName[name]
+        # Add year to list, key is the user name followed by email address
+        if key not in yearsOfContributions:
+            yearsOfContributions[key] = set()
+        yearsOfContributions[key].add(year)
+
+    contributors = set()
+    for (name, years) in yearsOfContributions.items():
+        contributors.add((name, min(years), max(years)))
+
+    # first sort by name
+    contributors = sorted(contributors, key=lambda x: x[0])
+    if sortBy == "start":
+        contributors = sorted(contributors, key=lambda x: x[1], reverse=True)
+    if sortBy == "end":
+        contributors = sorted(contributors, key=lambda x: x[2], reverse=True)
+
+    return list(
+        (x[0], x[1] if x[1] == x[2] else "{}-{}".format(x[1], x[2]))
+        for x in contributors
+    )
+
+
+def addCopyrightToPythonFile(filename, lines):
+    # Empty file should be kept empty
+    if len(lines) == 0:
+        return lines
+
+    newLines = []
+    # Keep the Shebang
+    if lines[0].startswith("#!"):
+        newLines.append(lines.pop(0))
+        newLines.append("")
+
+    # Add encoding
+    newLines.append("# -*- coding:utf-8 -*-")
+    newLines.append("")
+
+    # Add license information
+    for line in getLicenseSection(filename):
+        newLines.append(line)
+
+    # Skip header and add rest of file
+    headerEndReached = False
+    skipEmptyLines = True
+    for line in lines:
+        if not headerEndReached:
+            if len(line) > 0 and line[0] == "#" and line[1:] == HEADER_END:
+                headerEndReached = True
+                continue
+
+        if headerEndReached:
+            if skipEmptyLines:
+                if len(line) == 0:
+                    continue
+                skipEmptyLines = False
+                newLines.append("")
+            newLines.append(line)
+
+    if not headerEndReached:
+        newLines.extend(lines)
+
+    return newLines
+
+
+def main():
+    for root, dirs, files in os.walk(".", topdown=True):
+        for skip_dir in [".git", "reference"]:
+            if skip_dir in dirs:
+                dirs.remove(skip_dir)
+
+        for filename in files:
+            handler = None
+            fullname = os.path.join(root, filename)
+            if filename.endswith(".py"):
+                handler = addCopyrightToPythonFile
+
+            if handler is not None:
+                with open(fullname) as f:
+                    lines = list(line.rstrip() for line in f)
+                newLines = handler(fullname, lines)
+                if newLines != lines:
+                    print("Modifying {}".format(fullname))
+                    with open(fullname, "w") as f:
+                        for line in newLines:
+                            f.write(line + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/doc/examples/test_examples.py
+++ b/doc/examples/test_examples.py
@@ -1,3 +1,26 @@
+# -*- coding:utf-8 -*-
+
+#  ************************** Copyrights and license ***************************
+#
+# This file is part of gcovr 4.2, a parsing and reporting tool for gcov.
+# https://gcovr.com/en/stable
+#
+# _____________________________________________________________________________
+#
+# Copyright (c) 2021 Spacetown <michael.foerderer@gmx.de>
+# Copyright (c) 2018-2019 Lukas Atkinson <opensource@LukasAtkinson.de>
+# Copyright (c) 2019 R Edgar <freesurfer.rge@gmail.com>
+# Copyright (c) 2018 mayeut <mayeut@users.noreply.github.com>
+# Copyright (c) 2013 wehart <wehart@sandia.gov>
+# and possibly others.
+# Copyright (c) 2013 Sandia Corporation.
+# This software is distributed under the BSD License.
+# Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+# the U.S. Government retains certain rights in this software.
+# For more information, see the README.rst file.
+#
+# ****************************************************************************
+
 import glob
 import os
 import pytest

--- a/doc/examples/test_examples.py
+++ b/doc/examples/test_examples.py
@@ -7,7 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2021 the gcovr authors
+# Copyright (c) 2013-2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/doc/examples/test_examples.py
+++ b/doc/examples/test_examples.py
@@ -7,12 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2021 Spacetown <michael.foerderer@gmx.de>
-# Copyright (c) 2018-2019 Lukas Atkinson <opensource@LukasAtkinson.de>
-# Copyright (c) 2019 R Edgar <freesurfer.rge@gmail.com>
-# Copyright (c) 2018 mayeut <mayeut@users.noreply.github.com>
-# Copyright (c) 2013 wehart <wehart@sandia.gov>
-# and possibly others.
+# Copyright (c) 2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -7,10 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2021 Spacetown <michael.foerderer@gmx.de>
-# Copyright (c) 2018 Christian Taedcke <hacking@taedcke.com>
-# Copyright (c) 2018 Lukas Atkinson <opensource@LukasAtkinson.de>
-# and possibly others.
+# Copyright (c) 2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
@@ -18,6 +15,12 @@
 # For more information, see the README.rst file.
 #
 # ****************************************************************************
+
+# Configuration file for the Sphinx documentation builder.
+#
+# This file does only contain a selection of the most common options. For a
+# full list see the documentation:
+# http://www.sphinx-doc.org/en/stable/config
 
 # -- Path setup --------------------------------------------------------------
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,26 +1,40 @@
-# -*- coding: utf-8 -*-
+# -*- coding:utf-8 -*-
+
+#  ************************** Copyrights and license ***************************
 #
-# Configuration file for the Sphinx documentation builder.
+# This file is part of gcovr 4.2, a parsing and reporting tool for gcov.
+# https://gcovr.com/en/stable
 #
-# This file does only contain a selection of the most common options. For a
-# full list see the documentation:
-# http://www.sphinx-doc.org/en/stable/config
+# _____________________________________________________________________________
+#
+# Copyright (c) 2021 Spacetown <michael.foerderer@gmx.de>
+# Copyright (c) 2018 Christian Taedcke <hacking@taedcke.com>
+# Copyright (c) 2018 Lukas Atkinson <opensource@LukasAtkinson.de>
+# and possibly others.
+# Copyright (c) 2013 Sandia Corporation.
+# This software is distributed under the BSD License.
+# Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+# the U.S. Government retains certain rights in this software.
+# For more information, see the README.rst file.
+#
+# ****************************************************************************
 
 # -- Path setup --------------------------------------------------------------
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#
+
+from datetime import datetime
 import os
 import sys
+
 sys.path.insert(0, os.path.abspath(os.path.join('..', '..')))
 import gcovr.version # noqa
 
 # -- Project information -----------------------------------------------------
 
 project = u'gcovr'
-copyright = u'2018, the gcovr authors'
+copyright = u'{}, the gcovr authors'.format(datetime.today().year)
 author = u'the gcovr authors'
 
 # The short X.Y version

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -7,7 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2021 the gcovr authors
+# Copyright (c) 2013-2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/__init__.py
+++ b/gcovr/__init__.py
@@ -1,12 +1,21 @@
 # -*- coding:utf-8 -*-
-#  _________________________________________________________________________
-#
-#  Gcovr: A parsing and reporting tool for gcov
-#  Copyright (c) 2013 Sandia Corporation.
-#  This software is distributed under the BSD License.
-#  Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
-#  the U.S. Government retains certain rights in this software.
-#  For more information, see the README.md file.
-#  _________________________________________________________________________
 
-# Empty gcovr package
+#  ************************** Copyrights and license ***************************
+#
+# This file is part of gcovr 4.2, a parsing and reporting tool for gcov.
+# https://gcovr.com/en/stable
+#
+# _____________________________________________________________________________
+#
+# Copyright (c) 2021 Spacetown <michael.foerderer@gmx.de>
+# Copyright (c) 2014 Carlos Jenkins <carlos.jenkins@hp.com>
+# Copyright (c) 2013 Hart <whart222@gmail.com>
+# Copyright (c) 2010 wehart <wehart@sandia.gov>
+# and possibly others.
+# Copyright (c) 2013 Sandia Corporation.
+# This software is distributed under the BSD License.
+# Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+# the U.S. Government retains certain rights in this software.
+# For more information, see the README.rst file.
+#
+# ****************************************************************************

--- a/gcovr/__init__.py
+++ b/gcovr/__init__.py
@@ -7,11 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2021 Spacetown <michael.foerderer@gmx.de>
-# Copyright (c) 2014 Carlos Jenkins <carlos.jenkins@hp.com>
-# Copyright (c) 2013 Hart <whart222@gmail.com>
-# Copyright (c) 2010 wehart <wehart@sandia.gov>
-# and possibly others.
+# Copyright (c) 2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/__init__.py
+++ b/gcovr/__init__.py
@@ -7,7 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2021 the gcovr authors
+# Copyright (c) 2013-2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/__main__.py
+++ b/gcovr/__main__.py
@@ -7,23 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2021 Ensky <enskylin@gmail.com>
-# Copyright (c) 2018-2021 Spacetown <michael.foerderer@gmx.de>
-# Copyright (c) 2019-2020 Cezary Gapinski <cezary.gapinski@gmail.com>
-# Copyright (c) 2020 Christian Taedcke <hacking@taedcke.com>
-# Copyright (c) 2018-2020 Lukas Atkinson <opensource@LukasAtkinson.de>
-# Copyright (c) 2020 Noam Lewis <noamlewis@google.com>
-# Copyright (c) 2020 Oleksiy Pikalo <opikalo@gmail.com>
-# Copyright (c) 2020 Zachary J. Fields <zachary_fields@yahoo.com>
-# Copyright (c) 2019 Ma Liangliang <akml@163.com>
-# Copyright (c) 2019 Richard Kjerstadius <kjerstadius@gmail.com>
-# Copyright (c) 2018 James Reynolds <james.reynolds@cristiesoftware.com>
-# Copyright (c) 2018 Joel Klinghed <the_jk@spawned.biz>
-# Copyright (c) 2018 Marek Kurdej <marek@quasardb.net>
-# Copyright (c) 2018 Matthew Stadelman <stadelmanma@gmail.com>
-# Copyright (c) 2018 Songmin Li <lisongmin9@gmail.com>
-# Copyright (c) 2018 mayeut <mayeut@users.noreply.github.com>
-# and possibly others.
+# Copyright (c) 2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/__main__.py
+++ b/gcovr/__main__.py
@@ -1,33 +1,36 @@
 # -*- coding:utf-8 -*-
+
+#  ************************** Copyrights and license ***************************
 #
-# A report generator for gcov 3.4
+# This file is part of gcovr 4.2, a parsing and reporting tool for gcov.
+# https://gcovr.com/en/stable
 #
-# This routine generates a format that is similar to the format generated
-# by the Python coverage.py module.  This code is similar to the
-# data processing performed by lcov's geninfo command.  However, we
-# don't worry about parsing the *.gcna files, and backwards compatibility for
-# older versions of gcov is not supported.
+# _____________________________________________________________________________
 #
-# Outstanding issues
-#   - verify that gcov 3.4 or newer is being used
-#   - verify support for symbolic links
+# Copyright (c) 2021 Ensky <enskylin@gmail.com>
+# Copyright (c) 2018-2021 Spacetown <michael.foerderer@gmx.de>
+# Copyright (c) 2019-2020 Cezary Gapinski <cezary.gapinski@gmail.com>
+# Copyright (c) 2020 Christian Taedcke <hacking@taedcke.com>
+# Copyright (c) 2018-2020 Lukas Atkinson <opensource@LukasAtkinson.de>
+# Copyright (c) 2020 Noam Lewis <noamlewis@google.com>
+# Copyright (c) 2020 Oleksiy Pikalo <opikalo@gmail.com>
+# Copyright (c) 2020 Zachary J. Fields <zachary_fields@yahoo.com>
+# Copyright (c) 2019 Ma Liangliang <akml@163.com>
+# Copyright (c) 2019 Richard Kjerstadius <kjerstadius@gmail.com>
+# Copyright (c) 2018 James Reynolds <james.reynolds@cristiesoftware.com>
+# Copyright (c) 2018 Joel Klinghed <the_jk@spawned.biz>
+# Copyright (c) 2018 Marek Kurdej <marek@quasardb.net>
+# Copyright (c) 2018 Matthew Stadelman <stadelmanma@gmail.com>
+# Copyright (c) 2018 Songmin Li <lisongmin9@gmail.com>
+# Copyright (c) 2018 mayeut <mayeut@users.noreply.github.com>
+# and possibly others.
+# Copyright (c) 2013 Sandia Corporation.
+# This software is distributed under the BSD License.
+# Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+# the U.S. Government retains certain rights in this software.
+# For more information, see the README.rst file.
 #
-# For documentation, bug reporting, and updates,
-# see http://gcovr.com/
-#
-#  _________________________________________________________________________
-#
-#  Gcovr: A parsing and reporting tool for gcov
-#  Copyright (c) 2013 Sandia Corporation.
-#  This software is distributed under the BSD License.
-#  Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
-#  the U.S. Government retains certain rights in this software.
-#  For more information, see the README.md file.
-# _________________________________________________________________________
-#
-# $Revision$
-# $Date$
-#
+# ****************************************************************************
 
 import os
 import re

--- a/gcovr/__main__.py
+++ b/gcovr/__main__.py
@@ -7,7 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2021 the gcovr authors
+# Copyright (c) 2013-2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/cobertura_xml_generator.py
+++ b/gcovr/cobertura_xml_generator.py
@@ -1,10 +1,23 @@
 # -*- coding:utf-8 -*-
 
-# This file is part of gcovr <http://gcovr.com/>.
+#  ************************** Copyrights and license ***************************
 #
-# Copyright 2013-2019 the gcovr authors
-# Copyright 2013 Sandia Corporation
-# This software is distributed under the BSD license.
+# This file is part of gcovr 4.2, a parsing and reporting tool for gcov.
+# https://gcovr.com/en/stable
+#
+# _____________________________________________________________________________
+#
+# Copyright (c) 2020-2021 Spacetown <michael.foerderer@gmx.de>
+# Copyright (c) 2019 Jeremy Fixemer <Jeremy.Fixemer@motorolasolutions.com>
+# Copyright (c) 2018-2019 Lukas Atkinson <opensource@LukasAtkinson.de>
+# and possibly others.
+# Copyright (c) 2013 Sandia Corporation.
+# This software is distributed under the BSD License.
+# Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+# the U.S. Government retains certain rights in this software.
+# For more information, see the README.rst file.
+#
+# ****************************************************************************
 
 import time
 

--- a/gcovr/cobertura_xml_generator.py
+++ b/gcovr/cobertura_xml_generator.py
@@ -7,10 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2020-2021 Spacetown <michael.foerderer@gmx.de>
-# Copyright (c) 2019 Jeremy Fixemer <Jeremy.Fixemer@motorolasolutions.com>
-# Copyright (c) 2018-2019 Lukas Atkinson <opensource@LukasAtkinson.de>
-# and possibly others.
+# Copyright (c) 2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/cobertura_xml_generator.py
+++ b/gcovr/cobertura_xml_generator.py
@@ -7,7 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2021 the gcovr authors
+# Copyright (c) 2013-2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/configuration.py
+++ b/gcovr/configuration.py
@@ -1,14 +1,30 @@
 # -*- coding:utf-8 -*-
 
-# This file is part of gcovr <http://gcovr.com/>.
+#  ************************** Copyrights and license ***************************
 #
-# This module manages processing and validation of the configuration options
-# passed into gcovr.
+# This file is part of gcovr 4.2, a parsing and reporting tool for gcov.
+# https://gcovr.com/en/stable
 #
+# _____________________________________________________________________________
 #
-# Copyright 2013-2019 the gcovr authors
-# Copyright 2013 Sandia Corporation
-# This software is distributed under the BSD license.
+# Copyright (c) 2020-2021 Spacetown <michael.foerderer@gmx.de>
+# Copyright (c) 2019-2020 Cezary Gapinski <cezary.gapinski@gmail.com>
+# Copyright (c) 2018-2020 Lukas Atkinson <opensource@LukasAtkinson.de>
+# Copyright (c) 2020 Noam Lewis <noamlewis@google.com>
+# Copyright (c) 2020 Oleksiy Pikalo <opikalo@gmail.com>
+# Copyright (c) 2020 Zachary J. Fields <zachary_fields@yahoo.com>
+# Copyright (c) 2019 Ma Liangliang <akml@163.com>
+# Copyright (c) 2019 Richard Kjerstadius <kjerstadius@gmail.com>
+# Copyright (c) 2018 Matthew Stadelman <stadelmanma@gmail.com>
+# and possibly others.
+# Copyright (c) 2013 Sandia Corporation.
+# This software is distributed under the BSD License.
+# Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+# the U.S. Government retains certain rights in this software.
+# For more information, see the README.rst file.
+#
+# ****************************************************************************
+
 from argparse import ArgumentTypeError, SUPPRESS
 from locale import getpreferredencoding
 from multiprocessing import cpu_count

--- a/gcovr/configuration.py
+++ b/gcovr/configuration.py
@@ -7,16 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2020-2021 Spacetown <michael.foerderer@gmx.de>
-# Copyright (c) 2019-2020 Cezary Gapinski <cezary.gapinski@gmail.com>
-# Copyright (c) 2018-2020 Lukas Atkinson <opensource@LukasAtkinson.de>
-# Copyright (c) 2020 Noam Lewis <noamlewis@google.com>
-# Copyright (c) 2020 Oleksiy Pikalo <opikalo@gmail.com>
-# Copyright (c) 2020 Zachary J. Fields <zachary_fields@yahoo.com>
-# Copyright (c) 2019 Ma Liangliang <akml@163.com>
-# Copyright (c) 2019 Richard Kjerstadius <kjerstadius@gmail.com>
-# Copyright (c) 2018 Matthew Stadelman <stadelmanma@gmail.com>
-# and possibly others.
+# Copyright (c) 2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/configuration.py
+++ b/gcovr/configuration.py
@@ -7,7 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2021 the gcovr authors
+# Copyright (c) 2013-2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/coverage.py
+++ b/gcovr/coverage.py
@@ -1,10 +1,23 @@
 # -*- coding:utf-8 -*-
 
-# This file is part of gcovr <http://gcovr.com/>.
+#  ************************** Copyrights and license ***************************
 #
-# Copyright 2013-2018 the gcovr authors
-# Copyright 2013 Sandia Corporation
-# This software is distributed under the BSD license.
+# This file is part of gcovr 4.2, a parsing and reporting tool for gcov.
+# https://gcovr.com/en/stable
+#
+# _____________________________________________________________________________
+#
+# Copyright (c) 2021 Spacetown <michael.foerderer@gmx.de>
+# Copyright (c) 2019 CezaryGapinski <cezary.gapinski@gmail.com>
+# Copyright (c) 2018 Lukas Atkinson <opensource@LukasAtkinson.de>
+# and possibly others.
+# Copyright (c) 2013 Sandia Corporation.
+# This software is distributed under the BSD License.
+# Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+# the U.S. Government retains certain rights in this software.
+# For more information, see the README.rst file.
+#
+# ****************************************************************************
 
 from .utils import calculate_coverage
 

--- a/gcovr/coverage.py
+++ b/gcovr/coverage.py
@@ -7,10 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2021 Spacetown <michael.foerderer@gmx.de>
-# Copyright (c) 2019 CezaryGapinski <cezary.gapinski@gmail.com>
-# Copyright (c) 2018 Lukas Atkinson <opensource@LukasAtkinson.de>
-# and possibly others.
+# Copyright (c) 2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/coverage.py
+++ b/gcovr/coverage.py
@@ -7,7 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2021 the gcovr authors
+# Copyright (c) 2013-2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/coveralls_generator.py
+++ b/gcovr/coveralls_generator.py
@@ -1,16 +1,22 @@
 # -*- coding:utf-8 -*-
 
-# This file is part of gcovr <http://gcovr.com/>.
+#  ************************** Copyrights and license ***************************
 #
-# Copyright 2013-2019 the gcovr authors
-# Copyright 2013 Sandia Corporation
-# This software is distributed under the BSD license.
-# Filename: coveralls_generator.py
-# Author: Zachary J. Fields
-# Description: Module to generate Coveralls.io formatted JSON
-#              from coverage data collected by `gcovr`
-# Modification History:
+# This file is part of gcovr 4.2, a parsing and reporting tool for gcov.
+# https://gcovr.com/en/stable
 #
+# _____________________________________________________________________________
+#
+# Copyright (c) 2020-2021 Spacetown <michael.foerderer@gmx.de>
+# Copyright (c) 2020 Zachary J. Fields <zachary_fields@yahoo.com>
+# and possibly others.
+# Copyright (c) 2013 Sandia Corporation.
+# This software is distributed under the BSD License.
+# Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+# the U.S. Government retains certain rights in this software.
+# For more information, see the README.rst file.
+#
+# ****************************************************************************
 
 from __future__ import absolute_import
 

--- a/gcovr/coveralls_generator.py
+++ b/gcovr/coveralls_generator.py
@@ -7,9 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2020-2021 Spacetown <michael.foerderer@gmx.de>
-# Copyright (c) 2020 Zachary J. Fields <zachary_fields@yahoo.com>
-# and possibly others.
+# Copyright (c) 2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/coveralls_generator.py
+++ b/gcovr/coveralls_generator.py
@@ -7,7 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2021 the gcovr authors
+# Copyright (c) 2013-2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/csv_generator.py
+++ b/gcovr/csv_generator.py
@@ -1,10 +1,23 @@
 # -*- coding:utf-8 -*-
 
-# This file is part of gcovr <http://gcovr.com/>.
+#  ************************** Copyrights and license ***************************
 #
-# Copyright 2013-2018 the gcovr authors
-# Copyright 2013 Sandia Corporation
-# This software is distributed under the BSD license.
+# This file is part of gcovr 4.2, a parsing and reporting tool for gcov.
+# https://gcovr.com/en/stable
+#
+# _____________________________________________________________________________
+#
+# Copyright (c) 2020-2021 Spacetown <michael.foerderer@gmx.de>
+# Copyright (c) 2020 Noam Lewis <noamlewis@google.com>
+# Copyright (c) 2020 Oleksiy Pikalo <opikalo@gmail.com>
+# and possibly others.
+# Copyright (c) 2013 Sandia Corporation.
+# This software is distributed under the BSD License.
+# Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+# the U.S. Government retains certain rights in this software.
+# For more information, see the README.rst file.
+#
+# ****************************************************************************
 
 import csv
 

--- a/gcovr/csv_generator.py
+++ b/gcovr/csv_generator.py
@@ -7,10 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2020-2021 Spacetown <michael.foerderer@gmx.de>
-# Copyright (c) 2020 Noam Lewis <noamlewis@google.com>
-# Copyright (c) 2020 Oleksiy Pikalo <opikalo@gmail.com>
-# and possibly others.
+# Copyright (c) 2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/csv_generator.py
+++ b/gcovr/csv_generator.py
@@ -7,7 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2021 the gcovr authors
+# Copyright (c) 2013-2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/gcov.py
+++ b/gcovr/gcov.py
@@ -7,18 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2021 Spacetown <michael.foerderer@gmx.de>
-# Copyright (c) 2020 CODeRUS <coderusinbox@gmail.com>
-# Copyright (c) 2020 Edwin Mons <github@edwinm.ik.nu>
-# Copyright (c) 2020 Noam Lewis <noamlewis@google.com>
-# Copyright (c) 2020 cconverse711 <cconverse711@gmail.com>
-# Copyright (c) 2018-2019 Lukas Atkinson <opensource@LukasAtkinson.de>
-# Copyright (c) 2019 Philip Clapham <32672400+obiphi@users.noreply.github.com>
-# Copyright (c) 2019 alex43dm <wvdial@gmail.com>
-# Copyright (c) 2018 James Reynolds <james.reynolds@cristiesoftware.com>
-# Copyright (c) 2018 Martin Mraz <mraz.martin.dev@gmail.com>
-# Copyright (c) 2018 Songmin Li <lisongmin9@gmail.com>
-# and possibly others.
+# Copyright (c) 2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/gcov.py
+++ b/gcovr/gcov.py
@@ -1,10 +1,31 @@
 # -*- coding:utf-8 -*-
 
-# This file is part of gcovr <http://gcovr.com/>.
+#  ************************** Copyrights and license ***************************
 #
-# Copyright 2013-2018 the gcovr authors
-# Copyright 2013 Sandia Corporation
-# This software is distributed under the BSD license.
+# This file is part of gcovr 4.2, a parsing and reporting tool for gcov.
+# https://gcovr.com/en/stable
+#
+# _____________________________________________________________________________
+#
+# Copyright (c) 2021 Spacetown <michael.foerderer@gmx.de>
+# Copyright (c) 2020 CODeRUS <coderusinbox@gmail.com>
+# Copyright (c) 2020 Edwin Mons <github@edwinm.ik.nu>
+# Copyright (c) 2020 Noam Lewis <noamlewis@google.com>
+# Copyright (c) 2020 cconverse711 <cconverse711@gmail.com>
+# Copyright (c) 2018-2019 Lukas Atkinson <opensource@LukasAtkinson.de>
+# Copyright (c) 2019 Philip Clapham <32672400+obiphi@users.noreply.github.com>
+# Copyright (c) 2019 alex43dm <wvdial@gmail.com>
+# Copyright (c) 2018 James Reynolds <james.reynolds@cristiesoftware.com>
+# Copyright (c) 2018 Martin Mraz <mraz.martin.dev@gmail.com>
+# Copyright (c) 2018 Songmin Li <lisongmin9@gmail.com>
+# and possibly others.
+# Copyright (c) 2013 Sandia Corporation.
+# This software is distributed under the BSD License.
+# Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+# the U.S. Government retains certain rights in this software.
+# For more information, see the README.rst file.
+#
+# ****************************************************************************
 
 import os
 import re

--- a/gcovr/gcov.py
+++ b/gcovr/gcov.py
@@ -7,7 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2021 the gcovr authors
+# Copyright (c) 2013-2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/html_generator.py
+++ b/gcovr/html_generator.py
@@ -7,15 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2021 Ensky <enskylin@gmail.com>
-# Copyright (c) 2020-2021 Spacetown <michael.foerderer@gmx.de>
-# Copyright (c) 2020 Antonio Quarta <sgheppy88@gmail.com>
-# Copyright (c) 2020 Christian Taedcke <hacking@taedcke.com>
-# Copyright (c) 2018-2020 Lukas Atkinson <opensource@LukasAtkinson.de>
-# Copyright (c) 2018 Songmin Li <lisongmin9@gmail.com>
-# Copyright (c) 2018 Unknown <michael.foerderer@zf.com>
-# Copyright (c) 2018 lisongmin <lisongmin@126.com>
-# and possibly others.
+# Copyright (c) 2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/html_generator.py
+++ b/gcovr/html_generator.py
@@ -7,7 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2021 the gcovr authors
+# Copyright (c) 2013-2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/html_generator.py
+++ b/gcovr/html_generator.py
@@ -1,10 +1,28 @@
 # -*- coding:utf-8 -*-
 
-# This file is part of gcovr <http://gcovr.com/>.
+#  ************************** Copyrights and license ***************************
 #
-# Copyright 2013-2018 the gcovr authors
-# Copyright 2013 Sandia Corporation
-# This software is distributed under the BSD license.
+# This file is part of gcovr 4.2, a parsing and reporting tool for gcov.
+# https://gcovr.com/en/stable
+#
+# _____________________________________________________________________________
+#
+# Copyright (c) 2021 Ensky <enskylin@gmail.com>
+# Copyright (c) 2020-2021 Spacetown <michael.foerderer@gmx.de>
+# Copyright (c) 2020 Antonio Quarta <sgheppy88@gmail.com>
+# Copyright (c) 2020 Christian Taedcke <hacking@taedcke.com>
+# Copyright (c) 2018-2020 Lukas Atkinson <opensource@LukasAtkinson.de>
+# Copyright (c) 2018 Songmin Li <lisongmin9@gmail.com>
+# Copyright (c) 2018 Unknown <michael.foerderer@zf.com>
+# Copyright (c) 2018 lisongmin <lisongmin@126.com>
+# and possibly others.
+# Copyright (c) 2013 Sandia Corporation.
+# This software is distributed under the BSD License.
+# Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+# the U.S. Government retains certain rights in this software.
+# For more information, see the README.rst file.
+#
+# ****************************************************************************
 
 import os
 import datetime

--- a/gcovr/json_generator.py
+++ b/gcovr/json_generator.py
@@ -7,13 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2020-2021 Spacetown <michael.foerderer@gmx.de>
-# Copyright (c) 2019-2020 Cezary Gapiński <cezary.gapinski@gmail.com>
-# Copyright (c) 2020 Jugst3r <38359364+Jugst3r@users.noreply.github.com>
-# Copyright (c) 2020 Lukas Atkinson <opensource@LukasAtkinson.de>
-# Copyright (c) 2020 Oleksiy Pikalo <opikalo@gmail.com>
-# Copyright (c) 2020 Zachary J. Fields <zachary_fields@yahoo.com>
-# and possibly others.
+# Copyright (c) 2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/json_generator.py
+++ b/gcovr/json_generator.py
@@ -1,9 +1,26 @@
 # -*- coding:utf-8 -*-
 
-# This file is part of gcovr <http://gcovr.com/>.
+#  ************************** Copyrights and license ***************************
 #
-# Copyright 2019 the gcovr authors
-# This software is distributed under the BSD license.
+# This file is part of gcovr 4.2, a parsing and reporting tool for gcov.
+# https://gcovr.com/en/stable
+#
+# _____________________________________________________________________________
+#
+# Copyright (c) 2020-2021 Spacetown <michael.foerderer@gmx.de>
+# Copyright (c) 2019-2020 Cezary Gapiński <cezary.gapinski@gmail.com>
+# Copyright (c) 2020 Jugst3r <38359364+Jugst3r@users.noreply.github.com>
+# Copyright (c) 2020 Lukas Atkinson <opensource@LukasAtkinson.de>
+# Copyright (c) 2020 Oleksiy Pikalo <opikalo@gmail.com>
+# Copyright (c) 2020 Zachary J. Fields <zachary_fields@yahoo.com>
+# and possibly others.
+# Copyright (c) 2013 Sandia Corporation.
+# This software is distributed under the BSD License.
+# Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+# the U.S. Government retains certain rights in this software.
+# For more information, see the README.rst file.
+#
+# ****************************************************************************
 
 import json
 import os

--- a/gcovr/json_generator.py
+++ b/gcovr/json_generator.py
@@ -7,7 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2021 the gcovr authors
+# Copyright (c) 2013-2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/sonarqube_generator.py
+++ b/gcovr/sonarqube_generator.py
@@ -1,10 +1,23 @@
 # -*- coding:utf-8 -*-
 
-# This file is part of gcovr <http://gcovr.com/>.
+#  ************************** Copyrights and license ***************************
 #
-# Copyright 2013-2019 the gcovr authors
-# Copyright 2013 Sandia Corporation
-# This software is distributed under the BSD license.
+# This file is part of gcovr 4.2, a parsing and reporting tool for gcov.
+# https://gcovr.com/en/stable
+#
+# _____________________________________________________________________________
+#
+# Copyright (c) 2020-2021 Spacetown <michael.foerderer@gmx.de>
+# Copyright (c) 2019-2020 Lukas Atkinson <opensource@LukasAtkinson.de>
+# Copyright (c) 2019 Liangliang Ma <akml@163.com>
+# and possibly others.
+# Copyright (c) 2013 Sandia Corporation.
+# This software is distributed under the BSD License.
+# Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+# the U.S. Government retains certain rights in this software.
+# For more information, see the README.rst file.
+#
+# ****************************************************************************
 
 from lxml import etree
 

--- a/gcovr/sonarqube_generator.py
+++ b/gcovr/sonarqube_generator.py
@@ -7,7 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2021 the gcovr authors
+# Copyright (c) 2013-2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/sonarqube_generator.py
+++ b/gcovr/sonarqube_generator.py
@@ -7,10 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2020-2021 Spacetown <michael.foerderer@gmx.de>
-# Copyright (c) 2019-2020 Lukas Atkinson <opensource@LukasAtkinson.de>
-# Copyright (c) 2019 Liangliang Ma <akml@163.com>
-# and possibly others.
+# Copyright (c) 2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/summary_generator.py
+++ b/gcovr/summary_generator.py
@@ -1,14 +1,23 @@
 # -*- coding:utf-8 -*-
 
-'''
-Generator of the coverage summary.
-'''
-
-# This file is part of gcovr <http://gcovr.com/>.
+#  ************************** Copyrights and license ***************************
 #
-# Copyright 2013-2018 the gcovr authors
-# Copyright 2013 Sandia Corporation
-# This software is distributed under the BSD license.
+# This file is part of gcovr 4.2, a parsing and reporting tool for gcov.
+# https://gcovr.com/en/stable
+#
+# _____________________________________________________________________________
+#
+# Copyright (c) 2021 Spacetown <michael.foerderer@gmx.de>
+# Copyright (c) 2018 Lukas Atkinson <opensource@LukasAtkinson.de>
+# Copyright (c) 2018 Marek Kurdej <marek@quasardb.net>
+# and possibly others.
+# Copyright (c) 2013 Sandia Corporation.
+# This software is distributed under the BSD License.
+# Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+# the U.S. Government retains certain rights in this software.
+# For more information, see the README.rst file.
+#
+# ****************************************************************************
 
 import sys
 

--- a/gcovr/summary_generator.py
+++ b/gcovr/summary_generator.py
@@ -7,10 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2021 Spacetown <michael.foerderer@gmx.de>
-# Copyright (c) 2018 Lukas Atkinson <opensource@LukasAtkinson.de>
-# Copyright (c) 2018 Marek Kurdej <marek@quasardb.net>
-# and possibly others.
+# Copyright (c) 2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/summary_generator.py
+++ b/gcovr/summary_generator.py
@@ -7,7 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2021 the gcovr authors
+# Copyright (c) 2013-2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/tests/conftest.py
+++ b/gcovr/tests/conftest.py
@@ -7,8 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2020-2021 Spacetown <michael.foerderer@gmx.de>
-# and possibly others.
+# Copyright (c) 2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/tests/conftest.py
+++ b/gcovr/tests/conftest.py
@@ -1,3 +1,21 @@
+# -*- coding:utf-8 -*-
+
+#  ************************** Copyrights and license ***************************
+#
+# This file is part of gcovr 4.2, a parsing and reporting tool for gcov.
+# https://gcovr.com/en/stable
+#
+# _____________________________________________________________________________
+#
+# Copyright (c) 2020-2021 Spacetown <michael.foerderer@gmx.de>
+# and possibly others.
+# Copyright (c) 2013 Sandia Corporation.
+# This software is distributed under the BSD License.
+# Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+# the U.S. Government retains certain rights in this software.
+# For more information, see the README.rst file.
+#
+# ****************************************************************************
 
 def pytest_addoption(parser):  # pragma: no cover
     parser.addoption("--generate_reference", action="store_true", help="Generate the reference")

--- a/gcovr/tests/conftest.py
+++ b/gcovr/tests/conftest.py
@@ -7,7 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2021 the gcovr authors
+# Copyright (c) 2013-2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/tests/test_args.py
+++ b/gcovr/tests/test_args.py
@@ -7,15 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2018-2021 Spacetown <michael.foerderer@gmx.de>
-# Copyright (c) 2020 Jugst3r <38359364+Jugst3r@users.noreply.github.com>
-# Copyright (c) 2018-2020 Lukas Atkinson <opensource@LukasAtkinson.de>
-# Copyright (c) 2020 Noam Lewis <noamlewis@google.com>
-# Copyright (c) 2020 Zachary J. Fields <zachary_fields@yahoo.com>
-# Copyright (c) 2019 Richard Kjerstadius <kjerstadius@gmail.com>
-# Copyright (c) 2018 Marek Kurdej <marek@quasardb.net>
-# Copyright (c) 2018 mayeut <mayeut@users.noreply.github.com>
-# and possibly others.
+# Copyright (c) 2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/tests/test_args.py
+++ b/gcovr/tests/test_args.py
@@ -1,3 +1,29 @@
+# -*- coding:utf-8 -*-
+
+#  ************************** Copyrights and license ***************************
+#
+# This file is part of gcovr 4.2, a parsing and reporting tool for gcov.
+# https://gcovr.com/en/stable
+#
+# _____________________________________________________________________________
+#
+# Copyright (c) 2018-2021 Spacetown <michael.foerderer@gmx.de>
+# Copyright (c) 2020 Jugst3r <38359364+Jugst3r@users.noreply.github.com>
+# Copyright (c) 2018-2020 Lukas Atkinson <opensource@LukasAtkinson.de>
+# Copyright (c) 2020 Noam Lewis <noamlewis@google.com>
+# Copyright (c) 2020 Zachary J. Fields <zachary_fields@yahoo.com>
+# Copyright (c) 2019 Richard Kjerstadius <kjerstadius@gmail.com>
+# Copyright (c) 2018 Marek Kurdej <marek@quasardb.net>
+# Copyright (c) 2018 mayeut <mayeut@users.noreply.github.com>
+# and possibly others.
+# Copyright (c) 2013 Sandia Corporation.
+# This software is distributed under the BSD License.
+# Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+# the U.S. Government retains certain rights in this software.
+# For more information, see the README.rst file.
+#
+# ****************************************************************************
+
 from ..__main__ import main
 from ..version import __version__
 

--- a/gcovr/tests/test_args.py
+++ b/gcovr/tests/test_args.py
@@ -7,7 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2021 the gcovr authors
+# Copyright (c) 2013-2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/tests/test_config.py
+++ b/gcovr/tests/test_config.py
@@ -7,9 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2021 Spacetown <michael.foerderer@gmx.de>
-# Copyright (c) 2018-2019 Lukas Atkinson <opensource@LukasAtkinson.de>
-# and possibly others.
+# Copyright (c) 2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/tests/test_config.py
+++ b/gcovr/tests/test_config.py
@@ -1,4 +1,22 @@
-r"""Tests related to config file support."""
+# -*- coding:utf-8 -*-
+
+#  ************************** Copyrights and license ***************************
+#
+# This file is part of gcovr 4.2, a parsing and reporting tool for gcov.
+# https://gcovr.com/en/stable
+#
+# _____________________________________________________________________________
+#
+# Copyright (c) 2021 Spacetown <michael.foerderer@gmx.de>
+# Copyright (c) 2018-2019 Lukas Atkinson <opensource@LukasAtkinson.de>
+# and possibly others.
+# Copyright (c) 2013 Sandia Corporation.
+# This software is distributed under the BSD License.
+# Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+# the U.S. Government retains certain rights in this software.
+# For more information, see the README.rst file.
+#
+# ****************************************************************************
 
 import io
 import re

--- a/gcovr/tests/test_config.py
+++ b/gcovr/tests/test_config.py
@@ -7,7 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2021 the gcovr authors
+# Copyright (c) 2013-2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/tests/test_gcov_parser.py
+++ b/gcovr/tests/test_gcov_parser.py
@@ -7,13 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2021 Spacetown <michael.foerderer@gmx.de>
-# Copyright (c) 2020 Noam Lewis <noamlewis@google.com>
-# Copyright (c) 2018-2019 Lukas Atkinson <opensource@LukasAtkinson.de>
-# Copyright (c) 2019 Philip Clapham <32672400+obiphi@users.noreply.github.com>
-# Copyright (c) 2018 James Reynolds <james.reynolds@cristiesoftware.com>
-# Copyright (c) 2018 Songmin Li <lisongmin9@gmail.com>
-# and possibly others.
+# Copyright (c) 2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/tests/test_gcov_parser.py
+++ b/gcovr/tests/test_gcov_parser.py
@@ -1,10 +1,26 @@
 # -*- coding:utf-8 -*-
 
-# This file is part of gcovr <http://gcovr.com/>.
+#  ************************** Copyrights and license ***************************
 #
-# Copyright 2013-2018 the gcovr authors
-# Copyright 2013 Sandia Corporation
-# This software is distributed under the BSD license.
+# This file is part of gcovr 4.2, a parsing and reporting tool for gcov.
+# https://gcovr.com/en/stable
+#
+# _____________________________________________________________________________
+#
+# Copyright (c) 2021 Spacetown <michael.foerderer@gmx.de>
+# Copyright (c) 2020 Noam Lewis <noamlewis@google.com>
+# Copyright (c) 2018-2019 Lukas Atkinson <opensource@LukasAtkinson.de>
+# Copyright (c) 2019 Philip Clapham <32672400+obiphi@users.noreply.github.com>
+# Copyright (c) 2018 James Reynolds <james.reynolds@cristiesoftware.com>
+# Copyright (c) 2018 Songmin Li <lisongmin9@gmail.com>
+# and possibly others.
+# Copyright (c) 2013 Sandia Corporation.
+# This software is distributed under the BSD License.
+# Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+# the U.S. Government retains certain rights in this software.
+# For more information, see the README.rst file.
+#
+# ****************************************************************************
 
 import re
 import pytest

--- a/gcovr/tests/test_gcov_parser.py
+++ b/gcovr/tests/test_gcov_parser.py
@@ -7,7 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2021 the gcovr authors
+# Copyright (c) 2013-2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/tests/test_gcovr.py
+++ b/gcovr/tests/test_gcovr.py
@@ -7,19 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2020-2021 Spacetown <michael.foerderer@gmx.de>
-# Copyright (c) 2019-2020 Cezary Gapiński <cezary.gapinski@gmail.com>
-# Copyright (c) 2018-2020 Lukas Atkinson <opensource@LukasAtkinson.de>
-# Copyright (c) 2020 Noam Lewis <noamlewis@google.com>
-# Copyright (c) 2020 Oleksiy Pikalo <opikalo@gmail.com>
-# Copyright (c) 2020 Zachary J. Fields <zachary_fields@yahoo.com>
-# Copyright (c) 2019 Liangliang Ma <akml@163.com>
-# Copyright (c) 2018 Steven Myint <git@stevenmyint.com>
-# Copyright (c) 2018 mayeut <mayeut@users.noreply.github.com>
-# Copyright (c) 2013-2014 Hart <whart222@gmail.com>
-# Copyright (c) 2012-2013 wehart <wehart@sandia.gov>
-# Copyright (c) 2011-2012 jdsiiro <jdsiiro@sandia.gov>
-# and possibly others.
+# Copyright (c) 2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/tests/test_gcovr.py
+++ b/gcovr/tests/test_gcovr.py
@@ -1,3 +1,33 @@
+# -*- coding:utf-8 -*-
+
+#  ************************** Copyrights and license ***************************
+#
+# This file is part of gcovr 4.2, a parsing and reporting tool for gcov.
+# https://gcovr.com/en/stable
+#
+# _____________________________________________________________________________
+#
+# Copyright (c) 2020-2021 Spacetown <michael.foerderer@gmx.de>
+# Copyright (c) 2019-2020 Cezary Gapiński <cezary.gapinski@gmail.com>
+# Copyright (c) 2018-2020 Lukas Atkinson <opensource@LukasAtkinson.de>
+# Copyright (c) 2020 Noam Lewis <noamlewis@google.com>
+# Copyright (c) 2020 Oleksiy Pikalo <opikalo@gmail.com>
+# Copyright (c) 2020 Zachary J. Fields <zachary_fields@yahoo.com>
+# Copyright (c) 2019 Liangliang Ma <akml@163.com>
+# Copyright (c) 2018 Steven Myint <git@stevenmyint.com>
+# Copyright (c) 2018 mayeut <mayeut@users.noreply.github.com>
+# Copyright (c) 2013-2014 Hart <whart222@gmail.com>
+# Copyright (c) 2012-2013 wehart <wehart@sandia.gov>
+# Copyright (c) 2011-2012 jdsiiro <jdsiiro@sandia.gov>
+# and possibly others.
+# Copyright (c) 2013 Sandia Corporation.
+# This software is distributed under the BSD License.
+# Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+# the U.S. Government retains certain rights in this software.
+# For more information, see the README.rst file.
+#
+# ****************************************************************************
+
 import glob
 import io
 import os

--- a/gcovr/tests/test_gcovr.py
+++ b/gcovr/tests/test_gcovr.py
@@ -7,7 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2021 the gcovr authors
+# Copyright (c) 2013-2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/tests/test_html_generator.py
+++ b/gcovr/tests/test_html_generator.py
@@ -1,3 +1,23 @@
+# -*- coding:utf-8 -*-
+
+#  ************************** Copyrights and license ***************************
+#
+# This file is part of gcovr 4.2, a parsing and reporting tool for gcov.
+# https://gcovr.com/en/stable
+#
+# _____________________________________________________________________________
+#
+# Copyright (c) 2020-2021 Spacetown <michael.foerderer@gmx.de>
+# Copyright (c) 2020 Antonio Quarta <sgheppy88@gmail.com>
+# and possibly others.
+# Copyright (c) 2013 Sandia Corporation.
+# This software is distributed under the BSD License.
+# Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+# the U.S. Government retains certain rights in this software.
+# For more information, see the README.rst file.
+#
+# ****************************************************************************
+
 import os
 import pytest
 import sys

--- a/gcovr/tests/test_html_generator.py
+++ b/gcovr/tests/test_html_generator.py
@@ -7,7 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2021 the gcovr authors
+# Copyright (c) 2013-2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/tests/test_html_generator.py
+++ b/gcovr/tests/test_html_generator.py
@@ -7,9 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2020-2021 Spacetown <michael.foerderer@gmx.de>
-# Copyright (c) 2020 Antonio Quarta <sgheppy88@gmail.com>
-# and possibly others.
+# Copyright (c) 2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/txt_generator.py
+++ b/gcovr/txt_generator.py
@@ -1,10 +1,22 @@
 # -*- coding:utf-8 -*-
 
-# This file is part of gcovr <http://gcovr.com/>.
+#  ************************** Copyrights and license ***************************
 #
-# Copyright 2013-2018 the gcovr authors
-# Copyright 2013 Sandia Corporation
-# This software is distributed under the BSD license.
+# This file is part of gcovr 4.2, a parsing and reporting tool for gcov.
+# https://gcovr.com/en/stable
+#
+# _____________________________________________________________________________
+#
+# Copyright (c) 2020-2021 Spacetown <michael.foerderer@gmx.de>
+# Copyright (c) 2018-2019 Lukas Atkinson <opensource@LukasAtkinson.de>
+# and possibly others.
+# Copyright (c) 2013 Sandia Corporation.
+# This software is distributed under the BSD License.
+# Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+# the U.S. Government retains certain rights in this software.
+# For more information, see the README.rst file.
+#
+# ****************************************************************************
 
 from .utils import calculate_coverage, sort_coverage, presentable_filename, open_text_for_writing
 

--- a/gcovr/txt_generator.py
+++ b/gcovr/txt_generator.py
@@ -7,9 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2020-2021 Spacetown <michael.foerderer@gmx.de>
-# Copyright (c) 2018-2019 Lukas Atkinson <opensource@LukasAtkinson.de>
-# and possibly others.
+# Copyright (c) 2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/txt_generator.py
+++ b/gcovr/txt_generator.py
@@ -7,7 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2021 the gcovr authors
+# Copyright (c) 2013-2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/utils.py
+++ b/gcovr/utils.py
@@ -1,10 +1,27 @@
 # -*- coding:utf-8 -*-
 
-# This file is part of gcovr <http://gcovr.com/>.
+#  ************************** Copyrights and license ***************************
 #
-# Copyright 2013-2019 the gcovr authors
-# Copyright 2013 Sandia Corporation
-# This software is distributed under the BSD license.
+# This file is part of gcovr 4.2, a parsing and reporting tool for gcov.
+# https://gcovr.com/en/stable
+#
+# _____________________________________________________________________________
+#
+# Copyright (c) 2020-2021 Spacetown <michael.foerderer@gmx.de>
+# Copyright (c) 2020 Oleksiy Pikalo <opikalo@gmail.com>
+# Copyright (c) 2018-2019 Lukas Atkinson <opensource@LukasAtkinson.de>
+# Copyright (c) 2019 Richard Kjerstadius <kjerstadius@gmail.com>
+# Copyright (c) 2018 Marek Kurdej <marek@quasardb.net>
+# Copyright (c) 2018 Songmin Li <lisongmin9@gmail.com>
+# Copyright (c) 2018 Will Thompson <will@willthompson.co.uk>
+# and possibly others.
+# Copyright (c) 2013 Sandia Corporation.
+# This software is distributed under the BSD License.
+# Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+# the U.S. Government retains certain rights in this software.
+# For more information, see the README.rst file.
+#
+# ****************************************************************************
 
 from argparse import ArgumentTypeError
 import os

--- a/gcovr/utils.py
+++ b/gcovr/utils.py
@@ -7,7 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2021 the gcovr authors
+# Copyright (c) 2013-2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/utils.py
+++ b/gcovr/utils.py
@@ -7,14 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2020-2021 Spacetown <michael.foerderer@gmx.de>
-# Copyright (c) 2020 Oleksiy Pikalo <opikalo@gmail.com>
-# Copyright (c) 2018-2019 Lukas Atkinson <opensource@LukasAtkinson.de>
-# Copyright (c) 2019 Richard Kjerstadius <kjerstadius@gmail.com>
-# Copyright (c) 2018 Marek Kurdej <marek@quasardb.net>
-# Copyright (c) 2018 Songmin Li <lisongmin9@gmail.com>
-# Copyright (c) 2018 Will Thompson <will@willthompson.co.uk>
-# and possibly others.
+# Copyright (c) 2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/version.py
+++ b/gcovr/version.py
@@ -7,9 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2021 Spacetown <michael.foerderer@gmx.de>
-# Copyright (c) 2018-2019 Lukas Atkinson <opensource@LukasAtkinson.de>
-# and possibly others.
+# Copyright (c) 2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/version.py
+++ b/gcovr/version.py
@@ -1,13 +1,21 @@
 # -*- coding:utf-8 -*-
 
-# This file is part of gcovr <http://gcovr.com/>.
+#  ************************** Copyrights and license ***************************
 #
-# Copyright 2013-2018 the gcovr authors
-# Copyright 2013 Sandia Corporation
-# This software is distributed under the BSD license.
-
-# This file contains ONLY the version number.
-# It is executed by setup.py to load the current version.
-# This module may not depend on other parts of gcovr.
+# This file is part of gcovr 4.2, a parsing and reporting tool for gcov.
+# https://gcovr.com/en/stable
+#
+# _____________________________________________________________________________
+#
+# Copyright (c) 2021 Spacetown <michael.foerderer@gmx.de>
+# Copyright (c) 2018-2019 Lukas Atkinson <opensource@LukasAtkinson.de>
+# and possibly others.
+# Copyright (c) 2013 Sandia Corporation.
+# This software is distributed under the BSD License.
+# Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+# the U.S. Government retains certain rights in this software.
+# For more information, see the README.rst file.
+#
+# ****************************************************************************
 
 __version__ = "4.2"

--- a/gcovr/version.py
+++ b/gcovr/version.py
@@ -7,7 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2021 the gcovr authors
+# Copyright (c) 2013-2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/workers.py
+++ b/gcovr/workers.py
@@ -1,10 +1,23 @@
 # -*- coding:utf-8 -*-
 
-# This file is part of gcovr <http://gcovr.com/>.
+#  ************************** Copyrights and license ***************************
 #
-# Copyright 2013-2018 the gcovr authors
-# This software is distributed under the BSD license.
-
+# This file is part of gcovr 4.2, a parsing and reporting tool for gcov.
+# https://gcovr.com/en/stable
+#
+# _____________________________________________________________________________
+#
+# Copyright (c) 2021 Spacetown <michael.foerderer@gmx.de>
+# Copyright (c) 2018-2019 Lukas Atkinson <opensource@LukasAtkinson.de>
+# Copyright (c) 2018 James Reynolds <james.reynolds@cristiesoftware.com>
+# and possibly others.
+# Copyright (c) 2013 Sandia Corporation.
+# This software is distributed under the BSD License.
+# Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+# the U.S. Government retains certain rights in this software.
+# For more information, see the README.rst file.
+#
+# ****************************************************************************
 
 from threading import Thread, Condition, RLock
 from contextlib import contextmanager

--- a/gcovr/workers.py
+++ b/gcovr/workers.py
@@ -7,10 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2021 Spacetown <michael.foerderer@gmx.de>
-# Copyright (c) 2018-2019 Lukas Atkinson <opensource@LukasAtkinson.de>
-# Copyright (c) 2018 James Reynolds <james.reynolds@cristiesoftware.com>
-# and possibly others.
+# Copyright (c) 2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/gcovr/workers.py
+++ b/gcovr/workers.py
@@ -7,7 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2021 the gcovr authors
+# Copyright (c) 2013-2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/setup.py
+++ b/setup.py
@@ -7,14 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2020-2021 Spacetown <michael.foerderer@gmx.de>
-# Copyright (c) 2018-2019 Lukas Atkinson <opensource@LukasAtkinson.de>
-# Copyright (c) 2018 mayeut <mayeut@users.noreply.github.com>
-# Copyright (c) 2013-2016 Hart <whart222@gmail.com>
-# Copyright (c) 2013 jsiirola <jsiirola@gmail.com>
-# Copyright (c) 2010-2013 wehart <wehart@sandia.gov>
-# Copyright (c) 2012 jdsiiro <jdsiiro@sandia.gov>
-# and possibly others.
+# Copyright (c) 2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@
 #
 # _____________________________________________________________________________
 #
-# Copyright (c) 2021 the gcovr authors
+# Copyright (c) 2013-2021 the gcovr authors
 # Copyright (c) 2013 Sandia Corporation.
 # This software is distributed under the BSD License.
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,27 @@
-#  _________________________________________________________________________
+# -*- coding:utf-8 -*-
+
+#  ************************** Copyrights and license ***************************
 #
-#  Gcovr: A parsing and reporting tool for gcov
-#  Copyright (c) 2013 Sandia Corporation.
-#  This software is distributed under the BSD License.
-#  Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
-#  the U.S. Government retains certain rights in this software.
-#  For more information, see the README.md file.
-#  _________________________________________________________________________
+# This file is part of gcovr 4.2, a parsing and reporting tool for gcov.
+# https://gcovr.com/en/stable
+#
+# _____________________________________________________________________________
+#
+# Copyright (c) 2020-2021 Spacetown <michael.foerderer@gmx.de>
+# Copyright (c) 2018-2019 Lukas Atkinson <opensource@LukasAtkinson.de>
+# Copyright (c) 2018 mayeut <mayeut@users.noreply.github.com>
+# Copyright (c) 2013-2016 Hart <whart222@gmail.com>
+# Copyright (c) 2013 jsiirola <jsiirola@gmail.com>
+# Copyright (c) 2010-2013 wehart <wehart@sandia.gov>
+# Copyright (c) 2012 jdsiiro <jdsiiro@sandia.gov>
+# and possibly others.
+# Copyright (c) 2013 Sandia Corporation.
+# This software is distributed under the BSD License.
+# Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+# the U.S. Government retains certain rights in this software.
+# For more information, see the README.rst file.
+#
+# ****************************************************************************
 
 """
 Script to generate the installer for gcovr.


### PR DESCRIPTION
Inspired from another project I added a script which writes the copyright info to each python file. The comment contains the contributors sorted by the contribution date and afterwards by name.

The version in the copiright is used from `__Version__.py`.  For the copyright in the documtation the current year is used instead of the fixed 2018.

One idea is to create also the author list from the git log or to extend the copyright comment to other file types.