### PR TITLE
Add abstract interface for reader/writer.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,9 @@ Documentation:
 
 Internal changes:
 
+ - Move generators/writer to sub directory. (:issue:`443`)
+ - Add base class for reader and writers. Move the format specific stuff (CLI options, checks, ...) to the
+   derived class. (:issue:`474`)
  - Clean GCC environment variables in test suite. (:issue:`493`)
  - Fix problems from deployment of release 5.0. (:issue:`494`)
  - Use yaxmldiff for XML diffing in tests. (:issue:`495`)

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ endif
 endif
 	$(GCOV) --version
 
-qa: doc lint check-format test doc
+qa: lint check-format test doc
 
 lint:
 	$(PYTHON) -m flake8 doc gcovr

--- a/admin/add_copyright.py
+++ b/admin/add_copyright.py
@@ -89,8 +89,10 @@ def addCopyrightToPythonFile(filename, lines):
     if headerEndReached:
         for line in iterLines:
             if line != "":
-                # Use one empty line
+                # Use one empty line or two for classes
                 newLines.append("")
+                if line.startswith("class"):
+                    newLines.append("")
                 newLines.append(line)
                 break
         # keep all other lines

--- a/gcovr/coverage.py
+++ b/gcovr/coverage.py
@@ -16,7 +16,7 @@
 #
 # ****************************************************************************
 
