### PR TITLE
Activate symlink tests under Windows

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ Internal changes:
  - Add option to run all comiler versions at once. (:issue:`514`)
  - Fix globing of reference data in tests. (:issue:`533`)
  - Replace makefile for starting tests with noxfile.py. (:issue:`516`)
+ - Activate symlink test for windows. (:issue:`539`)
 
 5.0 (11 June 2021)
 ------------------

--- a/gcovr/gcov.py
+++ b/gcovr/gcov.py
@@ -22,7 +22,7 @@ import shlex
 import subprocess
 import io
 
-from .utils import search_file, Logger, commonpath
+from .utils import search_file, Logger, commonpath, gcov_realpath
 from .workers import locked_directory
 from .coverage import FileCoverage
 from .gcov_parser import parse_metadata, parse_coverage, ParserFlags
@@ -196,14 +196,14 @@ def guess_source_file_name(
 
 def guess_source_file_name_via_aliases(gcovname, currdir, data_fname):
     common_dir = commonpath([data_fname, currdir])
-    fname = os.path.realpath(os.path.join(common_dir, gcovname))
+    fname = gcov_realpath(os.path.join(common_dir, gcovname))
     if os.path.exists(fname):
         return fname
 
     initial_fname = fname
 
     data_fname_dir = os.path.dirname(data_fname)
-    fname = os.path.realpath(os.path.join(data_fname_dir, gcovname))
+    fname = gcov_realpath(os.path.join(data_fname_dir, gcovname))
     if os.path.exists(fname):
         return fname
 

--- a/gcovr/gcov.py
+++ b/gcovr/gcov.py
@@ -22,7 +22,7 @@ import shlex
 import subprocess
 import io
 
-from .utils import search_file, Logger, commonpath, gcov_realpath
+from .utils import search_file, Logger, commonpath, realpath
 from .workers import locked_directory
 from .coverage import FileCoverage
 from .gcov_parser import parse_metadata, parse_coverage, ParserFlags
@@ -196,14 +196,14 @@ def guess_source_file_name(
 
 def guess_source_file_name_via_aliases(gcovname, currdir, data_fname):
     common_dir = commonpath([data_fname, currdir])
-    fname = gcov_realpath(os.path.join(common_dir, gcovname))
+    fname = realpath(os.path.join(common_dir, gcovname))
     if os.path.exists(fname):
         return fname
 
     initial_fname = fname
 
     data_fname_dir = os.path.dirname(data_fname)
-    fname = gcov_realpath(os.path.join(data_fname_dir, gcovname))
+    fname = realpath(os.path.join(data_fname_dir, gcovname))
     if os.path.exists(fname):
         return fname
 

--- a/gcovr/tests/cmake_oos/Makefile
+++ b/gcovr/tests/cmake_oos/Makefile
@@ -7,10 +7,10 @@
 #   gcovrtest
 
 BASE_OS:=$(shell uname | cut -d'-' -f1)
-ifeq ($(BASE_OS),MSYS_NT)
-  CMAKE_GENERATOR := "MSYS Makefiles"
-else
+ifeq ($(filter $(BASE_OS),MSYS_NT MINGW64_NT),)
   CMAKE_GENERATOR := "Unix Makefiles"
+else
+  CMAKE_GENERATOR := "MSYS Makefiles"
 endif
 
 all:

--- a/gcovr/tests/filter-absolute-from-unfiltered-tracefile/Makefile
+++ b/gcovr/tests/filter-absolute-from-unfiltered-tracefile/Makefile
@@ -1,14 +1,11 @@
 CFLAGS= -fprofile-arcs -ftest-coverage -fPIC
 
 BASE_OS:=$(shell uname | cut -d'-' -f1)
-ifneq (,$(findstring MINGW,$(BASE_OS)))
-	BASE_OS:=MSYS_NT
-endif
-ifeq ($(BASE_OS),MSYS_NT)
+ifeq ($(filter $(BASE_OS),MSYS_NT MINGW64_NT),)
+	GCOVR_TEST_OPTIONS := -f $(shell pwd)/main.cpp
+else
 	# "cygpath -m" is the mixed mode: Windows drive letters but forward slashes
 	GCOVR_TEST_OPTIONS := -f $(shell cygpath -m "$$PWD")/main.cpp
-else
-	GCOVR_TEST_OPTIONS := -f $(shell pwd)/main.cpp
 endif
 
 all:

--- a/gcovr/tests/filter-absolute/Makefile
+++ b/gcovr/tests/filter-absolute/Makefile
@@ -1,14 +1,11 @@
 CFLAGS= -fprofile-arcs -ftest-coverage -fPIC
 
 BASE_OS:=$(shell uname | cut -d'-' -f1)
-ifneq (,$(findstring MINGW,$(BASE_OS)))
-	BASE_OS:=MSYS_NT
-endif
-ifeq ($(BASE_OS),MSYS_NT)
+ifeq ($(filter $(BASE_OS),MSYS_NT MINGW64_NT),)
+	GCOVR_TEST_OPTIONS := -f $(shell pwd)/main.cpp
+else
 	# "cygpath -m" is the mixed mode: Windows drive letters but forward slashes
 	GCOVR_TEST_OPTIONS := -f $(shell cygpath -m "$$PWD")/main.cpp
-else
-	GCOVR_TEST_OPTIONS := -f $(shell pwd)/main.cpp
 endif
 
 all:

--- a/gcovr/tests/filter-relative-lib-from-unfiltered-tracefile/Makefile
+++ b/gcovr/tests/filter-relative-lib-from-unfiltered-tracefile/Makefile
@@ -11,11 +11,7 @@ all: links
 run: txt xml html sonarqube
 
 # the src/ filter is provided by the project/gcovr.cfg configuration file
-ifeq ($(filter $(BASE_OS),MSYS_NT MINGW64_NT),)
 GCOVR_TEST_OPTIONS = -f '\.\./external-library/src'
-else
-GCOVR_TEST_OPTIONS = -f '.*/external-library/src'
-endif
 
 coverage_unfiltered.json:
 	cd project; ./testcase

--- a/gcovr/tests/filter-relative-lib-from-unfiltered-tracefile/Makefile
+++ b/gcovr/tests/filter-relative-lib-from-unfiltered-tracefile/Makefile
@@ -1,5 +1,7 @@
 CFLAGS= -fprofile-arcs -ftest-coverage -fPIC
 
+BASE_OS:=$(shell uname | cut -d'-' -f1)
+
 all: links
 	cd project; $(CXX) $(CFLAGS) -c src/main.cpp -o main.o
 	cd project; $(CXX) $(CFLAGS) -c ignore-this/no.cpp -o no.o
@@ -9,7 +11,11 @@ all: links
 run: txt xml html sonarqube
 
 # the src/ filter is provided by the project/gcovr.cfg configuration file
+ifeq ($(filter $(BASE_OS),MSYS_NT MINGW64_NT),)
 GCOVR_TEST_OPTIONS = -f '\.\./external-library/src'
+else
+GCOVR_TEST_OPTIONS = -f '.*/external-library/src'
+endif
 
 coverage_unfiltered.json:
 	cd project; ./testcase
@@ -28,9 +34,21 @@ sonarqube: coverage_unfiltered.json
 	cd project; $(GCOVR) $(GCOVR_TEST_OPTIONS) -a ../$< --sonarqube ../sonarqube.xml
 
 links:
+ifeq ($(filter $(BASE_OS),MSYS_NT MINGW64_NT),)
 	cd project; \
 	   test -d relevant-library || ln -sT ../external-library relevant-library
+else
+	cd project; \
+	   test -d relevant-library || cmd.exe /C "mklink /j relevant-library ..\external-library"
+endif
 
 clean:
-	cd project; rm -f testcase *.gc* *.o; rm -rf relevant-library
+	cd project; rm -f testcase *.gc* *.o;
+ifeq ($(filter $(BASE_OS),MSYS_NT MINGW64_NT),)
+	cd project; rm -rf relevant-library
+else
+	if [ -d "project/relevant-library" ]; then\
+		cmd.exe /C "rmdir /S /Q project\relevant-library";\
+	fi
+endif
 	rm -f coverage*.* sonarqube.xml

--- a/gcovr/tests/filter-relative-lib/Makefile
+++ b/gcovr/tests/filter-relative-lib/Makefile
@@ -1,5 +1,7 @@
 CFLAGS= -fprofile-arcs -ftest-coverage -fPIC
 
+BASE_OS:=$(shell uname | cut -d'-' -f1)
+
 all: links
 	cd project; $(CXX) $(CFLAGS) -c src/main.cpp -o main.o
 	cd project; $(CXX) $(CFLAGS) -c ignore-this/no.cpp -o no.o
@@ -9,7 +11,11 @@ all: links
 run: txt xml html sonarqube coveralls
 
 # the src/ filter is provided by the project/gcovr.cfg configuration file
+ifeq ($(filter $(BASE_OS),MSYS_NT MINGW64_NT),)
 GCOVR_TEST_OPTIONS = -f '\.\./external-library/src'
+else
+GCOVR_TEST_OPTIONS = -f '.*/external-library/src'
+endif
 
 coverage.json:
 	cd project; ./testcase
@@ -31,9 +37,21 @@ coveralls: coverage.json
 	cd project; $(GCOVR) --config gcovr_empty.cfg -a ../coverage.json --coveralls ../coveralls.json
 
 links:
+ifeq ($(filter $(BASE_OS),MSYS_NT MINGW64_NT),)
 	cd project; \
 	   test -d relevant-library || ln -sT ../external-library relevant-library
+else
+	cd project; \
+	   test -d relevant-library || cmd.exe /C "mklink /j relevant-library ..\external-library"
+endif
 
 clean:
-	cd project; rm -f testcase *.gc* *.o; rm -rf relevant-library
+	cd project; rm -f testcase *.gc* *.o;
+ifeq ($(filter $(BASE_OS),MSYS_NT MINGW64_NT),)
+	cd project; rm -rf relevant-library
+else
+	if [ -d "project/relevant-library" ]; then\
+		cmd.exe /C "rmdir /S /Q project\relevant-library";\
+	fi
+endif
 	rm -f coverage*.* sonarqube.xml coveralls.json

--- a/gcovr/tests/linked/Makefile
+++ b/gcovr/tests/linked/Makefile
@@ -1,5 +1,7 @@
 CFLAGS= -fprofile-arcs -ftest-coverage -fPIC
 
+BASE_OS:=$(shell uname | cut -d'-' -f1)
+
 all: links
 	$(CXX) $(CFLAGS) -c subdir/A/file1.cpp -o subdir/A/file1.o
 	$(CXX) $(CFLAGS) -c subdir/A/file2.cpp -o subdir/A/file2.o
@@ -33,10 +35,17 @@ coveralls: coverage.json
 	$(GCOVR) -a $< --coveralls coveralls.json
 
 clean:
+ifeq ($(filter $(BASE_OS),MSYS_NT MINGW64_NT),)
 	rm -Rf subdir
+else
+	if [ -d "subdir" ]; then\
+		cmd.exe /C "rmdir /S /Q subdir";\
+	fi
+endif
 	rm -f coverage*.* sonarqube*.* coveralls.json
 
 links:
+ifeq ($(filter $(BASE_OS),MSYS_NT MINGW64_NT),)
 	if [ -d "subdir" ]; then\
 		rm -Rf subdir;\
 	fi
@@ -48,6 +57,16 @@ links:
 	ln -s ../../../nested/subdir/A n;\
 	cd ..;\
 	ln -s m/n A;\
-	ln -s . loop;\
-	cd ..;
+	ln -s . loop;
+else
+	if [ -d "subdir" ]; then\
+		cmd.exe /C "rmdir /S /Q subdir";\
+	fi
+	mkdir subdir;
+	cmd.exe /C "cd subdir && mklink /j B ..\..\nested\subdir\B"
+	cmd.exe /C "cd subdir && mkdir m"
+	cmd.exe /C "cd subdir\m && mklink /j n ..\..\..\nested\subdir\A"
+	cmd.exe /C "cd subdir && mklink /j A m\n"
+	cmd.exe /C "cd subdir && mklink /j loop ."
+endif
 	find ../nested -name '*.o' -or -name '*.gc*' -delete || exit 0

--- a/gcovr/tests/shared_lib/Makefile
+++ b/gcovr/tests/shared_lib/Makefile
@@ -6,16 +6,13 @@ ifeq ($(BASE_OS),Darwin)
   CFLAGS     += -fPIC
   SOFLAGS    += -dynamiclib -undefined dynamic_lookup
 endif
-ifneq (,$(findstring MINGW,$(BASE_OS)))
-  BASE_OS:=MSYS_NT
-endif
 ifeq ($(BASE_OS),CYGWIN_NT)
   DYNLIB_EXT = dll
   #DEFINES   += -mno-cygwin
   #SOFLAGS   += -shared -wl,--kill-at
   SOFLAGS    += -shared
 endif
-ifeq ($(BASE_OS),MSYS_NT)
+ifneq ($(filter $(BASE_OS),MSYS_NT MINGW64_NT),)
   DYNLIB_EXT = dll
   SOFLAGS    += -shared
 endif
@@ -37,21 +34,21 @@ all:
 
 run: txt xml html sonarqube coveralls
 
-ifeq ($(BASE_OS),MSYS_NT)
+ifneq ($(filter $(BASE_OS),MSYS_NT MINGW64_NT),)
 ifneq ($(notdir $(SHELL)),sh)
 coverage.json : export PATH := $(subst /,\,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))\lib;${PATH}
 endif
 endif
 
 coverage.json:
-ifeq ($(BASE_OS),MSYS_NT)
+ifeq ($(filter $(BASE_OS),MSYS_NT MINGW64_NT),)
+	LD_LIBRARY_PATH=`pwd`/lib testApp/test/a.out
+else
 ifeq ($(notdir $(SHELL)),sh)
 	PATH="`pwd`/lib:${PATH}" testApp/test/a.out
 else
 	testApp/test/a.out
 endif
-else
-	LD_LIBRARY_PATH=`pwd`/lib testApp/test/a.out
 endif
 	$(GCOVR) --json $@
 

--- a/gcovr/tests/simple1/Makefile
+++ b/gcovr/tests/simple1/Makefile
@@ -1,13 +1,10 @@
 
 BASE_OS:=$(shell uname | cut -d'-' -f1)
-ifneq (,$(findstring MINGW,$(BASE_OS)))
-  BASE_OS:=MSYS_NT
-endif
 
-ifeq ($(BASE_OS),MSYS_NT)
-  FAIL_UNDER_LINE := 76.9
-else
+ifeq ($(filter $(BASE_OS),MSYS_NT MINGW64_NT),)
   FAIL_UNDER_LINE := $(shell cat reference/$(CC)/fail_under)
+else
+  FAIL_UNDER_LINE := 76.9
 endif
 
 all:
@@ -55,7 +52,7 @@ json_summary:
 json:
 	./testcase
 	$(GCOVR) --json coverage.json
-	
+
 coveralls:
 	./testcase
 	$(GCOVR) -d --coveralls coveralls.json

--- a/gcovr/tests/test_gcovr.py
+++ b/gcovr/tests/test_gcovr.py
@@ -231,19 +231,7 @@ def pytest_generate_tests(metafunc):
             if format not in targets:
                 continue
 
-            needs_symlinks = any(
-                [
-                    name == "linked" and format == "html",
-                    name == "filter-relative-lib",
-                    name == "filter-relative-lib-from-unfiltered-tracefile",
-                ]
-            )
-
             marks = [
-                pytest.mark.xfail(
-                    needs_symlinks and is_windows,
-                    reason="have yet to figure out symlinks on Windows",
-                ),
                 pytest.mark.xfail(
                     name == "exclude-throw-branches"
                     and format == "html"

--- a/gcovr/utils.py
+++ b/gcovr/utils.py
@@ -201,7 +201,12 @@ class FilterOption(object):
             logger.warn("your filter : {}", self.regex)
             logger.warn("did you mean: {}", suggestion)
 
-        if os.path.isabs(self.regex):
+        isabs = self.regex.startswith("/")
+        if not isabs and (sys.platform == "win32"):
+            # Starts with a drive letter
+            isabs = re.match(r"^[A-Za-z]:/", self.regex)
+
+        if isabs:
             return AbsoluteFilter(self.regex)
         else:
             return RelativeFilter(self.path_context, self.regex)

--- a/gcovr/utils.py
+++ b/gcovr/utils.py
@@ -37,6 +37,32 @@ class LoopChecker(object):
         return False
 
 
+if sys.platform == "win32":
+    if sys.version_info >= (3, 8):
+        gcov_realpath = os.path.realpath
+    else:
+        # Only used for old python versions. Function can be treated as stable.
+        from nt import _getfinalpathname
+
+        DOS_DEVICE_PATH_PREFIX = "\\\\?\\"
+        DOS_DEVICE_PATH_PREFIX_UNC = DOS_DEVICE_PATH_PREFIX + "UNC\\"
+
+        def gcov_realpath(path):
+            path = os.path.realpath(path)
+            # If file exist try to resolve the symbolic links
+            if os.path.exists(path):
+                has_prefix = True if path.startswith(DOS_DEVICE_PATH_PREFIX) else False
+                path = _getfinalpathname(path)
+                if not has_prefix and path.startswith(DOS_DEVICE_PATH_PREFIX):
+                    if path.startswith(DOS_DEVICE_PATH_PREFIX_UNC):
+                        path = path[len(DOS_DEVICE_PATH_PREFIX_UNC):]
+                    else:
+                        path = path[len(DOS_DEVICE_PATH_PREFIX):]
+            return path
+else:
+    gcov_realpath = os.path.realpath
+
+
 def search_file(predicate, path, exclude_dirs):
     """
     Given a search path, recursively descend to find files that satisfy a
@@ -57,11 +83,11 @@ def search_file(predicate, path, exclude_dirs):
         dirs[:] = [d for d in dirs
                    if not any(exc.match(os.path.join(root, d))
                               for exc in exclude_dirs)]
-        root = os.path.realpath(root)
+        root = gcov_realpath(root)
 
         for name in files:
             if predicate(name):
-                yield os.path.realpath(os.path.join(root, name))
+                yield gcov_realpath(os.path.join(root, name))
 
 
 def commonpath(files):
@@ -88,9 +114,9 @@ def commonpath(files):
         return ''
 
     if len(files) == 1:
-        prefix_path = os.path.dirname(os.path.realpath(files[0]))
+        prefix_path = os.path.dirname(gcov_realpath(files[0]))
     else:
-        split_paths = [os.path.realpath(path).split(os.path.sep)
+        split_paths = [gcov_realpath(path).split(os.path.sep)
                        for path in files]
         # We only have to compare the lexicographically minimum and maximum
         # paths to find the common prefix of all, e.g.:
@@ -214,7 +240,7 @@ class Filter(object):
 
 class AbsoluteFilter(Filter):
     def match(self, path):
-        abspath = os.path.realpath(path)
+        abspath = gcov_realpath(path)
         return super(AbsoluteFilter, self).match(abspath)
 
 
@@ -224,13 +250,13 @@ class RelativeFilter(Filter):
         self.root = root
 
     def match(self, path):
-        abspath = os.path.realpath(path)
+        abspath = gcov_realpath(path)
 
         # On Windows, a relative path can never cross drive boundaries.
         # If so, the relative filter cannot match.
         if sys.platform == 'win32':
             path_drive, _ = os.path.splitdrive(abspath)
-            root_drive, _ = os.path.splitdrive(os.path.realpath(self.root))
+            root_drive, _ = os.path.splitdrive(gcov_realpath(self.root))
             if path_drive != root_drive:
                 return None
 

--- a/gcovr/writer/html.py
+++ b/gcovr/writer/html.py
@@ -23,7 +23,7 @@ import io
 from argparse import ArgumentTypeError
 
 from ..version import __version__
-from ..utils import gcov_realpath, commonpath, sort_coverage, calculate_coverage, Logger, open_text_for_writing
+from ..utils import realpath, commonpath, sort_coverage, calculate_coverage, Logger, open_text_for_writing
 
 
 class Lazy:
@@ -278,7 +278,7 @@ class RootInfo:
         }
 
         display_filename = (
-            os.path.relpath(gcov_realpath(cdata_fname), self.directory)
+            os.path.relpath(realpath(cdata_fname), self.directory)
             .replace('\\', '/'))
 
         if link_report is not None:

--- a/gcovr/writer/html.py
+++ b/gcovr/writer/html.py
@@ -23,7 +23,7 @@ import io
 from argparse import ArgumentTypeError
 
 from ..version import __version__
-from ..utils import commonpath, sort_coverage, calculate_coverage, Logger, open_text_for_writing
+from ..utils import gcov_realpath, commonpath, sort_coverage, calculate_coverage, Logger, open_text_for_writing
 
 
 class Lazy:
@@ -278,7 +278,7 @@ class RootInfo:
         }
 
         display_filename = (
-            os.path.relpath(os.path.realpath(cdata_fname), self.directory)
+            os.path.relpath(gcov_realpath(cdata_fname), self.directory)
             .replace('\\', '/'))
 
         if link_report is not None:


### PR DESCRIPTION
Under Windows we have to use junctions instead of symlinks. As I know a Shell can't `cd` into a symbolic link.
With Junctions and a custom `gcov_realpath` for python < 3.8 the tests are now working also on windows.
With this change #535 should change the `gcov_realpath` to not resolve the path to a different drive on windows.