### PR TITLE
Add persisten cache in docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ pip-log.txt
 # wheel
 gcovr-*/
 
+# nox
+.nox*/
+
 # Translations
 *.mo
 

--- a/admin/Dockerfile.qa
+++ b/admin/Dockerfile.qa
@@ -30,10 +30,17 @@ RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 10
 
 WORKDIR /gcovr
 
-ENV CC=$CC CXX=$CXX GCOVR_ISOLATED_TEST=zkQEVaBpXF1i NOX_ENV_DIR=/gcovr/.nox-containerized.$CC.uid_$USERID
+ENV \
+  CC=$CC \
+  CXX=$CXX \
+  GCOVR_ISOLATED_TEST=zkQEVaBpXF1i \
+  NOX_ENV_DIR=/gcovr/.nox-containerized.$CC.uid_$USERID
+# Separate instruction because of reference to NOX_ENV_DIR
+ENV \
+  XDG_CACHE_HOME=$NOX_ENV_DIR/.cache
 
 RUN \
-  python3 -m pip install --no-cache-dir nox
+  python3 -m pip install nox
 
 # Create new user "docker" and set password to "docker"
 RUN addgroup docker


### PR DESCRIPTION
As mentioned in #559 the cache isn't used inside docker because it's not persistent.
This PR configures the while cache of the container to be inside the venv folder of the container. Now the PIP and other caches are persistent for different runs of a container instance.

[no changelog]