### PR TITLE
Add --timestamp option for reproducible reports.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,9 +17,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: For a dry run, don't verify tags and documentation
+      if: ${{ ! startsWith(github.event.ref, 'refs/tags/') }}
+      run: |
+        echo EXTRA_CHECKLIST_ARGS="--no-verify-tags --no-verify-docs-next-version" >> $GITHUB_ENV
     - name: Run release_checklist
       run: |
-        admin/release_checklist 5.0
+        admin/release_checklist $EXTRA_CHECKLIST_ARGS 5.0
 
   deploy:
     runs-on: ubuntu-18.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,23 +64,10 @@ jobs:
         fi
         exit 0
 
-  release-check:
-    runs-on: ubuntu-20.04
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Setup environment
-      run: |
-        echo "GITHUB_PR_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
-      shell: bash
-    - name: Run release_checklist
-      run: |
-        admin/release_checklist --no-verify-tags --no-verify-docs-next-version 5.0
-
   build:
     runs-on: ${{ matrix.os }}
 
-    needs: [milestone-check, changelog-check, release-check]
+    needs: [milestone-check, changelog-check]
 
     strategy:
       fail-fast: false
@@ -162,7 +149,7 @@ jobs:
 
   run-docker:
     runs-on: ubuntu-18.04
-    needs: [milestone-check, changelog-check, release-check]
+    needs: [milestone-check, changelog-check]
 
     strategy:
       fail-fast: false

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Improvements and new features:
 - Deactivate localization of gcov by setting LC_ALL=C instead of LC_ALL=en_US (:issue:`513`)
 - Don't use a temporary directory for running gcov (:issue:`525`)
 - Fix junctions on windows for Python 3.8 (:issue:`535`)
+- Can create reproducible reports with the :option:`--timestamp` option (:issue:`546`)
 
 Documentation:
 

--- a/admin/release_checklist
+++ b/admin/release_checklist
@@ -79,10 +79,7 @@ grep -qE "version=['\"]gcovr $target_version['\"]" doc/examples/example_xml.xml 
     || error "examples: Please regenerate: " \
              "cd doc/examples; ./example_xml.sh > example_xml.xml"
 
-grep -qE "^ *$0 --no-verify-tags --no-verify-docs-next-version $target_version\$" .github/workflows/test.yml \
-    || error ".github/workflows/test.yml: Please update the $0 version"
-
-grep -qE "^ *$0 $target_version\$" .github/workflows/deploy.yml \
+grep -qE "^ *$0 .EXTRA_CHECKLIST_ARGS $target_version\$" .github/workflows/deploy.yml \
     || error ".github/workflows/deploy.yml: Please update the $0 version"
 
 occurrences="$(

--- a/doc/examples/example_html.sh
+++ b/doc/examples/example_html.sh
@@ -1,15 +1,25 @@
 #!/bin/bash
+set -euo pipefail  # "use strict"
+
+# This file is used both as an example and as a test.
+# In order to get reproducible tests,
+# this function wraps gcovr to force a specific timestamp.
+# This can be ignored by end users and isn't really part of the example.
+gcovr() {
+    python3 -m gcovr --timestamp="2021-11-08 21:12:28" "$@"
+}
+
 
 ${CXX:-g++} -fprofile-arcs -ftest-coverage -fPIC -O0 example.cpp -o program
 
 ./program
 
 #BEGIN gcovr html
-gcovr -r . --html
+gcovr --html
 #END gcovr html
 
 #BEGIN gcovr html details
-gcovr -r . --html --html-details -o example_html.details.html
+gcovr --html-details example_html.details.html
 #END gcovr html details
 
 rm -f program *.gc*

