### PR TITLE
Make CI run successfully on all branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,7 @@ name: Test
 
 on:
   push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
     types: [opened, synchronize, reopened, edited]
 
 jobs:
@@ -23,6 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Check if PR is assigned to a milestone
+      if: ${{ github.event_name == 'pull_request' }}
       run: |
         if [ -z "$PR_MILESTONE" ]; then
           echo 'No milestone selected for PR'
@@ -77,7 +76,7 @@ jobs:
     - name: Run release_checklist
       run: |
         admin/release_checklist --no-verify-tags --no-verify-docs-next-version 4.2
- 
+
   build:
     runs-on: ${{ matrix.os }}
 
@@ -170,7 +169,7 @@ jobs:
     - name: Generate documentation
       run: |
         make doc
-  
+
   run-docker:
     runs-on: ubuntu-18.04
     needs: [milestone-check, changelog-check, release-check]


### PR DESCRIPTION
This PR contains two changes.

First, the **milestone check** only makes sense on pull requests, so it's now limited to events of that type. Previously, this would cause the CI to fail on the master branch.

Second, running the CI is also useful on **branches other than master**. In particular, this lets contributors run CI on their forked repositories.

Since this is a purely internal change relating to #460:
[no changelog]