### PR TITLE
Add an option to disable long file names

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -18,6 +18,7 @@ The following developers contributed to gcovr (ordered alphabetically):
     Christian Taedcke,
     Dave George,
     Dom Postorivo,
+    ebmmy,
     Elektrobit Automotive GmbH,
     Ensky Lin,
     goriy,

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Improvements and new features:
 - Can create reproducible reports with the :option:`--timestamp` option (:issue:`546`)
 - Add "Goto function" in html details. (:issue:`515`)
 - Fix "root" path in JSON summary report. (:issue:`548`)
+- Document the used options of ``gcov``. (:issue:`528`)
 
 Documentation:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,7 @@ Improvements and new features:
 - Can create reproducible reports with the :option:`--timestamp` option (:issue:`546`)
 - Add "Goto function" in html details. (:issue:`515`)
 - Fix "root" path in JSON summary report. (:issue:`548`)
-- Document the used options of ``gcov``. (:issue:`528`)
+- Solve problems with file name limitations and document the used options of ``gcov``. (:issue:`528`)
 
 Documentation:
 

--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -121,3 +121,22 @@ To fix this, upgrade GCC to:
 * any version since 7.
 
 Note that the compiler may ignore ``inline`` functions that are never used.
+
+
+.. _used gcov options:
+
+Which options are used for calling gcov?
+----------------------------------------
+
+The options used for calling ``gcov`` depends on the version of gcov.
+
+Following options are always used:
+
+- ``--branch-counts``
+- ``--branch-probabilities``
+- ``--object-directory``
+
+Following options are only used if available:
+
+- ``--demangled-names``: Not available for LLVM based ``gcov``.
+- ``--hash-filenames``: Available since GCC 7, as fallback the option ``--preserve-paths`` is used.

--- a/gcovr/configuration.py
+++ b/gcovr/configuration.py
@@ -1016,15 +1016,6 @@ GCOVR_CONFIG_OPTIONS = [
         type=int,
         default=1,
     ),
-    GcovrConfigOption(
-        "gcov_long_file_names", ["--gcov-long-file-names"], config='gcov-long-file-names',
-        group="gcov_options",
-        help="Disable long output file names for included source files.",
-        action="store_const",
-        default=True,
-        const=True,
-        const_negate=False,
-    ),
 ]
 
 

--- a/gcovr/configuration.py
+++ b/gcovr/configuration.py
@@ -1016,6 +1016,15 @@ GCOVR_CONFIG_OPTIONS = [
         type=int,
         default=1,
     ),
+    GcovrConfigOption(
+        "gcov_long_file_names", ["--gcov-long-file-names"], config='gcov-long-file-names',
+        group="gcov_options",
+        help="Disable long output file names for included source files.",
+        action="store_const",
+        default=True,
+        const=True,
+        const_negate=False,
+    ),
 ]
 
 

--- a/gcovr/gcov.py
+++ b/gcovr/gcov.py
@@ -466,6 +466,9 @@ def run_gcov_and_process_files(
 ):
     gcov_cmd = gcov(options.gcov_cmd, logger)
 
+    # ATTENTION:
+    # This lock is essential for parallel processing because without
+    # this there can be name collisions for the generated output files.
     with locked_directory(chdir):
         out, err = gcov_cmd.run_with_args(
             [

--- a/gcovr/gcov.py
+++ b/gcovr/gcov.py
@@ -388,8 +388,10 @@ def run_gcov_and_process_files(
         "--branch-counts",
         "--branch-probabilities",
         "--preserve-paths",
-        "--long-file-names" if options.gcov_long_file_names else "",
     ]
+
+    if options.gcov_long_file_names:
+        gcov_options.append("--long-file-names")
 
     if not options.gcov_long_file_names and options.gcov_parallel > 1:
         logger.warn(

--- a/gcovr/gcov.py
+++ b/gcovr/gcov.py
@@ -388,8 +388,15 @@ def run_gcov_and_process_files(
         "--branch-counts",
         "--branch-probabilities",
         "--preserve-paths",
-        "--long-file-names",
+        "--long-file-names" if options.gcov_long_file_names else "",
     ]
+
+    if not options.gcov_long_file_names and options.gcov_parallel > 1:
+        logger.warn(
+            "Using --no-gcov-long-file-names together with -j option is likely to "
+            "create issues with concurrent file accesses."
+        )
+
     if "llvm-cov" not in gcov_cmd[0]:
         gcov_options.append("--demangled-names")
     cmd = (


### PR DESCRIPTION
Using tho option ` --long-file-names` with `llvm-cov` leads to file name larger than 255 characters on our setup and makes `gcovr` unusable. Hence this PR adding an option to disable it.