--- a/doc/examples/example_timestamps.sh
+++ b/doc/examples/example_timestamps.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+set -eu  # "use strict"
+set -x  # trace all commands
+
+#BEGIN simple epoch
+gcovr --timestamp 1640606727
+#END simple epoch
+
+#BEGIN simple RFC 3339
+gcovr --timestamp '2021-12-27 13:05:27'
+#END simple RFC 3339
+
+#BEGIN RFC 3339 with UTC timezone
+gcovr --timestamp '2021-12-27T13:05:27Z'
+gcovr --timestamp '2021-12-27T13:05:27+00:00'
+gcovr --timestamp '2021-12-27T13:05:27-00:00'
+#END RFC 3339 with UTC timezone
+
+#BEGIN prefixes
+gcovr --timestamp @1640606727
+gcovr --timestamp epoch:1640606727
+gcovr --timestamp 'rfc3339:2021-12-27 13:05:27'
+#END prefixes
+
+# The following commands can only be performed if
+# A) we are in a git repository, and
+# B) git is installed.
+# The use of "command -v" is a Posixly-correct way to check for existence of a
+# command, unlike the "which", "type", or "hash" commands.
+if test -d ../../.git && command -v git >/dev/null; then
+
+#BEGIN git commit
+gcovr --timestamp="$(git show --no-patch --format=%cI HEAD)"
+#END git commit
+
+for fmt in %at %ct %aI %cI; do
+    gcovr --timestamp="$(git show --no-patch --format=$fmt HEAD)"
+done
+
+for date in unix iso-strict iso8601-strict iso-strict-local iso8601-strict-local; do
+    gcovr --timestamp="$(git show --no-patch --date=$date --format=%cd HEAD)"
+done
+
+fi

--- a/doc/examples/test_examples.py
+++ b/doc/examples/test_examples.py
@@ -74,3 +74,7 @@ def test_example(example):
     else:
         assert output == baseline
     os.chdir(startdir)
+
+
+def test_timestamps_example():
+    subprocess.check_call(["sh", "example_timestamps.sh"], cwd=datadir)

--- a/doc/source/guide-timestamps.rst
+++ b/doc/source/guide-timestamps.rst
@@ -1,0 +1,114 @@
+.. _timestamps:
+
+Reproducible Timestamps
+=======================
+
+In some cases, it may be desirable to list a specific timestamp in the report.
+Timestamps are shown in
+the :ref:`html_output`,
+:ref:`coveralls_output`,
+and the :ref:`cobertura_output`.
+This can be achieved via the :option:`--timestamp <gcovr --timestamp>` option.
+This option does not affect the modification times or other filesystem metadata.
+
+.. versionadded:: NEXT
+
+   The :option:`gcovr --timestamp` option.
+
+
+Timestamp Syntax
+----------------
+
+The timestamp option understands different formats:
+Unix timestamps and RFC-3339 timestamps.
+
+Unix timestamps (also known as Posix time or Epoch)
+are the number of seconds since 1 Jan 1970.
+These timestamps are always resolved in the UTC timezone.
+Example usage:
+
+.. include:: ../examples/example_timestamps.sh
+   :code: bash
+   :start-after: #BEGIN simple epoch
+   :end-before: #END simple epoch
+
+`RFC 3339 <https://datatracker.ietf.org/doc/html/rfc3339>`_
+specifies a reasonable subset of ISO-8601 timestamps.
+This is the ``YYYY-MM-DDThh:mm:ss`` format,
+optionally followed by a timezone offset (``+hh:mm``, or ``Z`` for UTC).
+Example usage without a timezone:
+
+.. include:: ../examples/example_timestamps.sh
+   :code: bash
+   :start-after: #BEGIN simple RFC 3339
+   :end-before: #END simple RFC 3339
+
+Example usages that show equivalent specifications for UTC timestamps:
+
+.. include:: ../examples/example_timestamps.sh
+   :code: bash
+   :start-after: #BEGIN RFC 3339 with UTC timezone
+   :end-before: #END RFC 3339 with UTC timezone
+
+Differences and clarifications with respect to RFC-3339:
+
+* the time zone may be omitted
+* the date and time parts may be separated by a space character
+  instead of the ``T``
+* the date is parsed in a case insensitive manner
+* sub-second accuracy is not currently supported
+
+Additional formats may be added in the future.
+To ensure that timestamps are handled in the expected manner,
+it is possible to select a particular timestamp syntax with a prefix.
+
+* Epoch timestamps can be selected with a ``@`` or ``epoch:`` prefix.
+* RFC-3339 timestamps can be selected with a ``rfc3339:`` prefix.
+
+Examples of prefixes:
+
+.. include:: ../examples/example_timestamps.sh
+   :code: bash
+   :start-after: #BEGIN prefixes
+   :end-before: #END prefixes
+
+
+Using timestamps from Git commits
+---------------------------------
+
+As an example of using the timestamp feature,
+we might want to attribute a coverage report
+to the time when a Git commit was created.
+Git lets us extract the commit date from a commit
+with the `git show <https://git-scm.com/docs/git-show>`_ command.
+For the current HEAD commit::
+
+  git show --no-patch --format=%cI HEAD
+
+This can be combined into a Bash one-liner like this:
+
+.. include:: ../examples/example_timestamps.sh
+   :code: bash
+   :start-after: #BEGIN git commit
+   :end-before: #END git commit
+
+Each Git commit has two dates, the author date and the committer date.
+This information can be extracted with various format codes,
+e.g. ``%aI`` for the author date and ``%cI`` for the committer date.
+These format codes are also available in different formats.
+The supported Git formats are:
+
+* Unix timestamps: ``%at``, ``%ct``
+* "Strict ISO" format: ``%aI``, ``%cI``
+* depending on the ``--date`` option: ``%ad``, ``%cd``
+
+Git's ``--date`` option
+is documented in `git log <https://git-scm.com/docs/git-log>`_.
+The supported settings are:
+
+* Unix timestamps: ``--date=unix``
+* "Strict ISO" format:
+  ``--date=iso-strict``,
+  ``--date=iso8601-strict``,
+  ``--date=iso-strict-local``,
+  ``--date=iso8601-strict-local``

