### PR TITLE
Add flake8-print to check usage of print function.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -48,6 +48,7 @@ Internal changes:
  - Add test for compiler option ``-fprofile-abs-path``. (:issue:`521`)
  - Ensure that shell files are always saved with LF linebreaks. (:issue:`547`)
  - Update the test driver to share the reference data between the different compiler versions. (:issue:`556`)
+ - Add flake8-print to check usage of print function. (:issue:`566`)
 
 5.0 (11 June 2021)
 ------------------

--- a/admin/add_copyright.py
+++ b/admin/add_copyright.py
@@ -20,6 +20,7 @@
 
 import copy
 import os
+import logging
 import subprocess
 
 import gcovr.version
@@ -155,7 +156,7 @@ def main():
                 for handler in handlers:
                     newLines = handler(fullname, newLines)
                 if newLines != lines:
-                    print("Modifying {}".format(fullname))
+                    logging.info("Modifying {}".format(fullname))
                     with open(fullname, "w") as f:
                         for line in newLines:
                             f.write(line + "\n")

--- a/gcovr/__main__.py
+++ b/gcovr/__main__.py
@@ -158,7 +158,7 @@ def main(args=None):
         logger.setLevel(logging.DEBUG)
 
     if cli_options.version:
-        print(f"gcovr {__version__}\n\n{COPYRIGHT}")
+        sys.stdout.write(f"gcovr {__version__}\n\n{COPYRIGHT}")
         sys.exit(0)
 
     if options.html_title == '':

--- a/gcovr/tests/test_gcovr.py
+++ b/gcovr/tests/test_gcovr.py
@@ -18,8 +18,8 @@
 
 import glob
 import io
+import logging
 import os
-import os.path
 import platform
 import pytest
 import re
@@ -149,9 +149,9 @@ def assert_xml_equals(reference, coverage):
 
 
 def run(cmd, cwd=None):
-    print("STDOUT - START", str(cmd))
+    sys.stdout.write(f"STDOUT - START {cmd}\n")
     returncode = subprocess.call(cmd, stderr=subprocess.STDOUT, env=env, cwd=cwd)
-    print("STDOUT - END")
+    sys.stdout.write("STDOUT - END\n")
     return returncode == 0
 
 
@@ -314,7 +314,7 @@ def generate_reference_data(output_pattern):  # pragma: no cover
                 continue
             else:
                 os.makedirs(REFERENCE_DIRS[0], exist_ok=True)
-                print("copying %s to %s" % (generated_file, reference_file))
+                logging.info(f"copying {generated_file} to {reference_file}")
                 shutil.copyfile(generated_file, reference_file)
 
 

--- a/gcovr/tests/test_html_generator.py
+++ b/gcovr/tests/test_html_generator.py
@@ -16,6 +16,7 @@
 #
 # ****************************************************************************
 
+import logging
 import os
 import pytest
 import sys
@@ -41,10 +42,10 @@ def test_windows__make_short_sourcename(outfile, source_filename):
     source_filename = source_filename.replace('C:', CurrentDrive)
 
     result = _make_short_sourcename(outfile, source_filename)
-    print("=" * 100)
-    print(outfile)
-    print(source_filename)
-    print(result)
+    logging.info("=" * 100)
+    logging.info(outfile)
+    logging.info(source_filename)
+    logging.info(result)
     assert ':' not in result or (result.startswith(CurrentDrive) and ':' not in result[2:])
 
     assert len(result) < 256

--- a/noxfile.py
+++ b/noxfile.py
@@ -55,7 +55,7 @@ def qa(session: nox.Session) -> None:
 @nox.session
 def lint(session: nox.Session) -> None:
     """Run the lint (flake8 and black)."""
-    session.install("flake8")
+    session.install("flake8", "flake8-print")
     # Black installs under Pypy but doesn't necessarily run (cf psf/black#2559).
     if platform.python_implementation() == "CPython":
         session.install(BLACK_PINNED_VERSION)


### PR DESCRIPTION
As discussed in #540 this PR adds `flake8-print` to check for wrong usage of print instead of the logger.

Following parts must go to STDOUT and use `sys.stdout.write` as in summary report:
- Output of `--version`.
- START/END marker of output in tests.