### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,29 +69,57 @@ jobs:
 
     needs: [milestone-check, changelog-check]
 
+    # Testing strategy
+    # ----------------
+    #
+    # We have different axes of the testing matrix:
+    #
+    # OS: Linux, Windows
+    # Compiler: GCC-5, GCC-6, GCC-8, Clang-10
+    # Python: 3.7 -- 3.10, pypy3
+    #
+    # Instead of testing all combinations, we try to achieve full coverage
+    # across each axis. The main test matrix just represents the Python axis on
+    # Linux. The OS=Windows and Compiler axis are added manually.
+    #
+    # Some cases (Linux with Python 3.7, Clang-10) are handled via the Docker-tests.
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2019]
+        os: [ubuntu-20.04]
         gcc: [gcc-8]
-        python-version: [3.7, 3.8] # 3.6 is used in Docker
+        python-version: ['3.8', '3.9', '3.10', 'pypy-3.7'] # 3.7 is used in Docker
 
         include:
+
+          # Test additional compilers with Linux.
+          # Note that Clang-10 is handled via Docker.
           - os: ubuntu-18.04
             gcc: gcc-5
-            python-version: 3.7
+            python-version: '3.8'
           - os: ubuntu-18.04
             gcc: gcc-6
-            python-version: 3.8
-          - os: ubuntu-20.04
+            python-version: '3.8'
+
+          # Test minimum and maximum Python version on Windows.
+          - os: windows-2019
             gcc: gcc-8
-            python-version: pypy3
+            python-version: '3.7'
+          - os: windows-2019
+            gcc: gcc-8
+            python-version: '3.10'
 
     steps:
     - uses: actions/checkout@v2
     - name: Setup environment
       run: |
-        echo "USE_COVERAGE=${{ ( ( matrix.os == 'windows-2019' ) && ( matrix.python-version == '3.7' ) ) || ( ( matrix.os == 'ubuntu-18.04' ) && ( matrix.gcc == 'gcc-6' ) && ( matrix.python-version == '3.8' ) ) }}" >> $GITHUB_ENV
+        # Enable coverage for specific target configurations
+        case "${{ matrix.os }}/${{ matrix.gcc }}/${{ matrix.python-version }}" in
+          windows-2019/gcc-8/3.7) USE_COVERAGE=true ;;
+          ubuntu-18.04/gcc-6/3.8) USE_COVERAGE=true ;;
+          *)                      USE_COVERAGE=false ;;
+        esac
+        echo USE_COVERAGE=$USE_COVERAGE >> $GITHUB_ENV
       shell: bash
     - name: Install msys with GCC (Windows)
       if: ${{ startsWith(matrix.os,'windows-') }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ Next Release
 
 Breaking changes:
 
+- Dropped support for Python 3.6 (:issue:`550`)
+
 Improvements and new features:
 
 - Add function coverage metric (:issue:`362`)

--- a/admin/Dockerfile.qa
+++ b/admin/Dockerfile.qa
@@ -4,10 +4,29 @@ ARG USERID
 ARG CC
 ARG CXX
 
+# Install dependencies.
+#
+# Installing pip is a bit more complicated though:
+# * `apt install python3.7-pip` -> does not exist
+# * `python3.7 -m ensurepip` -> standard library module removed by Debian
+# * `apt install python3-pip` -> pulls in >100MB of unneeded stuff
+# * `get-pip.py` script -> depends on distutils standard library module, removed by Debian
+#
+# Solution: install python3-setuptools (includes Python 3.6),
+# then use the get-pip script from Python 3.7.
 RUN \
-  apt update && \
-  apt-get install -y sudo make $CC $CXX python3 python3-pip ninja-build && \
-  apt-get clean
+    apt-get update && \
+    apt-get install -y sudo make $CC $CXX python3-setuptools python3.7 ninja-build curl && \
+    apt-get clean
+
+# Install pip manually
+RUN \
+    curl -sSL https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
+    python3.7 get-pip.py && \
+    rm get-pip.py
+
+# Install Python 3.7 as the default "python3" executable
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 10
 
 WORKDIR /gcovr
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,3 @@
 sphinx
 sphinx_rtd_theme
-sphinxcontrib-autoprogram == 0.1.5 ; python_version == "3.6"
-sphinxcontrib-autoprogram >= 0.1.5 ; python_version >= "3.7"
+sphinxcontrib-autoprogram >= 0.1.5

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -8,9 +8,9 @@ Installation
 Which environments does ``gcovr`` support?
 
 Python:
-    3.6+.
+    3.7+.
 
-    The automated tests run on CPython (versions 3.6, 3.7, 3.8)
+    The automated tests run on CPython (versions 3.7, 3.8, 3.9, 3.10)
     and a compatible PyPy3.
     Gcovr will only run on Python versions with upstream support.
 
@@ -23,6 +23,7 @@ Python:
     2.7    4.2
     3.4    4.1
     3.5    4.2
+    3.6    5.0
     ====== =====
 
 Operating System:

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/x-rst",
     platforms=["any"],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     packages=find_packages(include=["gcovr*"], exclude=["gcovr.tests"]),
     install_requires=["jinja2", "lxml", "pygments"],
     package_data={


### PR DESCRIPTION
Python 3.6 was EOL'ed on 23 Dec 2021. In line with gcovr's support policy for Python versions, this pull request removes support for Python 3.6.

References: [PEP 494 (Python 3.6 Release Schedule)](https://www.python.org/dev/peps/pep-0494/), [endoflife.date/python](https://endoflife.date/python)

This has no strong immediate benefits, but will allow us to use more modern Python features in the future. Highlight features of Python 3.7 include:

* [`dataclasses`](https://docs.python.org/3/library/dataclasses.html) to easily define struct-like classes. Could simplify a lot of places where we currently pass around tuples!
* `from __future__ import annotations` for easier type annotations
* guaranteed dict insertion order preservation
* significant improvements to asyncio. Could allow us to replace the multithreading approach for running concurrent gcov processes.

Following this PR, I plan to submit patches that introduce more type checking, with the eventual goal of enabling `mypy` as a linter. While using a type checker sometimes requires writing the code a bit differently, it is my experience that this can detect some bugs up front – a good counterpart to our test suite. It is also my hope that such type annotations will make other refactorings safer, make it easier to navigate the codebase, and help other people contribute more easily.