--- a/doc/source/guide.rst
+++ b/doc/source/guide.rst
@@ -163,6 +163,8 @@ print the same tabular output.
    Added :option:`--txt<gcovr --txt>`.
 
 
+.. _cobertura_output:
+
 Cobertura XML Output
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -198,6 +200,8 @@ of times that each line was covered.  Consequently, XML output can be
 used to support performance optimization in the same manner that
 ``gcov`` does.
 
+
+.. _html_output:
 
 HTML Output
 ~~~~~~~~~~~
@@ -783,3 +787,10 @@ a multi-program laboratory managed and operated by Sandia Corporation,
 a wholly owned subsidiary of Lockheed Martin Corporation, for the
 U.S.  Department of Energy's National Nuclear Security Administration
 under contract DE-AC04-94AL85000.
+
+Additional Topics
+-----------------
+
+.. toctree::
+
+   guide-timestamps

--- a/gcovr/configuration.py
+++ b/gcovr/configuration.py
@@ -70,8 +70,7 @@ def timestamp(value: str) -> datetime.datetime:
     try:
         return parse_timestamp(value)
     except ValueError as ex:
-        (msg,) = ex.args
-        raise ArgumentTypeError(f"{msg}: {value:!r}") from None
+        raise ArgumentTypeError(f"{ex}: {value!r}") from None
 
 
 class OutputOrDefault(object):

--- a/gcovr/configuration.py
+++ b/gcovr/configuration.py
@@ -20,6 +20,7 @@ from argparse import ArgumentTypeError, SUPPRESS
 from locale import getpreferredencoding
 from multiprocessing import cpu_count
 from typing import Iterable, Any
+import datetime
 import os
 import re
 
@@ -62,6 +63,15 @@ def check_input_file(value, basedir=None):
             "Should be a file that already exists: {value!r}".format(value=value))
 
     return os.path.abspath(value)
+
+
+def timestamp(value: str) -> datetime.datetime:
+    from .timestamps import parse_timestamp  # lazy import
+    try:
+        return parse_timestamp(value)
+    except ValueError as ex:
+        (msg,) = ex.args
+        raise ArgumentTypeError(f"{msg}: {value:!r}") from None
 
 
 class OutputOrDefault(object):
