### PR TITLE
Workaround for hanging test "threaded" in pypy.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -53,6 +53,7 @@ Internal changes:
  - Ensure that shell files are always saved with LF linebreaks. (:issue:`547`)
  - Update the test driver to share the reference data between the different compiler versions. (:issue:`556`)
  - Add flake8-print to check usage of print function. (:issue:`566`)
+ - Add timeout for each single test. (:issue:`572`)
 
 5.0 (11 June 2021)
 ------------------

--- a/gcovr/tests/threaded/Makefile
+++ b/gcovr/tests/threaded/Makefile
@@ -1,5 +1,7 @@
 CFLAGS= -fprofile-arcs -ftest-coverage -fPIC
 
+GCOVR += --verbose
+
 all:
 	$(CXX) $(CFLAGS) -c subdir/A/file1.cpp -o subdir/A/file1.o
 	$(CXX) $(CFLAGS) -c subdir/A/file2.cpp -o subdir/A/file2.o
@@ -13,6 +15,7 @@ all:
 
 run: txt xml html sonarqube coveralls
 
+# Activate verbose mode because of hanging pypy in GitHub actions
 coverage.json:
 	./subdir/testcase
 	$(GCOVR) -j 4 -r subdir --json $@

--- a/noxfile.py
+++ b/noxfile.py
@@ -123,6 +123,7 @@ def tests_compiler(session: nox.Session, version: str) -> None:
         "lxml",
         "pygments==2.7.4",
         "pytest",
+        "pytest-timeout",
         "cmake",
         "yaxmldiff",
     )

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ exclude_lines =
 [flake8]
 max-line-length = 88
 ignore = E203, E501, W503
-exclude = .git, __pycache__ 
+exclude = .git, __pycache__
 
 [tool:pytest]
-addopts = -v --doctest-modules --ignore-glob=*/linked/subdir/*
+addopts = -v --timeout=60 --doctest-modules --ignore-glob=*/linked/subdir/*


### PR DESCRIPTION
Activate verbose mode hanging pypy in GitHub actions