### PR TITLE
Use setuptools.find_packages() in setup.py (fixes #464)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ Script to generate the installer for gcovr.
 """
 
 from runpy import run_path
-from setuptools import setup
+from setuptools import setup, find_packages
 
 
 version = run_path('./gcovr/version.py')['__version__']
@@ -30,7 +30,7 @@ setup(name='gcovr',
       version=version,
       platforms=["any"],
       python_requires='>=3.5',
-      packages=['gcovr'],
+      packages=find_packages(include=['gcovr*'], exclude=['gcovr.tests']),
       install_requires=[
           'jinja2',
           'lxml',


### PR DESCRIPTION
Given recent refactoring done in #443, use `setuptools.find_packages()` to generate the list of packages for installation.
Fixes #464

[no changelog]