### PR TITLE
Fix resolution of relative filters in configuration files.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Improvements and new features:
 - Generate also a Report of Excluded Coverage. (:issue:`503`)
 - Added :option:`--decisions` to add decision coverage to HTML and JSON output. (:issue:`350`)
 - Replace own logger with python logger module. (:issue:`540`)
+- Fix resolution of relative filters in configuration files. (:issue:`568`)
 
 Documentation:
 

--- a/gcovr/configuration.py
+++ b/gcovr/configuration.py
@@ -17,6 +17,7 @@
 # ****************************************************************************
 
 from argparse import ArgumentTypeError, SUPPRESS
+from inspect import isclass
 from locale import getpreferredencoding
 from multiprocessing import cpu_count
 from typing import Iterable, Any
@@ -429,7 +430,7 @@ def _get_value_from_config_entry(cfg_entry, option):
 
         value = cfg_entry.value
         args = ()
-        if option.type is FilterOption:
+        if isclass(option.type) and issubclass(option.type, FilterOption):
             args = [os.path.dirname(cfg_entry.filename)]
         elif option.type is check_input_file:
             value = check_input_file(value, os.path.dirname(cfg_entry.filename))


### PR DESCRIPTION
The option type wasn't detected correct and the working directory was used instead of the directory of the configuration file.

Closes #567 