### PR TITLE
Fix deploy workflow.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,8 +59,14 @@ jobs:
     - name: Build
       run: |
         python setup.py sdist bdist_wheel
+    - name: Upload distribution
+      if: ${{ success() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: dist
+        path: dist/**
     - name: Publish
-      if: ${{ github.event_name == 'release' }}
+      if: ${{ success() && (github.event_name == 'release') }}
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,16 +1,21 @@
 # This workflows will upload a Python Package using Twine when a release is created
 # For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
 
-name: Upload Python Package
+name: Deploy
 
 on:
   release:
     types: [created]
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
 
 jobs:
 
   release-check:
     runs-on: ubuntu-20.04
+
+    continue-on-error: ${{ github.event_name != 'release' }}
 
     steps:
     - uses: actions/checkout@v2
@@ -22,17 +27,23 @@ jobs:
     runs-on: ubuntu-18.04
     needs: release-check
 
+    env:
+      PYTHON_VERSION: "3.8"
+      CC: "gcc-8"
+
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.5'
-    - name: Install GCC (Linux)
+        python-version: ${{ env.PYTHON_VERSION }}
+    - name: Install GCC
       run: |
         sudo apt update
-        sudo apt-get install -y make ${{ matrix.gcc }} $(echo ${{ matrix.gcc }} | sed -e 's/gcc/g\+\+/')
+        sudo apt-get install -y make $CC $(echo $CC | sed -e 's/gcc/g\+\+/')
         sudo apt-get clean
+    - name: Install ninja
+      uses: seanmiddleditch/gha-setup-ninja@master
     - name: Install dependencies
       run: |
         make setup-dev PYTHON=python
@@ -41,14 +52,17 @@ jobs:
         make lint PYTHON=python
     - name: Test with pytest
       run: |
-        make test CC=${{ matrix.gcc }} PYTHON=python TEST_OPTS="--archive_differences"
+        make test CC=$CC PYTHON=python
     - name: Generate documentation
       run: |
         make doc PYTHON=python
-    - name: Build and publish
+    - name: Build
+      run: |
+        python setup.py sdist bdist_wheel
+    - name: Publish
+      if: ${{ github.event_name == 'release' }}
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python setup.py sdist bdist_wheel
         twine upload dist/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,7 +106,6 @@ jobs:
       run: |
         echo "USE_COVERAGE=${{ ( ( matrix.os == 'windows-2019' ) && ( matrix.python-version == '3.7' ) ) || ( ( matrix.os == 'ubuntu-18.04' ) && ( matrix.gcc == 'gcc-6' ) && ( matrix.python-version == '3.8' ) ) }}" >> $GITHUB_ENV
         echo "CC=${{ matrix.gcc }}" >> $GITHUB_ENV
-        echo "CXX=$(echo ${{ matrix.gcc }} | sed -e 's/gcc/g\+\+/')" >> $GITHUB_ENV
         echo "PYTHON=python" >> $GITHUB_ENV
       shell: bash
     - name: Install msys with GCC (Windows)

--- a/admin/release_checklist
+++ b/admin/release_checklist
@@ -103,7 +103,7 @@ if git tag | grep -qE "^$target_version\$"; then
                        "Please use annotated tags (git tag -a) for releases"
 else
     maybe_error $verify_tags \
-                "Please tag this release: git tag -a $target_version"
+                "Please publish the release $target_version in GitHub"
 fi
 
 if [[ "$ok" = yes ]]; then

--- a/gcovr/tests/cmake_oos/CMakeLists.txt
+++ b/gcovr/tests/cmake_oos/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 2.6.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 
 project(gcovrtest)
 

--- a/gcovr/tests/cmake_oos_ninja/CMakeLists.txt
+++ b/gcovr/tests/cmake_oos_ninja/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 2.6.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 
 project(gcovrtest)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pytest-cov
 pyutilib
 coverage
 codecov
+wheel

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,12 +24,10 @@ classifiers =
     Operating System :: POSIX
     Operating System :: Unix
     Programming Language :: Python
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
     Topic :: Software Development
     Topic :: Software Development :: Quality Assurance
     Topic :: Software Development :: Testing


### PR DESCRIPTION
- Fix problems mentioned in https://github.com/gcovr/gcovr/issues/424#issuecomment-858091994.
- Fix CMake varning because minimum required version was 2.6.4.

The deploy workflow is also executed on `push` and `pull_request` but the publish is skipped. There is also the dist folder saved as artifact.
Now we can be sure that the build will succeed.

[no changelog]