-from .utils import calculate_coverage
+from gcovr.writer.utils import calculate_coverage
 
 # for type annotations:
 if False: from typing import (  # noqa, pylint: disable=all

--- a/gcovr/gcov.py
+++ b/gcovr/gcov.py
@@ -539,7 +539,7 @@ class GcovParser(object):
         for ex in self.deferred_exceptions:
             raise ex
 
-        sys.exit(1)
+        sys.exit(1)  # TBD: Change exit code because 1 is used for CLI errors
 
 
 def process_datafile(filename, covdata, options, toerase, workdir):

--- a/gcovr/reader/__init__.py
+++ b/gcovr/reader/__init__.py
@@ -16,26 +16,28 @@
 #
 # ****************************************************************************
 
-import sys
+from .json import Json
 
-from ..utils import get_global_stats
+READERS = [Json()]
 
 
-def print_summary(covdata):
-    '''Print a small report to the standard output.
-    Output the percentage, covered and total lines and branches.
-    '''
+class Readers:
+    __options_called = False
 
-    (lines_total, lines_covered, percent,
-     branches_total, branches_covered,
-     percent_branches) = get_global_stats(covdata)
+    @classmethod
+    def options(_cls):
+        if not _cls.__options_called:
+            _cls.__options_called = True
+            for r in READERS:
+                for o in r.options():
+                    yield o
 
-    lines_out = "lines: %0.1f%% (%s out of %s)\n" % (
-        percent, lines_covered, lines_total
-    )
-    branches_out = "branches: %0.1f%% (%s out of %s)\n" % (
-        percent_branches, branches_covered, branches_total
-    )
+    @classmethod
+    def check_options(_cls, options, logger):
+        for r in READERS:
+            r.check_options(options, logger)
 
-    sys.stdout.write(lines_out)
-    sys.stdout.write(branches_out)
+    @classmethod
+    def read(_cls, covdata, options, logger):
+        for r in READERS:
+            r.read(covdata, options, logger)

--- a/gcovr/reader/base.py
+++ b/gcovr/reader/base.py
@@ -1,0 +1,28 @@
+# -*- coding:utf-8 -*-
+
+#  ************************** Copyrights and license ***************************
+#
+# This file is part of gcovr 4.2, a parsing and reporting tool for gcov.
+# https://gcovr.com/en/stable
+#
+# _____________________________________________________________________________
+#
+# Copyright (c) 2013-2021 the gcovr authors
+# Copyright (c) 2013 Sandia Corporation.
+# This software is distributed under the BSD License.
+# Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+# the U.S. Government retains certain rights in this software.
+# For more information, see the README.rst file.
+#
+# ****************************************************************************
+
+
+class Base:
+    def options(self):
+        raise NotImplementedError("Iterator options not implemented")
+
+    def check_options(self, options, logger):
+        pass
+
+    def read(self, covdata, options, logger):
+        raise NotImplementedError("Function read not implemented")

--- a/gcovr/reader/json.py
+++ b/gcovr/reader/json.py
@@ -1,0 +1,141 @@
+# -*- coding:utf-8 -*-
+
+#  ************************** Copyrights and license ***************************
+#
+# This file is part of gcovr 4.2, a parsing and reporting tool for gcov.
+# https://gcovr.com/en/stable
+#
+# _____________________________________________________________________________
+#
+# Copyright (c) 2013-2021 the gcovr authors
+# Copyright (c) 2013 Sandia Corporation.
+# This software is distributed under the BSD License.
+# Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+# the U.S. Government retains certain rights in this software.
+# For more information, see the README.rst file.
+#
+# ****************************************************************************
+
+import json
+import os
+import sys
+
+from glob import glob
+
+from .base import Base
+from ..gcov import apply_filter_include_exclude
+from ..coverage import FileCoverage
+from ..configuration import GcovrConfigOption
+from ..writer.json import JSON_FORMAT_VERSION
+
+
+class Json(Base):
+    def options(self):
+        yield GcovrConfigOption(
+            "add_tracefile",
+            ["-a", "--add-tracefile"],
+            help="Combine the coverage data from JSON files. "
+            "Coverage files contains source files structure relative "
+            "to root directory. Those structures are combined "
+            "in the output relative to the current root directory. "
+            "Unix style wildcards can be used to add the pathnames "
+            "matching a specified pattern. In this case pattern "
+            "must be set in double quotation marks. "
+            "Option can be specified multiple times. "
+            "When option is used gcov is not run to collect "
+            "the new coverage data.",
+            action="append",
+            default=[],
+        )
+
+    def read(self, covdata, options, logger):
+        r"""merge a coverage from multiple reports in the format
+        partially compatible with gcov JSON output"""
+
+        if len(options.add_tracefile):
+            filenames = set()
+            for trace_files_regex in options.add_tracefile:
+                trace_files = glob(trace_files_regex, recursive=True)
+                if not trace_files:
+                    logger.error(
+                        "Bad --add-tracefile option.\n"
+                        "\tThe specified file does not exist."
+                    )
+                    sys.exit(1)
+                else:
+                    for trace_file in trace_files:
+                        filenames.add(os.path.normpath(trace_file))
+
+            for filename in filenames:
+                gcovr_json_data = {}
+                logger.verbose_msg("Processing JSON file: {}", filename)
+
+                with open(filename, "r") as json_file:
+                    gcovr_json_data = json.load(json_file)
+
+                version = str(gcovr_json_data["gcovr/format_version"])
+                assert (
+                    version == JSON_FORMAT_VERSION
+                ), "Wrong format version, got {} expected {}.".format(
+                    version, JSON_FORMAT_VERSION
+                )
+
+                coverage = {}
+                for gcovr_file in gcovr_json_data["files"]:
+                    file_path = os.path.join(
+                        os.path.abspath(options.root),
+                        os.path.normpath(gcovr_file["file"]),
+                    )
+
+                    filtered, excluded = apply_filter_include_exclude(
+                        file_path, options.filter, options.exclude
+                    )
+
+                    # Ignore if the filename does not match the filter
+                    if filtered:
+                        logger.verbose_msg(
+                            "  Filtering coverage data for file {}", file_path
+                        )
+                        continue
+
+                    # Ignore if the filename matches the exclude pattern
+                    if excluded:
+                        logger.verbose_msg(
+                            "  Excluding coverage data for file {}", file_path
+                        )
+                        continue
+
+                    file_coverage = FileCoverage(file_path)
+                    self._lines_from_json(file_coverage, gcovr_file["lines"])
+                    coverage[file_path] = file_coverage
+
+                self._split_coverage_results(covdata, coverage)
+
+    def _split_coverage_results(self, covdata, coverages):
+        for coverage in coverages.values():
+            if coverage.filename not in covdata:
+                covdata[coverage.filename] = FileCoverage(coverage.filename)
+
+            covdata[coverage.filename].update(coverage)
+
+    def _lines_from_json(self, file, json_lines):
+        [
+            self._line_from_json(file.line(json_line["line_number"]), json_line)
+            for json_line in json_lines
+        ]
+
+    def _line_from_json(self, line, json_line):
+        line.noncode = json_line["gcovr/noncode"]
+        line.count = json_line["count"]
+        self._branches_from_json(line, json_line["branches"])
+
+    def _branches_from_json(self, line, json_branches):
+        [
+            self._branch_from_json(line.branch(no), json_branch)
+            for no, json_branch in enumerate(json_branches, 0)
+        ]
+
+    def _branch_from_json(self, branch, json_branch):
+        branch.fallthrough = json_branch["fallthrough"]
+        branch.throw = json_branch["throw"]
+        branch.count = json_branch["count"]

--- a/gcovr/reader/json.py
+++ b/gcovr/reader/json.py
@@ -31,7 +31,7 @@ from ..writer.json import JSON_FORMAT_VERSION
 class Json(Base):
     def options(self):
         yield GcovrConfigOption(
-            "add_tracefile",
+            "json_add_tracefile",
             ["-a", "--add-tracefile"],
             help="Combine the coverage data from JSON files. "
             "Coverage files contains source files structure relative "
@@ -48,9 +48,9 @@ class Json(Base):
         )
 
     def check_options(self, options, logger):
-        if len(options.add_tracefile):
+        if len(options.json_add_tracefile):
             filenames = set()
-            for trace_files_regex in options.add_tracefile:
+            for trace_files_regex in options.json_add_tracefile:
                 trace_files = glob(trace_files_regex, recursive=True)
                 if not trace_files:
                     raise RuntimeError(
@@ -61,14 +61,14 @@ class Json(Base):
                     for trace_file in trace_files:
                         filenames.add(os.path.normpath(trace_file))
 
-            options.add_tracefile = filenames
+            options.json_add_tracefile = filenames
 
     def read(self, covdata, options, logger):
         r"""merge a coverage from multiple reports in the format
         partially compatible with gcov JSON output"""
 
-        if len(options.add_tracefile):
-            for filename in options.add_tracefile:
+        if len(options.json_add_tracefile):
+            for filename in options.json_add_tracefile:
                 gcovr_json_data = {}
                 logger.verbose_msg("Processing JSON file: {}", filename)
 

--- a/gcovr/reader/json.py
+++ b/gcovr/reader/json.py
@@ -18,7 +18,6 @@
 
 import json
 import os
-import sys
 
 from glob import glob
 
@@ -48,25 +47,28 @@ class Json(Base):
             default=[],
         )
 
-    def read(self, covdata, options, logger):
-        r"""merge a coverage from multiple reports in the format
-        partially compatible with gcov JSON output"""
-
+    def check_options(self, options, logger):
         if len(options.add_tracefile):
             filenames = set()
             for trace_files_regex in options.add_tracefile:
                 trace_files = glob(trace_files_regex, recursive=True)
                 if not trace_files:
-                    logger.error(
+                    raise RuntimeError(
                         "Bad --add-tracefile option.\n"
-                        "\tThe specified file does not exist."
+                        "\tThe specified file [{}] does not exist.".format(trace_files_regex)
                     )
-                    sys.exit(1)
                 else:
                     for trace_file in trace_files:
                         filenames.add(os.path.normpath(trace_file))
 
-            for filename in filenames:
+            options.add_tracefile = filenames
+
+    def read(self, covdata, options, logger):
+        r"""merge a coverage from multiple reports in the format
+        partially compatible with gcov JSON output"""
+
+        if len(options.add_tracefile):
+            for filename in options.add_tracefile:
                 gcovr_json_data = {}
                 logger.verbose_msg("Processing JSON file: {}", filename)
 

--- a/gcovr/tests/test_args.py
+++ b/gcovr/tests/test_args.py
@@ -330,16 +330,23 @@ def test_html_tab_size_zero(capsys):
 
 
 def test_multiple_output_formats_to_stdout(capsys):
-    c = capture(capsys, ['--xml', '--html', '--sonarqube', '--coveralls'])
+    c = capture(capsys, ['--json', '--txt', '--html', '--csv', '--xml', '--sonarqube', '--coveralls'])
+    print(c.err)
+    assert 'Text output skipped' in c.err
     assert 'HTML output skipped' in c.err
+    assert 'CSV output skipped' in c.err
+    assert 'Cobertura output skipped' in c.err
     assert 'Sonarqube output skipped' in c.err
     assert 'Coveralls output skipped' in c.err
     assert c.exception.code == 0
 
 
 def test_multiple_output_formats_to_stdout_1(capsys):
-    c = capture(capsys, ['--xml', '--html', '--sonarqube', '--coveralls', '-o', '-'])
+    c = capture(capsys, ['--json', '--txt', '--html', '--csv', '--xml', '--sonarqube', '--coveralls', '-o', '-'])
+    assert 'Text output skipped' in c.err
     assert 'HTML output skipped' in c.err
+    assert 'CSV output skipped' in c.err
+    assert 'Cobertura output skipped' in c.err
     assert 'Sonarqube output skipped' in c.err
     assert 'Coveralls output skipped' in c.err
     assert c.exception.code == 0

--- a/gcovr/tests/test_config.py
+++ b/gcovr/tests/test_config.py
@@ -124,7 +124,7 @@ def test_unknown_keys():
      True, False, True),
     ('store_true', 'delete-gcov-files', 'delete',
      True, False, True),
-    ('store_false', 'html-absolute-paths', 'relative_anchors',
+    ('store_false', 'html-absolute-paths', 'html_relative_anchors',
      False, True, True),
     ('store_const', 'testopt-const', 'testopt_const',
      17, 3, True),

--- a/gcovr/utils.py
+++ b/gcovr/utils.py
@@ -20,7 +20,6 @@ from argparse import ArgumentTypeError
 import os
 import re
 import sys
-from contextlib import contextmanager
 
 
 class LoopChecker(object):
@@ -113,44 +112,6 @@ def commonpath(files):
     if prefix_path:
         prefix_path = os.path.join(os.path.relpath(prefix_path), '')
     return prefix_path
-
-
-#
-# Get global statistics
-#
-def get_global_stats(covdata):
-    lines_total = 0
-    lines_covered = 0
-    branches_total = 0
-    branches_covered = 0
-
-    keys = list(covdata.keys())
-
-    for key in keys:
-        (total, covered, _) = covdata[key].line_coverage()
-        lines_total += total
-        lines_covered += covered
-
-        (total, covered, _) = covdata[key].branch_coverage()
-        branches_total += total
-        branches_covered += covered
-
-    percent = calculate_coverage(lines_covered, lines_total)
-    percent_branches = calculate_coverage(branches_covered, branches_total)
-
-    return (lines_total, lines_covered, percent,
-            branches_total, branches_covered, percent_branches)
-
-
-def calculate_coverage(covered, total, nan_value=0.0):
-    coverage = nan_value
-    if total != 0:
-        coverage = round(100.0 * covered / total, 1)
-        # If we get 100.0% and not all branches are covered use 99.9%
-        if (coverage == 100.0) and (covered != total):
-            coverage = 99.9
-
-    return coverage
 
 
 class FilterOption(object):
@@ -292,122 +253,3 @@ class Logger(object):
         """
         if self.verbose:
             self.msg(pattern, *args, **kwargs)
-
-
-def sort_coverage(covdata, show_branch,
-                  by_num_uncovered=False, by_percent_uncovered=False):
-    """Sort a coverage dict.
-
-    covdata (dict): the coverage dictionary
-    show_branch (bool): select branch coverage (True) or line coverage (False)
-    by_num_uncovered, by_percent_uncovered (bool):
-        select the sort mode. By default, sort alphabetically.
-
-    returns: the sorted keys
-    """
-    def num_uncovered_key(key):
-        cov = covdata[key]
-        (total, covered, _) = \
-            cov.branch_coverage() if show_branch else cov.line_coverage()
-        uncovered = total - covered
-        return uncovered
-
-    def percent_uncovered_key(key):
-        cov = covdata[key]
-        (total, covered, _) = \
-            cov.branch_coverage() if show_branch else cov.line_coverage()
-        if covered:
-            return -1.0 * covered / total
-        elif total:
-            return total
-        else:
-            return 1e6
-
-    if by_num_uncovered:
-        key_fn = num_uncovered_key
-    elif by_percent_uncovered:
-        key_fn = percent_uncovered_key
-    else:
-        key_fn = None  # default key, sort alphabetically
-
-    return sorted(covdata, key=key_fn)
-
-
-@contextmanager
-def open_text_for_writing(filename=None, default_filename=None, **kwargs):
-    """Context manager to open and close a file for text writing.
-
-    Stdout is used if `filename` is None or '-'.
-    """
-    if filename is not None and filename.endswith(os.sep):
-        filename += default_filename
-
-    if filename is not None and filename != '-':
-        fh = open(filename, 'w', **kwargs)
-        close = True
-    else:
-        fh = sys.stdout
-        close = False
-
-    try:
-        yield fh
-    finally:
-        if close:
-            fh.close()
-
-
-@contextmanager
-def open_binary_for_writing(filename=None, default_filename=None, **kwargs):
-    """Context manager to open and close a file for binary writing.
-
-    Stdout is used if `filename` is None or '-'.
-    """
-    if filename is not None and filename.endswith(os.sep):
-        filename += default_filename
-
-    if filename is not None and filename != '-':
-        # files in write binary mode for UTF-8
-        fh = open(filename, 'wb', **kwargs)
-        close = True
-    else:
-        fh = sys.stdout.buffer
-        close = False
-
-    try:
-        yield fh
-    finally:
-        if close:
-            fh.close()
-
-
-def presentable_filename(filename, root_filter):
-    # type: (str, re.Regex) -> str
-    """mangle a filename so that it is suitable for a report"""
-
-    normalized = root_filter.sub('', filename)
-    if filename.endswith(normalized):
-        # remove any slashes between the removed prefix and the normalized name
-        if filename != normalized:
-            while normalized.startswith(os.path.sep):
-                normalized = normalized[len(os.path.sep):]
-    else:
-        # Do no truncation if the filter does not start matching
-        # at the beginning of the string
-        normalized = filename
-
-    return normalized.replace('\\', '/')
-
-
-def fixup_percent(percent):
-    # output csv percent values in range [0,1.0]
-    return percent / 100 if percent is not None else None
-
-
-def summarize_file_coverage(coverage, root_filter):
-    filename = presentable_filename(
-        coverage.filename, root_filter=root_filter)
-
-    branch_total, branch_covered, branch_percent = coverage.branch_coverage()
-    line_total, line_covered, line_percent = coverage.line_coverage()
-    return (filename, line_total, line_covered, fixup_percent(line_percent),
-            branch_total, branch_covered, fixup_percent(branch_percent))

--- a/gcovr/writer/__init__.py
+++ b/gcovr/writer/__init__.py
@@ -16,8 +16,6 @@
 #
 # ****************************************************************************
 
-import sys
-
 from ..configuration import GcovrConfigOption
 from .json import Json
 from .cobertura import Cobertura
@@ -94,5 +92,4 @@ class Writers:
             print_summary_report(covdata)
 
         if writer_error_occurred:
-            logger.error("Error occurred while printing reports")
-            sys.exit(7)
+            raise RuntimeError("Error occurred while printing reports")

--- a/gcovr/writer/__init__.py
+++ b/gcovr/writer/__init__.py
@@ -1,0 +1,98 @@
+# -*- coding:utf-8 -*-
+
+#  ************************** Copyrights and license ***************************
+#
+# This file is part of gcovr 4.2, a parsing and reporting tool for gcov.
+# https://gcovr.com/en/stable
+#
+# _____________________________________________________________________________
+#
+# Copyright (c) 2013-2021 the gcovr authors
+# Copyright (c) 2013 Sandia Corporation.
+# This software is distributed under the BSD License.
+# Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+# the U.S. Government retains certain rights in this software.
+# For more information, see the README.rst file.
+#
+# ****************************************************************************
+
+import sys
+
+from ..configuration import GcovrConfigOption
+from .json import Json
+from .cobertura import Cobertura
+from .html import Html
+from .txt import Txt, print_report, print_summary_report
+from .csv import Csv
+from .sonarqube import Sonarqube
+from .coveralls import Coveralls
+
+WRITERS = [Json(), Txt(), Html(), Csv(), Cobertura(), Sonarqube(), Coveralls()]
+
+
+class Writers:
+    __options_called = False
+
+    @classmethod
+    def options(_cls):
+        if not _cls.__options_called:
+            _cls.__options_called = True
+            for w in WRITERS:
+                for o in w.options():
+                    yield o
+
+    @classmethod
+    def check_options(_cls, options, logger):
+        for w in WRITERS:
+            w.check_options(options, logger)
+
+    @classmethod
+    def write(_cls, covdata, options, logger):
+        writer_error_occurred = False
+        reports_were_written = False
+        default_output_used = False
+        default_output = (
+            GcovrConfigOption.OutputOrDefault(None)
+            if options.output is None
+            else options.output
+        )
+
+        for w in WRITERS:
+            for output_choices, writer, on_no_output in w.writers(options, logger):
+                output = GcovrConfigOption.OutputOrDefault.choose(
+                    output_choices, default=default_output
+                )
+                if output is not None and output is default_output:
+                    default_output_used = True
+                    if not output.is_dir:
+                        default_output = None
+                if output is not None:
+                    if writer(covdata, output.abspath, options):
+                        writer_error_occurred = True
+                    reports_were_written = True
+                else:
+                    on_no_output()
+
+        if not reports_were_written:
+            print_report(
+                covdata,
+                "-" if default_output is None else default_output.abspath,
+                options,
+            )
+            default_output = None
+
+        if (
+            default_output is not None
+            and default_output.value is not None
+            and not default_output_used
+        ):
+            logger.warn(
+                "--output={!r} option was provided but not used.", default_output.value
+            )
+
+        if options.print_summary:
+            print_summary_report(covdata)
+
+        if writer_error_occurred:
+            logger.error("Error occurred while printing reports")
+            sys.exit(7)

--- a/gcovr/writer/base.py
+++ b/gcovr/writer/base.py
@@ -1,0 +1,34 @@
+# -*- coding:utf-8 -*-
+
+#  ************************** Copyrights and license ***************************
+#
+# This file is part of gcovr 4.2, a parsing and reporting tool for gcov.
+# https://gcovr.com/en/stable
+#
+# _____________________________________________________________________________
+#
+# Copyright (c) 2013-2021 the gcovr authors
+# Copyright (c) 2013 Sandia Corporation.
+# This software is distributed under the BSD License.
+# Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+# the U.S. Government retains certain rights in this software.
+# For more information, see the README.rst file.
+#
+# ****************************************************************************
+
+
+class Base:
+    def options(self):
+        raise NotImplementedError("Iterator options not implemented")
+
+    def check_options(self, options, logger):
+        pass
+
+    def writers(self, options, logger):
+        raise NotImplementedError("Iterator writers not implemented")
+
+    def print_report(self, covdata, output_file, options):
+        raise NotImplementedError("Function print_report not implemented")
+
+    def print_summary_report(self, covdata, output_file, options):
+        raise NotImplementedError("Function print_summary not implemented")

--- a/gcovr/writer/cobertura.py
+++ b/gcovr/writer/cobertura.py
@@ -41,7 +41,7 @@ class Cobertura(Base):
             const=GcovrConfigOption.OutputOrDefault(None),
         )
         yield GcovrConfigOption(
-            "prettycobertura",
+            "cobertura_pretty",
             ["--cobertura-pretty", "--xml-pretty"],
             group="output_options",
             help="Pretty-print the XML report. Implies --xml. Default: {default!s}.",
@@ -49,7 +49,7 @@ class Cobertura(Base):
         )
 
     def writers(self, options, logger):
-        if options.cobertura or options.prettycobertura:
+        if options.cobertura or options.cobertura_pretty:
             yield (
                 [options.cobertura],
                 print_report,
@@ -194,7 +194,7 @@ def print_report(covdata, output_file, options):
         fh.write(
             etree.tostring(
                 root,
-                pretty_print=options.prettycobertura,
+                pretty_print=options.cobertura_pretty,
                 encoding="UTF-8",
                 xml_declaration=True,
                 doctype="<!DOCTYPE coverage SYSTEM 'http://cobertura.sourceforge.net/xml/coverage-04.dtd'>",

--- a/gcovr/writer/coveralls.py
+++ b/gcovr/writer/coveralls.py
@@ -27,26 +27,49 @@ import shutil
 import subprocess
 
 from hashlib import md5
-from ..utils import presentable_filename, open_text_for_writing
+
+from .base import Base
+from .utils import presentable_filename, open_text_for_writing
+from ..configuration import GcovrConfigOption
 
 PRETTY_JSON_INDENT = 4
 
 
-def _write_coveralls_result(gcovr_json_dict, output_file, pretty):
-    r"""helper utility to output json format dictionary to a file/STDOUT """
-    write_json = json.dump
+class Coveralls(Base):
+    def options(self):
+        yield GcovrConfigOption(
+            "coveralls",
+            ["--coveralls"],
+            group="output_options",
+            metavar="OUTPUT",
+            help="Generate Coveralls API coverage report in this file name. "
+            "OUTPUT is optional and defaults to --output.",
+            nargs="?",
+            type=GcovrConfigOption.OutputOrDefault,
+            default=None,
+            const=GcovrConfigOption.OutputOrDefault(None),
+        )
+        yield GcovrConfigOption(
+            "coveralls_pretty",
+            ["--coveralls-pretty"],
+            group="output_options",
+            help="Pretty-print the coveralls report. Implies --coveralls. Default: {default!s}.",
+            action="store_true",
+        )
 
-    if pretty:
-        write_json = functools.partial(write_json, indent=PRETTY_JSON_INDENT,
-                                       separators=(',', ': '), sort_keys=True)
-    else:
-        write_json = functools.partial(write_json, sort_keys=True)
+    def writers(self, options, logger):
+        if options.coveralls or options.coveralls_pretty:
+            yield (
+                [options.coveralls],
+                print_report,
+                lambda: logger.warn(
+                    "Coveralls output skipped - "
+                    "consider providing output file with `--coveralls=OUTPUT`."
+                ),
+            )
 
-    with open_text_for_writing(output_file, 'coveralls.json') as fh:
-        write_json(gcovr_json_dict, fh)
 
-
-def print_coveralls_report(covdata, output_file, options):
+def print_report(covdata, output_file, options):
     """
     Outputs a JSON report in the Coveralls API coverage format
 
@@ -59,128 +82,134 @@ def print_coveralls_report(covdata, output_file, options):
     json_dict = {}
 
     # Capture timestamp
-    json_dict['run_at'] = datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S UTC")
+    json_dict["run_at"] = datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S UTC")
 
     # Pull environment variables
-    if(os.environ.get('COVERALLS_REPO_TOKEN') is not None):
-        json_dict['repo_token'] = os.environ.get('COVERALLS_REPO_TOKEN')
+    if os.environ.get("COVERALLS_REPO_TOKEN") is not None:
+        json_dict["repo_token"] = os.environ.get("COVERALLS_REPO_TOKEN")
 
     CurrentBranch = None
     CurrentCommit = None
     CurrentPullRequest = None
     # Stub for own test suite
-    if (os.environ.get('GCOVR_TEST_SUITE') is not None):
-        json_dict['service_name'] = "gcovr-test-suite"
-        json_dict['service_job_id'] = 'id'
-        json_dict['service_number'] = 'number'
-        CurrentPullRequest = 'pr'
-        CurrentBranch = 'branch'
+    if os.environ.get("GCOVR_TEST_SUITE") is not None:
+        json_dict["service_name"] = "gcovr-test-suite"
+        json_dict["service_job_id"] = "id"
+        json_dict["service_number"] = "number"
+        CurrentPullRequest = "pr"
+        CurrentBranch = "branch"
         CurrentCommit = None
     # Consume Travis CI specific environment variables _(if available)_
     # See https://docs.travis-ci.com/user/environment-variables
-    elif (os.environ.get('TRAVIS_JOB_ID') is not None):
-        json_dict['service_name'] = "travis-ci"
-        json_dict['service_job_id'] = os.environ.get('TRAVIS_JOB_ID')
-        json_dict['service_number'] = os.environ.get('TRAVIS_BUILD_NUMBER')
-        CurrentCommit = os.environ.get('TRAVIS_COMMIT')
-        CurrentPullRequest = os.environ.get('TRAVIS_PULL_REQUEST')
-        CurrentBranch = os.environ.get('TRAVIS_BRANCH')
+    elif os.environ.get("TRAVIS_JOB_ID") is not None:
+        json_dict["service_name"] = "travis-ci"
+        json_dict["service_job_id"] = os.environ.get("TRAVIS_JOB_ID")
+        json_dict["service_number"] = os.environ.get("TRAVIS_BUILD_NUMBER")
+        CurrentCommit = os.environ.get("TRAVIS_COMMIT")
+        CurrentPullRequest = os.environ.get("TRAVIS_PULL_REQUEST")
+        CurrentBranch = os.environ.get("TRAVIS_BRANCH")
     # Consume Appveyor specific environment variables _(if available)_
     # See https://www.appveyor.com/docs/environment-variables/
-    elif (os.environ.get('APPVEYOR_URL') is not None):
-        json_dict['service_name'] = "appveyor"
-        json_dict['service_job_id'] = os.environ.get('APPVEYOR_JOB_ID')
-        json_dict['service_number'] = os.environ.get('APPVEYOR_JOB_NUMBER')
-        CurrentCommit = os.environ.get('APPVEYOR_REPO_COMMIT')
-        CurrentPullRequest = os.environ.get('APPVEYOR_PULL_REQUEST_NUMBER')
-        CurrentBranch = os.environ.get('APPVEYOR_REPO_BRANCH')
+    elif os.environ.get("APPVEYOR_URL") is not None:
+        json_dict["service_name"] = "appveyor"
+        json_dict["service_job_id"] = os.environ.get("APPVEYOR_JOB_ID")
+        json_dict["service_number"] = os.environ.get("APPVEYOR_JOB_NUMBER")
+        CurrentCommit = os.environ.get("APPVEYOR_REPO_COMMIT")
+        CurrentPullRequest = os.environ.get("APPVEYOR_PULL_REQUEST_NUMBER")
+        CurrentBranch = os.environ.get("APPVEYOR_REPO_BRANCH")
     # Consume Jenkins specific environment variables _(if available)_
     # See https://opensource.triology.de/jenkins/pipeline-syntax/globals
-    elif (os.environ.get('JENKINS_URL') is not None):
-        json_dict['service_name'] = "jenkins-ci"
-        json_dict['service_job_id'] = os.environ.get('JOB_NAME')
-        json_dict['service_number'] = os.environ.get('BUILD_ID')
-        if (os.environ.get('GIT_COMMIT') is not None):
-            CurrentCommit = os.environ.get('GIT_COMMIT')
-        CurrentPullRequest = os.environ.get('CHANGE_ID')
-        CurrentBranch = os.environ.get('BRANCH_NAME')
+    elif os.environ.get("JENKINS_URL") is not None:
+        json_dict["service_name"] = "jenkins-ci"
+        json_dict["service_job_id"] = os.environ.get("JOB_NAME")
+        json_dict["service_number"] = os.environ.get("BUILD_ID")
+        if os.environ.get("GIT_COMMIT") is not None:
+            CurrentCommit = os.environ.get("GIT_COMMIT")
+        CurrentPullRequest = os.environ.get("CHANGE_ID")
+        CurrentBranch = os.environ.get("BRANCH_NAME")
     # Consume GitHup Actions specific environment variables _(if available)_
     # See https://docs.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables
-    elif (os.environ.get('GITHUB_ACTIONS') is not None):
-        json_dict['service_name'] = "github-actions-ci"
-        json_dict['service_job_id'] = os.environ.get('GITHUB_WORKFLOW')
-        json_dict['service_number'] = os.environ.get('GITHUB_RUN_ID')
-        CurrentCommit = os.environ.get('GITHUB_SHA')
-        if os.environ.get('GITHUB_HEAD_REF') is not None:
-            CurrentPullRequest = re.sub(r'^refs/pull/(\d+)/merge$', r'\1', os.environ.get('GITHUB_HEAD_REF'))
-            CurrentBranch = os.environ.get('GITHUB_REF')
+    elif os.environ.get("GITHUB_ACTIONS") is not None:
+        json_dict["service_name"] = "github-actions-ci"
+        json_dict["service_job_id"] = os.environ.get("GITHUB_WORKFLOW")
+        json_dict["service_number"] = os.environ.get("GITHUB_RUN_ID")
+        CurrentCommit = os.environ.get("GITHUB_SHA")
+        if os.environ.get("GITHUB_HEAD_REF") is not None:
+            CurrentPullRequest = re.sub(
+                r"^refs/pull/(\d+)/merge$", r"\1", os.environ.get("GITHUB_HEAD_REF")
+            )
+            CurrentBranch = os.environ.get("GITHUB_REF")
         else:
-            CurrentBranch = re.sub(r'^refs/heads/', '', os.environ.get('GITHUB_REF'))
+            CurrentBranch = re.sub(r"^refs/heads/", "", os.environ.get("GITHUB_REF"))
 
     if CurrentPullRequest is not None:
-        json_dict['service_pull_request'] = CurrentPullRequest
+        json_dict["service_pull_request"] = CurrentPullRequest
 
-    git = shutil.which('git') if os.environ.get('GCOVR_TEST_SUITE_NO_GIT_COMMAND') is None else None
+    git = (
+        shutil.which("git")
+        if os.environ.get("GCOVR_TEST_SUITE_NO_GIT_COMMAND") is None
+        else None
+    )
 
     def run_git_cmd(*args):
-        process = subprocess.Popen([git] + list(args),
-                                   stdout=subprocess.PIPE,
-                                   cwd=options.root_dir)
-        return process.communicate()[0].decode('UTF-8').rstrip()
+        process = subprocess.Popen(
+            [git] + list(args), stdout=subprocess.PIPE, cwd=options.root_dir
+        )
+        return process.communicate()[0].decode("UTF-8").rstrip()
 
     def run_git_log_cmd(arg):
-        return run_git_cmd('--no-pager', 'log', '-1', '--pretty=format:{}'.format(arg))
+        return run_git_cmd("--no-pager", "log", "-1", "--pretty=format:{}".format(arg))
 
-    if (git and 'true' in run_git_cmd('rev-parse', '--is-inside-work-tree')):
+    if git and "true" in run_git_cmd("rev-parse", "--is-inside-work-tree"):
         if CurrentBranch is None:
-            CurrentBranch = run_git_cmd('rev-parse', '--abbrev-ref', 'HEAD').rstrip()
+            CurrentBranch = run_git_cmd("rev-parse", "--abbrev-ref", "HEAD").rstrip()
         if CurrentCommit is None:
-            CurrentCommit = run_git_log_cmd('%H')
+            CurrentCommit = run_git_log_cmd("%H")
 
-        json_dict['git'] = {
-            'head': {
-                'id': CurrentCommit,
-                'author_name': run_git_log_cmd('%aN'),
-                'author_email': run_git_log_cmd('%ae'),
-                'committer_name': run_git_log_cmd('%cN'),
-                'committer_email': run_git_log_cmd('%ce'),
-                'message': run_git_log_cmd('%s')
+        json_dict["git"] = {
+            "head": {
+                "id": CurrentCommit,
+                "author_name": run_git_log_cmd("%aN"),
+                "author_email": run_git_log_cmd("%ae"),
+                "committer_name": run_git_log_cmd("%cN"),
+                "committer_email": run_git_log_cmd("%ce"),
+                "message": run_git_log_cmd("%s"),
             },
-            'branch': CurrentBranch,
-            'remotes': [
-                {
-                    'name': line.split()[0],
-                    'url': line.split()[1]
-                }
-                for line in run_git_cmd('remote', '-v').split('\n') if line.endswith('(fetch)')
-            ]
+            "branch": CurrentBranch,
+            "remotes": [
+                {"name": line.split()[0], "url": line.split()[1]}
+                for line in run_git_cmd("remote", "-v").split("\n")
+                if line.endswith("(fetch)")
+            ],
         }
     elif CurrentCommit is not None:
-        json_dict['commit_sha'] = CurrentCommit
+        json_dict["commit_sha"] = CurrentCommit
 
     # Loop through each coverage file collecting details
-    json_dict['source_files'] = []
+    json_dict["source_files"] = []
     for file_path in sorted(covdata):
         # Object with Coveralls file details
         source_file = {}
 
         # Generate md5 hash of file contents
-        with open(file_path, 'rb') as file_handle:
+        with open(file_path, "rb") as file_handle:
             hasher = md5()
-            for data in iter(functools.partial(file_handle.read, 8192), b''):
+            for data in iter(functools.partial(file_handle.read, 8192), b""):
                 hasher.update(data)
             file_hash = hasher.hexdigest()
-            source_file['source_digest'] = file_hash
+            source_file["source_digest"] = file_hash
 
         # Extract FileCoverage object
         coverage_details = covdata[file_path]
 
         # Isolate relative file path
-        relative_file_path = presentable_filename(file_path, root_filter=options.root_filter)
-        source_file['name'] = relative_file_path
+        relative_file_path = presentable_filename(
+            file_path, root_filter=options.root_filter
+        )
+        source_file["name"] = relative_file_path
 
         # Initialize coverage array and load with line coverage data
-        source_file['coverage'] = []
+        source_file["coverage"] = []
         # source_file['branches'] = []
         for line in sorted(coverage_details.lines):
             # Extract LineCoverage object
@@ -188,16 +217,16 @@ def print_coveralls_report(covdata, output_file, options):
 
             # Comment lines are not collected in `covdata`, but must
             # be reported to coveralls (fill missing lines)
-            list_index = (len(source_file['coverage']) + 1)
-            source_file['coverage'].extend(None for i in range(list_index, line))
+            list_index = len(source_file["coverage"]) + 1
+            source_file["coverage"].extend(None for i in range(list_index, line))
 
             # Skip blank lines _(neither covered or uncovered)_
             if not line_details.is_covered and not line_details.is_uncovered:
-                source_file['coverage'].append(None)
+                source_file["coverage"].append(None)
                 continue
 
             # Record line counts at corresponding list index
-            source_file['coverage'].append(line_details.count)
+            source_file["coverage"].append(line_details.count)
 
             # Record branch information (INCOMPLETE/OMITTED)
             # branch_details = line_details.branches
@@ -210,6 +239,24 @@ def print_coveralls_report(covdata, output_file, options):
             #     source_file['coverage'].append(b_hits)
 
         # File data has been compiled
-        json_dict['source_files'].append(source_file)
+        json_dict["source_files"].append(source_file)
 
     _write_coveralls_result(json_dict, output_file, options.coveralls_pretty)
+
+
+def _write_coveralls_result(gcovr_json_dict, output_file, pretty):
+    r"""helper utility to output json format dictionary to a file/STDOUT """
+    write_json = json.dump
+
+    if pretty:
+        write_json = functools.partial(
+            write_json,
+            indent=PRETTY_JSON_INDENT,
+            separators=(",", ": "),
+            sort_keys=True,
+        )
+    else:
+        write_json = functools.partial(write_json, sort_keys=True)
+
+    with open_text_for_writing(output_file, "coveralls.json") as fh:
+        write_json(gcovr_json_dict, fh)

--- a/gcovr/writer/html.py
+++ b/gcovr/writer/html.py
@@ -130,7 +130,7 @@ class Html(Base):
             default=4,
         )
         yield GcovrConfigOption(
-            "relative_anchors",
+            "html_relative_anchors",
             ["--html-absolute-paths"],
             group="output_options",
             help="Use absolute paths to link the --html-details reports. "
@@ -350,7 +350,7 @@ class RootInfo:
         self.medium_threshold = options.html_medium_threshold
         self.high_threshold = options.html_high_threshold
         self.details = options.html_details
-        self.relative_anchors = options.relative_anchors
+        self.relative_anchors = options.html_relative_anchors
 
         self.version = __version__
         self.head = options.html_title
@@ -480,7 +480,7 @@ def print_report(covdata, output_file, options):
         with open_text_for_writing(css_output) as f:
             f.write(css_data)
 
-        if options.relative_anchors:
+        if options.html_relative_anchors:
             css_link = os.path.basename(css_output)
         else:
             css_link = css_output

--- a/gcovr/writer/html.py
+++ b/gcovr/writer/html.py
@@ -20,7 +20,6 @@ import os
 import datetime
 import hashlib
 import io
-import sys
 
 from argparse import ArgumentTypeError
 
@@ -163,25 +162,22 @@ class Html(Base):
 
     def check_options(self, options, logger):
         if options.html_title == "":
-            logger.error("an empty --html_title= is not allowed.")
-            sys.exit(1)
+            raise RuntimeError("an empty --html_title= is not allowed.")
 
         if options.html_medium_threshold == 0:
-            logger.error("value of --html-medium-threshold= should not be zero.")
-            sys.exit(1)
+            raise RuntimeError("value of --html-medium-threshold= should not be zero.")
 
         if options.html_medium_threshold > options.html_high_threshold:
-            logger.error(
+            raise RuntimeError(
                 "value of --html-medium-threshold={} should be\n"
-                "lower than or equal to the value of --html-high-threshold={}.",
-                options.html_medium_threshold,
-                options.html_high_threshold,
+                "lower than or equal to the value of --html-high-threshold={}.".format(
+                    options.html_medium_threshold,
+                    options.html_high_threshold
+                )
             )
-            sys.exit(1)
 
         if options.html_tab_size < 1:
-            logger.error("value of --html-tab-size= should be greater 0.")
-            sys.exit(1)
+            raise RuntimeError("value of --html-tab-size= should be greater 0.")
 
         potential_html_output = (
             (options.html and options.html.value)
@@ -189,17 +185,15 @@ class Html(Base):
             or (options.output and options.output.value)
         )
         if options.html_details and not potential_html_output:
-            logger.error(
+            raise RuntimeError(
                 "a named output must be given, if the option --html-details\n"
                 "is used."
             )
-            sys.exit(1)
 
         if options.html_self_contained is False and not potential_html_output:
-            logger.error(
+            raise RuntimeError(
                 "can only disable --html-self-contained when a named output is given."
             )
-            sys.exit(1)
 
     def writers(self, options, logger):
         if options.html or options.html_details:

--- a/gcovr/writer/json.py
+++ b/gcovr/writer/json.py
@@ -19,12 +19,16 @@
 import json
 import os
 import functools
-from ..gcov import apply_filter_include_exclude
 
-from ..utils import (get_global_stats, Logger, presentable_filename,
-                     sort_coverage, summarize_file_coverage, open_text_for_writing)
-
-from ..coverage import FileCoverage
+from .base import Base
+from .utils import (
+    get_global_stats,
+    open_text_for_writing,
+    presentable_filename,
+    sort_coverage,
+    summarize_file_coverage,
+)
+from ..configuration import GcovrConfigOption
 
 
 JSON_FORMAT_VERSION = "0.2"
@@ -32,141 +36,170 @@ JSON_SUMMARY_FORMAT_VERSION = "0.2"
 PRETTY_JSON_INDENT = 4
 
 
+class Json(Base):
+    def options(self):
+        yield GcovrConfigOption(
+            "json",
+            ["--json"],
+            group="output_options",
+            metavar="OUTPUT",
+            help="Generate a JSON report. "
+            "OUTPUT is optional and defaults to --output.",
+            nargs="?",
+            type=GcovrConfigOption.OutputOrDefault,
+            default=None,
+            const=GcovrConfigOption.OutputOrDefault(None),
+        )
+        yield GcovrConfigOption(
+            "json_pretty",
+            ["--json-pretty"],
+            group="output_options",
+            help="Pretty-print the JSON report. Implies --json. Default: {default!s}.",
+            action="store_true",
+        )
+        yield GcovrConfigOption(
+            "json_summary",
+            ["--json-summary"],
+            group="output_options",
+            metavar="OUTPUT",
+            help="Generate a JSON summary report. "
+            "OUTPUT is optional and defaults to --output.",
+            nargs="?",
+            type=GcovrConfigOption.OutputOrDefault,
+            default=None,
+            const=GcovrConfigOption.OutputOrDefault(None),
+        )
+        yield GcovrConfigOption(
+            "json_summary_pretty",
+            ["--json-summary-pretty"],
+            group="output_options",
+            help="Pretty-print the JSON SUMMARY report. Implies --json-summary. Default: {default!s}.",
+            action="store_true",
+        )
+
+    def writers(self, options, logger):
+        if options.json or options.json_pretty:
+            yield (
+                [options.json],
+                print_report,
+                lambda: logger.warn(
+                    "JSON output skipped - "
+                    "consider providing output file with `--json=OUTPUT`."
+                ),
+            )
+
+        if options.json_summary or options.json_summary_pretty:
+            yield (
+                [options.json_summary],
+                print_summary_report,
+                lambda: logger.warn(
+                    "JSON summary output skipped - "
+                    "consider providing output file with `--json-summary=OUTPUT`."
+                ),
+            )
+
+
+def print_report(covdata, output_file, options):
+    r"""produce an JSON report in the format partially
+    compatible with gcov JSON output"""
+
+    gcovr_json_root = {}
+    gcovr_json_root["gcovr/format_version"] = JSON_FORMAT_VERSION
+    gcovr_json_root["files"] = []
+
+    for no in sorted(covdata):
+        gcovr_json_file = {}
+        gcovr_json_file["file"] = presentable_filename(
+            covdata[no].filename, root_filter=options.root_filter
+        )
+        gcovr_json_file["lines"] = _json_from_lines(covdata[no].lines)
+        gcovr_json_root["files"].append(gcovr_json_file)
+
+    _write_json_result(
+        gcovr_json_root, output_file, "coverage.json", options.json_pretty
+    )
+
+
+def print_summary_report(covdata, output_file, options):
+
+    json_dict = {}
+
+    json_dict["root"] = os.path.relpath(
+        options.root, os.getcwd() if output_file == "-" else output_file
+    )
+    json_dict["gcovr/summary_format_version"] = JSON_SUMMARY_FORMAT_VERSION
+    json_dict["files"] = []
+
+    # Data
+    keys = sort_coverage(
+        covdata,
+        show_branch=options.show_branch,
+        by_num_uncovered=options.sort_uncovered,
+        by_percent_uncovered=options.sort_percent,
+    )
+
+    for key in keys:
+        (
+            filename,
+            line_total,
+            line_covered,
+            line_percent,
+            branch_total,
+            branch_covered,
+            branch_percent,
+        ) = summarize_file_coverage(covdata[key], options.root_filter)
+
+        json_dict["files"].append(
+            {
+                "filename": filename,
+                "line_total": line_total,
+                "line_covered": line_covered,
+                "line_percent": line_percent,
+                "branch_total": branch_total,
+                "branch_covered": branch_covered,
+                "branch_percent": branch_percent,
+            }
+        )
+
+    (
+        lines_total,
+        lines_covered,
+        lines_percent,
+        branches_total,
+        branches_covered,
+        branches_percent,
+    ) = get_global_stats(covdata)
+
+    # Footer & summary
+    json_dict["line_total"] = lines_total
+    json_dict["line_covered"] = lines_covered
+    json_dict["line_percent"] = lines_percent
+
+    json_dict["branch_total"] = branches_total
+    json_dict["branch_covered"] = branches_covered
+    json_dict["branch_percent"] = branches_percent
+
+    _write_json_result(
+        json_dict, output_file, "summary_coverage.json", options.json_summary_pretty
+    )
+
+
 def _write_json_result(gcovr_json_dict, output_file, default_filename, pretty):
     r"""helper utility to output json format dictionary to a file/STDOUT """
     write_json = json.dump
 
     if pretty:
-        write_json = functools.partial(write_json, indent=PRETTY_JSON_INDENT,
-                                       separators=(',', ': '), sort_keys=True)
+        write_json = functools.partial(
+            write_json,
+            indent=PRETTY_JSON_INDENT,
+            separators=(",", ": "),
+            sort_keys=True,
+        )
     else:
         write_json = functools.partial(write_json, sort_keys=True)
 
     with open_text_for_writing(output_file, default_filename) as fh:
         write_json(gcovr_json_dict, fh)
-
-
-#
-# Produce gcovr JSON report
-#
-def print_json_report(covdata, output_file, options):
-    r"""produce an JSON report in the format partially
-    compatible with gcov JSON output"""
-
-    gcovr_json_root = {}
-    gcovr_json_root['gcovr/format_version'] = JSON_FORMAT_VERSION
-    gcovr_json_root['files'] = []
-
-    for no in sorted(covdata):
-        gcovr_json_file = {}
-        gcovr_json_file['file'] = presentable_filename(covdata[no].filename,
-                                                       root_filter=options.root_filter)
-        gcovr_json_file['lines'] = _json_from_lines(covdata[no].lines)
-        gcovr_json_root['files'].append(gcovr_json_file)
-
-    _write_json_result(gcovr_json_root, output_file, 'coverage.json', options.json_pretty)
-
-
-#
-# Produce gcovr JSON summary report
-#
-def print_json_summary_report(covdata, output_file, options):
-
-    json_dict = {}
-
-    json_dict['root'] = os.path.relpath(options.root, os.getcwd() if output_file == '-' else output_file)
-    json_dict['gcovr/summary_format_version'] = JSON_SUMMARY_FORMAT_VERSION
-    json_dict['files'] = []
-
-    # Data
-    keys = sort_coverage(
-        covdata, show_branch=options.show_branch,
-        by_num_uncovered=options.sort_uncovered,
-        by_percent_uncovered=options.sort_percent)
-
-    for key in keys:
-        (filename, line_total, line_covered, line_percent,
-         branch_total, branch_covered,
-         branch_percent) = summarize_file_coverage(covdata[key],
-                                                   options.root_filter)
-
-        json_dict['files'].append({
-            'filename': filename,
-            'line_total': line_total,
-            'line_covered': line_covered,
-            'line_percent': line_percent,
-            'branch_total': branch_total,
-            'branch_covered': branch_covered,
-            'branch_percent': branch_percent,
-        })
-
-    (lines_total, lines_covered, lines_percent,
-     branches_total, branches_covered,
-     branches_percent) = get_global_stats(covdata)
-
-    # Footer & summary
-    json_dict['line_total'] = lines_total
-    json_dict['line_covered'] = lines_covered
-    json_dict['line_percent'] = lines_percent
-
-    json_dict['branch_total'] = branches_total
-    json_dict['branch_covered'] = branches_covered
-    json_dict['branch_percent'] = branches_percent
-
-    _write_json_result(json_dict, output_file, 'summary_coverage.json', options.json_summary_pretty)
-
-
-#
-#  Get coverage from already existing gcovr JSON files
-#
-def gcovr_json_files_to_coverage(filenames, covdata, options):
-    r"""merge a coverage from multiple reports in the format
-    partially compatible with gcov JSON output"""
-
-    logger = Logger(options.verbose)
-
-    for filename in filenames:
-        gcovr_json_data = {}
-        logger.verbose_msg("Processing JSON file: {}", filename)
-
-        with open(filename, 'r') as json_file:
-            gcovr_json_data = json.load(json_file)
-
-        version = str(gcovr_json_data['gcovr/format_version'])
-        assert version == JSON_FORMAT_VERSION, "Wrong format version, got {} expected {}.".format(version, JSON_FORMAT_VERSION)
-
-        coverage = {}
-        for gcovr_file in gcovr_json_data['files']:
-            file_path = os.path.join(
-                os.path.abspath(options.root),
-                os.path.normpath(gcovr_file['file']))
-
-            filtered, excluded = apply_filter_include_exclude(
-                file_path, options.filter, options.exclude)
-
-            # Ignore if the filename does not match the filter
-            if filtered:
-                logger.verbose_msg("  Filtering coverage data for file {}", file_path)
-                continue
-
-            # Ignore if the filename matches the exclude pattern
-            if excluded:
-                logger.verbose_msg("  Excluding coverage data for file {}", file_path)
-                continue
-
-            file_coverage = FileCoverage(file_path)
-            _lines_from_json(file_coverage, gcovr_file['lines'])
-            coverage[file_path] = file_coverage
-
-        _split_coverage_results(covdata, coverage)
-
-
-def _split_coverage_results(covdata, coverages):
-    for coverage in coverages.values():
-        if coverage.filename not in covdata:
-            covdata[coverage.filename] = FileCoverage(coverage.filename)
-
-        covdata[coverage.filename].update(coverage)
 
 
 def _json_from_lines(lines):
@@ -176,10 +209,10 @@ def _json_from_lines(lines):
 
 def _json_from_line(line):
     json_line = {}
-    json_line['branches'] = _json_from_branches(line.branches)
-    json_line['count'] = line.count
-    json_line['line_number'] = line.lineno
-    json_line['gcovr/noncode'] = line.noncode
+    json_line["branches"] = _json_from_branches(line.branches)
+    json_line["count"] = line.count
+    json_line["line_number"] = line.lineno
+    json_line["gcovr/noncode"] = line.noncode
     return json_line
 
 
@@ -190,27 +223,7 @@ def _json_from_branches(branches):
 
 def _json_from_branch(branch):
     json_branch = {}
-    json_branch['count'] = branch.count
-    json_branch['fallthrough'] = bool(branch.fallthrough)
-    json_branch['throw'] = bool(branch.throw)
+    json_branch["count"] = branch.count
+    json_branch["fallthrough"] = bool(branch.fallthrough)
+    json_branch["throw"] = bool(branch.throw)
     return json_branch
-
-
-def _lines_from_json(file, json_lines):
-    [_line_from_json(file.line(json_line['line_number']), json_line) for json_line in json_lines]
-
-
-def _line_from_json(line, json_line):
-    line.noncode = json_line['gcovr/noncode']
-    line.count = json_line['count']
-    _branches_from_json(line, json_line['branches'])
-
-
-def _branches_from_json(line, json_branches):
-    [_branch_from_json(line.branch(no), json_branch) for no, json_branch in enumerate(json_branches, 0)]
-
-
-def _branch_from_json(branch, json_branch):
-    branch.fallthrough = json_branch['fallthrough']
-    branch.throw = json_branch['throw']
-    branch.count = json_branch['count']

--- a/gcovr/writer/txt.py
+++ b/gcovr/writer/txt.py
@@ -16,39 +16,87 @@
 #
 # ****************************************************************************
 
-from ..utils import calculate_coverage, sort_coverage, presentable_filename, open_text_for_writing
+import sys
+
+from .base import Base
+from .utils import (
+    calculate_coverage,
+    get_global_stats,
+    open_text_for_writing,
+    presentable_filename,
+    sort_coverage,
+)
+from ..configuration import GcovrConfigOption
 
 
-def print_text_report(covdata, output_file, options):
+class Txt(Base):
+    def options(self):
+        yield GcovrConfigOption(
+            "txt",
+            ["--txt"],
+            group="output_options",
+            metavar="OUTPUT",
+            help="Generate a text report. "
+            "OUTPUT is optional and defaults to --output.",
+            nargs="?",
+            type=GcovrConfigOption.OutputOrDefault,
+            default=None,
+            const=GcovrConfigOption.OutputOrDefault(None),
+        )
+        yield GcovrConfigOption(
+            "print_summary",
+            ["-s", "--print-summary"],
+            group="output_options",
+            help="Print a small report to stdout "
+            "with line & branch percentage coverage. "
+            "This is in addition to other reports. "
+            "Default: {default!s}.",
+            action="store_true",
+        )
+
+    def writers(self, options, logger):
+        if options.txt:
+            yield (
+                [options.txt],
+                print_report,
+                lambda: logger.warn(
+                    "Text output skipped - "
+                    "consider providing an output file with `--txt=OUTPUT`."
+                ),
+            )
+
+
+def print_report(covdata, output_file, options):
     """produce the classic gcovr text report"""
 
-    with open_text_for_writing(output_file, 'coverage.txt') as fh:
+    with open_text_for_writing(output_file, "coverage.txt") as fh:
         total_lines = 0
         total_covered = 0
 
         # Header
-        fh.write("-" * 78 + '\n')
+        fh.write("-" * 78 + "\n")
         fh.write(" " * 27 + "GCC Code Coverage Report\n")
         fh.write("Directory: " + options.root + "\n")
 
-        fh.write("-" * 78 + '\n')
+        fh.write("-" * 78 + "\n")
         a = options.show_branch and "Branches" or "Lines"
         b = options.show_branch and "Taken" or "Exec"
         c = "Missing"
-        fh.write(
-            "File".ljust(40) + a.rjust(8) + b.rjust(8) + "  Cover   " + c + "\n"
-        )
-        fh.write("-" * 78 + '\n')
+        fh.write("File".ljust(40) + a.rjust(8) + b.rjust(8) + "  Cover   " + c + "\n")
+        fh.write("-" * 78 + "\n")
 
         # Data
         keys = sort_coverage(
-            covdata, show_branch=options.show_branch,
+            covdata,
+            show_branch=options.show_branch,
             by_num_uncovered=options.sort_uncovered,
-            by_percent_uncovered=options.sort_percent)
+            by_percent_uncovered=options.sort_percent,
+        )
 
         def _summarize_file_coverage(coverage):
             filename = presentable_filename(
-                coverage.filename, root_filter=options.root_filter)
+                coverage.filename, root_filter=options.root_filter
+            )
             filename = filename.ljust(40)
             if len(filename) > 40:
                 filename = filename + "\n" + " " * 40
@@ -59,23 +107,63 @@ def print_text_report(covdata, output_file, options):
             else:
                 total, cover, percent = coverage.line_coverage()
                 uncovered_lines = coverage.uncovered_lines_str()
-            percent = '--' if percent is None else str(int(percent))
-            return (total, cover,
-                    filename + str(total).rjust(8) + str(cover).rjust(8)
-                    + percent.rjust(6) + "%   " + uncovered_lines)
+            percent = "--" if percent is None else str(int(percent))
+            return (
+                total,
+                cover,
+                filename
+                + str(total).rjust(8)
+                + str(cover).rjust(8)
+                + percent.rjust(6)
+                + "%   "
+                + uncovered_lines,
+            )
 
         for key in keys:
             (t, n, txt) = _summarize_file_coverage(covdata[key])
             total_lines += t
             total_covered += n
-            fh.write(txt + '\n')
+            fh.write(txt + "\n")
 
         # Footer & summary
-        fh.write("-" * 78 + '\n')
+        fh.write("-" * 78 + "\n")
         percent = calculate_coverage(total_covered, total_lines, nan_value=None)
         percent = "--" if percent is None else str(int(percent))
         fh.write(
-            "TOTAL".ljust(40) + str(total_lines).rjust(8)
-            + str(total_covered).rjust(8) + str(percent).rjust(6) + "%" + '\n'
+            "TOTAL".ljust(40)
+            + str(total_lines).rjust(8)
+            + str(total_covered).rjust(8)
+            + str(percent).rjust(6)
+            + "%"
+            + "\n"
         )
-        fh.write("-" * 78 + '\n')
+        fh.write("-" * 78 + "\n")
+
+
+def print_summary_report(covdata):
+    """Print a small report to the standard output.
+    Output the percentage, covered and total lines and branches.
+    """
+
+    (
+        lines_total,
+        lines_covered,
+        percent,
+        branches_total,
+        branches_covered,
+        percent_branches,
+    ) = get_global_stats(covdata)
+
+    lines_out = "lines: %0.1f%% (%s out of %s)\n" % (
+        percent,
+        lines_covered,
+        lines_total,
+    )
+    branches_out = "branches: %0.1f%% (%s out of %s)\n" % (
+        percent_branches,
+        branches_covered,
+        branches_total,
+    )
+
+    sys.stdout.write(lines_out)
+    sys.stdout.write(branches_out)

--- a/gcovr/writer/utils.py
+++ b/gcovr/writer/utils.py
@@ -1,0 +1,212 @@
+# -*- coding:utf-8 -*-
+
+#  ************************** Copyrights and license ***************************
+#
+# This file is part of gcovr 4.2, a parsing and reporting tool for gcov.
+# https://gcovr.com/en/stable
+#
+# _____________________________________________________________________________
+#
+# Copyright (c) 2013-2021 the gcovr authors
+# Copyright (c) 2013 Sandia Corporation.
+# This software is distributed under the BSD License.
+# Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+# the U.S. Government retains certain rights in this software.
+# For more information, see the README.rst file.
+#
+# ****************************************************************************
+
+import os
+import re
+import sys
+
+from contextlib import contextmanager
+
+
+class Lazy:
+    def __init__(self, fn):
+        def load(*args):
+            result = fn(*args)
+
+            def reuse_value(*args):
+                return result
+
+            self.get = reuse_value
+            return result
+
+        self.get = load
+
+    def __call__(self, *args):
+        return self.get(*args)
+
+
+def sort_coverage(
+    covdata, show_branch, by_num_uncovered=False, by_percent_uncovered=False
+):
+    """Sort a coverage dict.
+
+    covdata (dict): the coverage dictionary
+    show_branch (bool): select branch coverage (True) or line coverage (False)
+    by_num_uncovered, by_percent_uncovered (bool):
+        select the sort mode. By default, sort alphabetically.
+
+    returns: the sorted keys
+    """
+
+    def num_uncovered_key(key):
+        cov = covdata[key]
+        (total, covered, _) = (
+            cov.branch_coverage() if show_branch else cov.line_coverage()
+        )
+        uncovered = total - covered
+        return uncovered
+
+    def percent_uncovered_key(key):
+        cov = covdata[key]
+        (total, covered, _) = (
+            cov.branch_coverage() if show_branch else cov.line_coverage()
+        )
+        if covered:
+            return -1.0 * covered / total
+        elif total:
+            return total
+        else:
+            return 1e6
+
+    if by_num_uncovered:
+        key_fn = num_uncovered_key
+    elif by_percent_uncovered:
+        key_fn = percent_uncovered_key
+    else:
+        key_fn = None  # default key, sort alphabetically
+
+    return sorted(covdata, key=key_fn)
+
+
+@contextmanager
+def open_text_for_writing(filename=None, default_filename=None, **kwargs):
+    """Context manager to open and close a file for text writing.
+
+    Stdout is used if `filename` is None or '-'.
+    """
+    if filename is not None and filename.endswith(os.sep):
+        filename += default_filename
+
+    if filename is not None and filename != "-":
+        fh = open(filename, "w", **kwargs)
+        close = True
+    else:
+        fh = sys.stdout
+        close = False
+
+    try:
+        yield fh
+    finally:
+        if close:
+            fh.close()
+
+
+@contextmanager
+def open_binary_for_writing(filename=None, default_filename=None, **kwargs):
+    """Context manager to open and close a file for binary writing.
+
+    Stdout is used if `filename` is None or '-'.
+    """
+    if filename is not None and filename.endswith(os.sep):
+        filename += default_filename
+
+    if filename is not None and filename != "-":
+        # files in write binary mode for UTF-8
+        fh = open(filename, "wb", **kwargs)
+        close = True
+    else:
+        fh = sys.stdout.buffer
+        close = False
+
+    try:
+        yield fh
+    finally:
+        if close:
+            fh.close()
+
+
+def presentable_filename(filename, root_filter):
+    # type: (str, re.Regex) -> str
+    """mangle a filename so that it is suitable for a report"""
+
+    normalized = root_filter.sub("", filename)
+    if filename.endswith(normalized):
+        # remove any slashes between the removed prefix and the normalized name
+        if filename != normalized:
+            while normalized.startswith(os.path.sep):
+                normalized = normalized[len(os.path.sep) :]
+    else:
+        # Do no truncation if the filter does not start matching
+        # at the beginning of the string
+        normalized = filename
+
+    return normalized.replace("\\", "/")
+
+
+def fixup_percent(percent):
+    # output csv percent values in range [0,1.0]
+    return percent / 100 if percent is not None else None
+
+
+def summarize_file_coverage(coverage, root_filter):
+    filename = presentable_filename(coverage.filename, root_filter=root_filter)
+
+    branch_total, branch_covered, branch_percent = coverage.branch_coverage()
+    line_total, line_covered, line_percent = coverage.line_coverage()
+    return (
+        filename,
+        line_total,
+        line_covered,
+        fixup_percent(line_percent),
+        branch_total,
+        branch_covered,
+        fixup_percent(branch_percent),
+    )
+
+
+def get_global_stats(covdata):
+    r"""Get the global statistics"""
+    lines_total = 0
+    lines_covered = 0
+    branches_total = 0
+    branches_covered = 0
+
+    keys = list(covdata.keys())
+
+    for key in keys:
+        (total, covered, _) = covdata[key].line_coverage()
+        lines_total += total
+        lines_covered += covered
+
+        (total, covered, _) = covdata[key].branch_coverage()
+        branches_total += total
+        branches_covered += covered
+
+    percent = calculate_coverage(lines_covered, lines_total)
+    percent_branches = calculate_coverage(branches_covered, branches_total)
+
+    return (
+        lines_total,
+        lines_covered,
+        percent,
+        branches_total,
+        branches_covered,
+        percent_branches,
+    )
+
+
+def calculate_coverage(covered, total, nan_value=0.0):
+    r"""Calculate the coverage. Return only 100.0 if all branches are covered."""
+    coverage = nan_value
+    if total != 0:
+        coverage = round(100.0 * covered / total, 1)
+        # If we get 100.0% and not all branches are covered use 99.9%
+        if (coverage == 100.0) and (covered != total):
+            coverage = 99.9
+
+    return coverage


### PR DESCRIPTION
Ass discussed in #443 a object oriented interface is added.

- The writer `xml.py` is renamed to `coveralls.py` and a option was added. I think we should deprecate the option `--xml` because `sonarcube.py` also produce a XML file.
- `add_copyright.py` was changed to generate black conform files.
- Move generator utils to a seperate file.
- Add reader for JSON files.
- Move the check functions and `OutputOrDefault` to `GcovrConfigOption` to access them eays in the readers and writers.