### PR TITLE
Use LF for sh files.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,6 +18,11 @@ indent_size = 4
 [*.json]
 insert_final_newline = false
 
+[*.sh]
+# Declare that the script files will always have LF line endings on checkout.
+# Otherwise using cygwin and WSL to execute these will fail if checkout is done on Windows.
+end_of_line = lf
+
 # for the web templates, use more compact indent
 [gcovr/templates/*]
 indent_size = 2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,7 @@ Internal changes:
  - Add support for full path in environment CC. (:issue:`541`)
  - Ensure that shell files are always checked out with LF linebreaks. (:issue:`538`)
  - Add test for compiler option ``-fprofile-abs-path``. (:issue:`521`)
+ - Ensure that shell files are always saved with LF linebreaks. (:issue:`547`)
 
 5.0 (11 June 2021)
 ------------------


### PR DESCRIPTION
With #538 git was configured to use LF for shell sc ripts. This PR extends the .editorconfig to also use LF.