@@ -849,6 +859,17 @@ GCOVR_CONFIG_OPTIONS = [
         action="store_true",
     ),
     GcovrConfigOption(
+        "timestamp",
+        ["--timestamp"],
+        group="output_options",
+        help="Override current time for reproducible reports. "
+        "Can use `YYYY-MM-DD hh:mm:ss` or epoch notation. "
+        "Used by HTML, Coveralls, and Cobertura reports. "
+        "Default: current time.",
+        type=timestamp,
+        default=datetime.datetime.now(),
+    ),
+    GcovrConfigOption(
         "filter", ["-f", "--filter"],
         group="filter_options",
         help="Keep only source files that match this filter. "
@@ -995,7 +1016,7 @@ GCOVR_CONFIG_OPTIONS = [
         const=cpu_count(),
         type=int,
         default=1,
-    )
+    ),
 ]
 
 

--- a/gcovr/tests/test_args.py
+++ b/gcovr/tests/test_args.py
@@ -381,3 +381,10 @@ def test_exclude_lines_by_pattern(capsys):
     c = capture(capsys, ['--exclude-lines-by-pattern', 'example.**'])
     assert 'Invalid regular expression' in c.err
     assert c.exception.code != 0
+
+
+def test_invalid_timestamp(capsys):
+    c = capture(capsys, ['--timestamp=foo'])
+    assert c.out == ''
+    assert "argument --timestamp: unknown timestamp format: 'foo'" in c.err
+    assert c.exception.code != 0

--- a/gcovr/timestamps.py
+++ b/gcovr/timestamps.py
@@ -127,6 +127,8 @@ def _parse_rfc3339(value: str) -> datetime.datetime:
     '2021-12-27T13:05:27'
     >>> _parse_rfc3339("2021-12-27T13:05:27").isoformat()
     '2021-12-27T13:05:27'
+    >>> _parse_rfc3339("2021-12-27t13:05:27").isoformat()
+    '2021-12-27T13:05:27'
     >>> _parse_rfc3339("2021-12-27@13:05:27+12:30")
     Traceback (most recent call last):
       ...
@@ -136,12 +138,15 @@ def _parse_rfc3339(value: str) -> datetime.datetime:
 
     >>> _parse_rfc3339("2021-12-27 13:05:27Z").isoformat()
     '2021-12-27T13:05:27+00:00'
+    >>> _parse_rfc3339("2021-12-27 13:05:27z").isoformat()
+    '2021-12-27T13:05:27+00:00'
     >>> _parse_rfc3339("2021-12-27 13:05:27+12:30").isoformat()
     '2021-12-27T13:05:27+12:30'
     >>> _parse_rfc3339("2021-12-27T13:05:27-07:23").isoformat()
     '2021-12-27T13:05:27-07:23'
 
-    Examples for invalid syntax
+    Examples for invalid syntax:
+
     >>> _parse_rfc3339("2021/12/27 13:05:27")
     Traceback (most recent call last):
       ...
@@ -152,7 +157,17 @@ def _parse_rfc3339(value: str) -> datetime.datetime:
       ...
     ValueError: timezone offset must be 'Z' or +hh:mm
 
