### PR TITLE
fix Docker-based tests by setting Unicode locale

### DIFF
--- a/admin/Dockerfile.qa
+++ b/admin/Dockerfile.qa
@@ -26,6 +26,10 @@ RUN echo "docker:docker" | chpasswd
 
 USER docker:docker
 
+# Select language-agnostic "C" locale.
+# Unicode is necessary for some tools like "black" to work.
+ENV LC_ALL=C.UTF-8 LANG=C.UTF-8
+
 CMD ( echo docker | sudo -S -p "Running pip with sudo" $PYTHON -m pip install -e . ) && \
   ( echo docker | sudo -S -p "Running chmod with sudo" chown -R docker:docker /gcovr ) && \
   make qa


### PR DESCRIPTION
The Docker tests recently started failing with the following message:

> RuntimeError: Click will abort further execution because Python was configured to use ASCII as encoding for the environment. Consult https://click.palletsprojects.com/unicode-support/ for mitigation steps.
>
> This system supports the C.UTF-8 locale which is recommended. You might be able to resolve your issue by exporting the following environment variables:
>
>     export LC_ALL=C.UTF-8
>     export LANG=C.UTF-8

It seems this is related to the recent update of the Click library to version 8. This library is used by tools such as the `black` formatter.

As a fix, these environment variables are set in the Docker container. This should not affect tests on the host systems, since the hosts usually already have a Unicode locale set.

[no changelog]