### PR TITLE
Fix problems from deployment of release 5.0

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,8 +4,6 @@
 name: Deploy
 
 on:
-  release:
-    types: [created]
   push:
   pull_request:
     types: [opened, synchronize, reopened, edited]
@@ -15,7 +13,7 @@ jobs:
   release-check:
     runs-on: ubuntu-20.04
 
-    continue-on-error: ${{ github.event_name != 'release' }}
+    continue-on-error: ${{ startsWith(github.event.ref,'refs/heads/') }}
 
     steps:
     - uses: actions/checkout@v2
@@ -59,6 +57,7 @@ jobs:
     - name: Build
       run: |
         python setup.py sdist bdist_wheel
+        twine check dist/*
     - name: Upload distribution
       if: ${{ success() }}
       uses: actions/upload-artifact@v2
@@ -66,7 +65,7 @@ jobs:
         name: dist
         path: dist/**
     - name: Publish
-      if: ${{ success() && (github.event_name == 'release') }}
+      if: ${{ success() && startsWith(github.event.ref,'refs/tags/') }}
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ lib64
 # Installer logs
 pip-log.txt
 
+# wheel
+gcovr-*/
+
 # Translations
 *.mo
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,8 @@ Documentation:
 
 Internal changes:
 
- - Clean GCC environment variables in test suite (:issue:`493`)
+ - Clean GCC environment variables in test suite. (:issue:`493`)
+ - Fix problems from deployment of release 5.0. (:issue:`494`)
 
 5.0 (11 June 2021)
 ------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pyutilib
 coverage
 codecov
 wheel
+twine

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,7 @@
 [metadata]
 description = Generate C/C++ code coverage reports with gcov
-long_description = file: README.rst, AUTHORS.txt
 license = BSD
-license_file = LICENSE.txt
+license_files = LICENSE.txt
 
 url = https://gcovr.com
 project_urls =

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     name="gcovr",
     version=version,
     long_description=long_description,
-    long_description_content_type="text/markdown",
+    long_description_content_type="text/x-rst",
     platforms=["any"],
     python_requires=">=3.6",
     packages=find_packages(include=["gcovr*"], exclude=["gcovr.tests"]),

--- a/setup.py
+++ b/setup.py
@@ -22,26 +22,44 @@ Script to generate the installer for gcovr.
 
 from runpy import run_path
 from setuptools import setup, find_packages
+from os import path
+import re
 
 
-version = run_path('./gcovr/version.py')['__version__']
+version = run_path("./gcovr/version.py")["__version__"]
+# read the contents of your README file
+this_directory = path.abspath(path.dirname(__file__))
+with open(path.join(this_directory, "README.rst"), encoding="utf-8") as f:
+    long_description = f.read()
 
-setup(name='gcovr',
-      version=version,
-      platforms=["any"],
-      python_requires='>=3.6',
-      packages=find_packages(include=['gcovr*'], exclude=['gcovr.tests']),
-      install_requires=[
-          'jinja2',
-          'lxml',
-          'pygments'
-      ],
-      package_data={
-          'gcovr': ['templates/*.css', 'templates/*.html'],
-      },
-      entry_points={
-          'console_scripts': [
-              'gcovr=gcovr.__main__:main',
-          ],
-      },
-      )
+long_description = re.sub(
+    r"^\.\. image:: \./",
+    r".. image:: https://raw.githubusercontent.com/gcovr/gcovr/{}/".format(version),
+    long_description,
+    flags=re.MULTILINE
+)
+long_description = re.sub(
+    r":option:`(.*?)<gcovr.*?>`",
+    r"``\1``",
+    long_description,
+    flags=re.MULTILINE
+)
+
+setup(
+    name="gcovr",
+    version=version,
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    platforms=["any"],
+    python_requires=">=3.6",
+    packages=find_packages(include=["gcovr*"], exclude=["gcovr.tests"]),
+    install_requires=["jinja2", "lxml", "pygments"],
+    package_data={
+        "gcovr": ["templates/*.css", "templates/*.html"],
+    },
+    entry_points={
+        "console_scripts": [
+            "gcovr=gcovr.__main__:main",
+        ],
+    },
+)


### PR DESCRIPTION
- Fix README.rst for PyPI upload.
- Rename license_file to license_files because of deprecation warning.
- Add twine to the requirements.txt to run check mentioned in https://packaging.python.org/guides/making-a-pypi-friendly-readme/. Our problems are not found by the check.
- Remove the deployment trigger for the release because we want to use annotated tags. The workflow is triggered if a tag is pushed. 