+    >>> _parse_rfc3339("test")
+    Traceback (most recent call last):
+      ...
+    ValueError: timestamp must use RFC-3339 ...
     """
+
+    err_must_use_rfc_3339 = "timestamp must use RFC-3339 (YYYY-MM-DD hh:mm:ss) format"
+
+    if len(value) < 19:
+        raise ValueError(err_must_use_rfc_3339)
+
     date_value = value[:10]  # YYYY-MM-DD
     sep = value[10]  # T or space
     time_value = value[11:19]  # hh:mm:ss
@@ -167,9 +182,7 @@ def _parse_rfc3339(value: str) -> datetime.datetime:
             "%Y-%m-%d %H:%M:%S",
         )
     except ValueError:
-        raise ValueError(
-            "timestamp must use RFC-3339 (YYYY-MM-DD hh:mm:ss) format"
-        ) from None
+        raise ValueError(err_must_use_rfc_3339) from None
 
     if not tz_value:
         return naive_timestamp

--- a/gcovr/timestamps.py
+++ b/gcovr/timestamps.py
@@ -1,0 +1,206 @@
+# -*- coding:utf-8 -*-
+
+#  ************************** Copyrights and license ***************************
+#
+# This file is part of gcovr 5.0, a parsing and reporting tool for gcov.
+# https://gcovr.com/en/stable
+#
+# _____________________________________________________________________________
+#
+# Copyright (c) 2021 the gcovr authors
+# This software is distributed under the BSD License.
+# For more information, see the README.rst file.
+#
+# ****************************************************************************
+
+import datetime
+import re
+
+UTC = datetime.timezone.utc
+
+
+def parse_timestamp(value: str) -> datetime.datetime:
+    r"""
+    Parse a timestamp.
+
+    This can either use use "YYYY-MM-DD hh:mm:ss" or epoch notation.
+
+    For future compatibility, the timestamp may start
+    with an alphanumeric prefix (think: URL-scheme)
+    that forces a particular parsing.
+
+    Implemented prefixes (case-insensitive):
+
+    * `epoch:` or `@` to parse the number as an Unix epoch
+    * `rfc3339:` to get the "ISO" format, with the following changes:
+      A timezone offset is optional.
+      The "T" separator may be replaced by a space.
+
+    Examples of parsing epochs:
+
+    >>> parse_timestamp("1640606727").isoformat()  # no prefix
+    '2021-12-27T12:05:27+00:00'
+    >>> parse_timestamp("@1640606727").isoformat()
+    '2021-12-27T12:05:27+00:00'
+    >>> parse_timestamp("epoch:1640606727").isoformat()
+    '2021-12-27T12:05:27+00:00'
+
+    Examples of parsing RFC 3339 like timestamps:
+
+    >>> parse_timestamp("2021-12-27 13:05:27").isoformat()  # no prefix
+    '2021-12-27T13:05:27'
+    >>> parse_timestamp("rfc3339:2021-12-27 13:05:27").isoformat()
+    '2021-12-27T13:05:27'
+
+    Examples of invalid formats:
+
+    >>> parse_timestamp("illegal-scheme:foo")
+    Traceback (most recent call last):
+      ...
+    ValueError: unknown timestamp format
+    >>> parse_timestamp("tomorrow at 2 PM")
+    Traceback (most recent call last):
+      ...
+    ValueError: unknown timestamp format
+    """
+
+    if value.startswith("@"):
+        return _parse_epoch(value[1:])
+
+    # handle explicit schemes
+    scheme_match = re.fullmatch(r"([a-zA-Z][a-zA-Z0-9+.-]*):(.*)", value)
+    if scheme_match is not None:
+        scheme = scheme_match.group(1).lower()
+        value = scheme_match.group(2)
+        if scheme == "epoch":
+            return _parse_epoch(value)
+        if scheme == "rfc3339":
+            return _parse_rfc3339(value)
+        raise ValueError("unknown timestamp format")
+
+    # guess the format
+    for parser in [_parse_epoch, _parse_rfc3339]:
+        try:
+            return parser(value)
+        except ValueError:
+            pass
+
+    raise ValueError("unknown timestamp format")
+
+
+def _parse_epoch(value: str) -> datetime.datetime:
+    r"""
+    Parse an epoch timestamp.
+
+    Epoch timestamps are always resolved in the UTC timezone.
+
+    >>> _parse_epoch("1640606727").isoformat()
+    '2021-12-27T12:05:27+00:00'
+    >>> _parse_epoch("invalid")
+    Traceback (most recent call last):
+      ...
+    ValueError: not a valid Unix epoch
+    """
+    try:
+        return datetime.datetime.fromtimestamp(int(value), UTC)
+    except Exception:
+        raise ValueError("not a valid Unix epoch") from None
+
+
+def _parse_rfc3339(value: str) -> datetime.datetime:
+    r"""
+    Parse an RFC-3339 or ISO-like timestamp.
+
+    This will accept timestamps in the following formats:
+
+    * `YYYY-MMM-DD hh:mm:ss`
+    * same, but with `T` separator instead of space
+    * same, but with timezone offset (e.g. `+hh:mm` or `Z`)
+
+    Note that timestamps without an explicit timezone are naive
+    and represent a local time,
+    which may complicate some aspects of testing.
+
+    Examples for separators:
+
+    >>> _parse_rfc3339("2021-12-27 13:05:27").isoformat()
+    '2021-12-27T13:05:27'
+    >>> _parse_rfc3339("2021-12-27T13:05:27").isoformat()
+    '2021-12-27T13:05:27'
+    >>> _parse_rfc3339("2021-12-27@13:05:27+12:30")
+    Traceback (most recent call last):
+      ...
+    ValueError: timestamp separator must be 'T' or space
+
+    Examples for timezone offsets:
+
+    >>> _parse_rfc3339("2021-12-27 13:05:27Z").isoformat()
+    '2021-12-27T13:05:27+00:00'
+    >>> _parse_rfc3339("2021-12-27 13:05:27+12:30").isoformat()
+    '2021-12-27T13:05:27+12:30'
+    >>> _parse_rfc3339("2021-12-27T13:05:27-07:23").isoformat()
+    '2021-12-27T13:05:27-07:23'
+
+    Examples for invalid syntax
+    >>> _parse_rfc3339("2021/12/27 13:05:27")
+    Traceback (most recent call last):
+      ...
+    ValueError: timestamp must use RFC-3339 ...
+
+    >>> _parse_rfc3339("2021-12-27 13:05:27 UTC")
+    Traceback (most recent call last):
+      ...
+    ValueError: timezone offset must be 'Z' or +hh:mm
+
+    """
+    date_value = value[:10]  # YYYY-MM-DD
+    sep = value[10]  # T or space
+    time_value = value[11:19]  # hh:mm:ss
+    tz_value = value[19:]  # empty or Z or +hh:mm
+
+    if sep.lower() not in ("t", " "):
+        raise ValueError("timestamp separator must be 'T' or space")
+
+    try:
+        naive_timestamp = datetime.datetime.strptime(
+            date_value + " " + time_value,
+            "%Y-%m-%d %H:%M:%S",
+        )
+    except ValueError:
+        raise ValueError(
+            "timestamp must use RFC-3339 (YYYY-MM-DD hh:mm:ss) format"
+        ) from None
+
+    if not tz_value:
+        return naive_timestamp
+
+    timezone = _parse_timezone(tz_value)
+    return naive_timestamp.replace(tzinfo=timezone)
+
+
+def _parse_timezone(value: str) -> datetime.timezone:
+    r"""
+    Unfortunately, it is necessary to handle timezones manually.
+    Python's supported strptime format specifiers are not sufficient.
+    For example, "%z" does not match "Z" on all Python versions
+    and might not support "+hh:mm" style timezone offsets.
+    """
+
+    if value.lower() == "z":
+        value = "+00:00"
+
+    tz_match = re.fullmatch(r"([+-])([0-9]{2}):([0-9]{2})", value)
+    if tz_match is None:
+        raise ValueError("timezone offset must be 'Z' or +hh:mm")
+    sign, hours, minutes = tz_match.groups()
+    offset_sign = +1 if sign == "+" else -1
+    offset_hours = int(hours)
+    offset_minutes = int(minutes)
+
+    offset = offset_sign * datetime.timedelta(
+        hours=offset_hours,
+        minutes=offset_minutes,
+    )
+    if offset.total_seconds() == 0:
+        return UTC
+    return datetime.timezone(offset)

--- a/gcovr/writer/cobertura.py
+++ b/gcovr/writer/cobertura.py
@@ -16,8 +16,6 @@
 #
 # ****************************************************************************
 
-import time
-
 from lxml import etree
 
 from ..version import __version__
@@ -83,7 +81,7 @@ def print_xml_report(covdata, output_file, options):
         "complexity", "0.0"
     )
     root.set(
-        "timestamp", str(int(time.time()))
+        "timestamp", str(int(options.timestamp.timestamp()))
     )
     root.set(
         "version", "gcovr %s" % (__version__,)

--- a/gcovr/writer/coveralls.py
+++ b/gcovr/writer/coveralls.py
@@ -59,7 +59,8 @@ def print_coveralls_report(covdata, output_file, options):
     json_dict = {}
 
     # Capture timestamp
-    json_dict['run_at'] = datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S UTC")
+    timestamp: datetime.datetime = options.timestamp.astimezone(datetime.timezone.utc)
+    json_dict['run_at'] = timestamp.strftime("%Y-%m-%d %H:%M:%S UTC")
 
     # Pull environment variables
     if(os.environ.get('COVERALLS_REPO_TOKEN') is not None):

--- a/gcovr/writer/html.py
+++ b/gcovr/writer/html.py
@@ -17,7 +17,6 @@
 # ****************************************************************************
 
 import os
-import datetime
 import hashlib
 import io
 from argparse import ArgumentTypeError
@@ -191,7 +190,7 @@ class RootInfo:
 
         self.version = __version__
         self.head = options.html_title
-        self.date = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        self.date = options.timestamp.isoformat(sep=" ", timespec="seconds")
         self.encoding = options.html_encoding
         self.directory = None
         self.branches = dict()

--- a/noxfile.py
+++ b/noxfile.py
@@ -13,6 +13,7 @@ BLACK_CONFORM_FILES = [
     "noxfile.py",
     "gcovr/gcov.py",
     "gcovr/gcov_parser.py",
+    "gcovr/timestamps.py",
 ]
 
 nox.options.sessions = ["qa"]


### PR DESCRIPTION
Certain report formats include a timestamp (HTML, Coveralls, Cobertura). It may however be desirable to attribute the report to a different time:

* e.g. date of a commit instead of time when gcovr was run
* CI server might be running with wrong timezone
* the gcovr test suite

Currently, the gcovr test suite scrubs timestamps from the generated files in order to enable comparison. In the future, this option could be used instead. The HTML-example test was already modified to use fixed timestamps in order to avoid unnecessary Git diffs (the html-details example outputs are committed).

The supported date formats for the --timestamp option are the Unix epoch and formats that are like RFC-3339 ("ISO dates" without the more insane features). Time zones are optional.

This should be able to directly understand the outputs from the following GNU
date commands:

    date --rfc-3339=seconds
    date --iso-8601=seconds
    date +%s

It will also understand the following date formats used by Git:

    %aI, %cI, --date=iso-strict, --date=iso8601-strict
    %at, %ct, --date=unix
    %ad, %cd (when appropriate --date format is selected)

See: [`git show` pretty formats](https://git-scm.com/docs/git-show#_pretty_formats), [`git log` --date format](https://git-scm.com/docs/git-log#Documentation/git-log.txt---dateltformatgt)

Not supported is the RFC 2822 / RFC 5322 format known from emails (e.g. `Mon, 27 Dec 2021 19:09:44 +0100`). Also unsupported are timestamps with sub-second accuracy.

While the timestamp parser will guess the format (Epoch or RFC-3339) correctly, it is also possible to specify a particular format using a prefix:

    gcovr --html --timestamp=epoch:1640606727
    gcovr --html --timestamp=@1640606727
    gcovr --html --timestamp="rfc3339:2021-12-27 13:05:27"

That is, the supported prefixes are:

| prefix     |  description
|------------|--------------------------------
| `@`        |  Unix timestamps, matches GNU date
| `epoch:`   | Unix timestamps
| `rfc3339:` | RFC-3339 like timestamps

This will enable backwards-compatible future evolution of the supported formats. The prefixes are not yet mentioned in the `--help` message.

Context: #543 proposed disabling a test because it overwrote the timestamp in a committed file. Instead of disabling the test, this option prevents the timestamp from being changed.

Why this shouldn't be merged, perhaps: that's a lot of extra code for a little feature. Admittedly, a lot of the code is doctests. But my desire to support a reasonably strict timestamp format that can be maintained in a backwards-compatible manner seems to be a bad match for the Python standard library. The `datetime.fromisoformat()` function is almost suitable except that it's overly lax with respect to the time-separator (`2021-12-27318:53:12`) would parse successfully – note the `3` in the separator position) but also overly strict with respect to timezones (doesn't understand the extremely common `Z` for UTC-timezone).