### PR TITLE
Python 3.8 breaks network drive setups (#365)

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -18,6 +18,7 @@ The following developers contributed to gcovr (ordered alphabetically):
     Christian Taedcke,
     Dave George,
     Dom Postorivo,
+    Elektrobit Automotive GmbH,
     Ensky Lin,
     goriy,
     ja11sop,

--- a/gcovr/configuration.py
+++ b/gcovr/configuration.py
@@ -536,6 +536,13 @@ GCOVR_CONFIG_OPTIONS = [
         action="store_true",
     ),
     GcovrConfigOption(
+        "use_canonical_paths", ["--use-canonical-paths"],
+        help="Turns all paths into their canonical forms and resolves symbolic links. Paths residing on network drives "
+             "mapped to local disks will be changed to the path using the local disk. This affects also paths given as "
+             "arguments.\nNOTE: This flag will be ignored when running Python versions lower than 3.8!",
+        action="store_true",
+    ),
+    GcovrConfigOption(
         "root", ["-r", "--root"],
         help="The root directory of your source files. "
              "Defaults to '{default!s}', the current directory. "

--- a/gcovr/gcov.py
+++ b/gcovr/gcov.py
@@ -110,6 +110,7 @@ def process_gcov_data(data_fname, covdata, source_fname, options, currdir=None):
         starting_dir=options.starting_dir,
         obj_dir=None if options.objdir is None else os.path.abspath(options.objdir),
         logger=logger,
+        use_canonical_paths=options.use_canonical_paths,
         currdir=currdir,
     )
 
@@ -161,6 +162,7 @@ def guess_source_file_name(
     starting_dir,
     obj_dir,
     logger,
+    use_canonical_paths,
     currdir=None,
 ):
     if currdir is None:
@@ -171,6 +173,9 @@ def guess_source_file_name(
         fname = guess_source_file_name_heuristics(
             gcovname, currdir, root_dir, starting_dir, obj_dir, source_fname
         )
+
+    if use_canonical_paths:
+        fname = os.path.realpath(fname)
 
     logger.verbose_msg(
         "Finding source file corresponding to a gcov data file\n"

--- a/gcovr/utils.py
+++ b/gcovr/utils.py
@@ -166,7 +166,7 @@ class FilterOption(object):
         self.regex = regex
         self.path_context = os.getcwd() if path_context is None else path_context
 
-    def build_filter(self, logger):
+    def build_filter(self, logger, use_canonical_paths):
         # Try to detect unintended backslashes and warn.
         # Later, the regex engine may or may not raise a syntax error.
         # An unintended backslash is a literal backslash r"\\",
@@ -179,6 +179,11 @@ class FilterOption(object):
             logger.warn("did you mean: {}", suggestion)
 
         if os.path.isabs(self.regex):
+            if use_canonical_paths:
+                canonical_path = os.path.realpath(self.regex)
+                if canonical_path != self.regex:
+                    logger.msg(f"Filter {self.regex} has been normalized to {canonical_path}.")
+                    self.regex = canonical_path
             return AbsoluteFilter(self.regex)
         else:
             return RelativeFilter(self.path_context, self.regex)


### PR DESCRIPTION
[Python 3.8 breaks network drive setups (#365)](https://github.com/gcovr/gcovr/issues/365) contains my motivation. I've chosen this approach to solve the issue - hiding the change behind an option, since I can't test without the change on Windows nor on Linux. This means, that the patch might be possibly more general applicable than I conservatively can risk. I will investigate if I can add a unit test and update accordingly. But for now I'd like to have some feedback if there are greater changes needed.