### PR TITLE
Fix documentation generation for Python 3.6.

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,4 @@
 sphinx
 sphinx_rtd_theme
-sphinxcontrib-autoprogram>=0.1.5
+sphinxcontrib-autoprogram == 0.1.5 ; python_version == "3.6"
+sphinxcontrib-autoprogram >= 0.1.5 ; python_version >= "3.7"


### PR DESCRIPTION
Because of https://github.com/sphinx-contrib/autoprogram/issues/42 version is pinned for Python 3.6.

[no changelog]