### PR TITLE
Drop support for Python 3.5

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ Next Release
 
 Breaking changes:
 
- - Dropped support for Python 2.
+ - Dropped support for Python 2 and Python 3.5.
    From now on, gcovr will only support Python versions
    that enjoy upstream support.
 

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -28,7 +28,7 @@ Python:
 Operating System:
     Linux, Windows, and macOS.
 
-    The automated tests run on Ubuntu 18.04 and Windows Server 2019.
+    The automated tests run on Ubuntu 18.04 and 20.04 and Windows Server 2019.
 
 Compiler:
     GCC and Clang.

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -8,9 +8,10 @@ Installation
 Which environments does ``gcovr`` support?
 
 Python:
-    3.5+.
+    3.6+.
 
-    The automated tests run on CPython 3.5, CPython 3.7, and PyPy 3.5.
+    The automated tests run on CPython (versions 3.6, 3.7, 3.8)
+    and a compatible PyPy3.
     Gcovr will only run on Python versions with upstream support.
 
     Last gcovr release for old Python versions:
@@ -21,14 +22,15 @@ Python:
     2.6    3.4
     2.7    4.2
     3.4    4.1
+    3.5    4.2
     ====== =====
 
 Operating System:
     Linux, Windows, and macOS.
 
-    The automated tests run on Ubuntu 16.04 and Windows Server 2012.
+    The automated tests run on Ubuntu 18.04 and Windows Server 2019.
 
 Compiler:
     GCC and Clang.
 
-    The automated tests run on GCC 5.
+    The automated tests run on GCC 5, 6, and 8.

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ version = run_path('./gcovr/version.py')['__version__']
 setup(name='gcovr',
       version=version,
       platforms=["any"],
-      python_requires='>=3.5',
+      python_requires='>=3.6',
       packages=find_packages(include=['gcovr*'], exclude=['gcovr.tests']),
       install_requires=[
           'jinja2',


### PR DESCRIPTION
Since 3.5 is EOL, we can drop support.

While updating the docs I noticed that some statements about our test configurations were a bit out of date, so I fixed them as well.

Changelog was updated but doesn't need an issue reference:
[no changelog]