### PR TITLE
directly import Markup from markupsafe (fix breakage with jinja2>=3.1)

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -22,6 +22,7 @@ The following developers contributed to gcovr (ordered alphabetically):
     Elektrobit Automotive GmbH,
     Ensky Lin,
     Glenn Töws,
+    Grégoire Roussel,
     goriy,
     Irfan Adilovic,
     ja11sop,

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -55,6 +55,7 @@ Internal changes:
  - Add flake8-print to check usage of print function. (:issue:`566`)
  - Add timeout for each single test. (:issue:`572`)
  - Add support for gcc-9 and clang-13 to docker tests. (:issue:`527`)
+ - Support jinja2==3.1.0 (:issue:`576`)
 
 5.0 (11 June 2021)
 ------------------

--- a/gcovr/writer/html.py
+++ b/gcovr/writer/html.py
@@ -166,7 +166,7 @@ class PygmentHighlighting:
 
         import pygments
         from pygments.lexers import get_lexer_for_filename
-        from jinja2 import Markup
+        from markupsafe import Markup
         try:
             lexer = get_lexer_for_filename(filename, None, stripnl=False)
             return lambda code: [Markup(line.rstrip()) for line in pygments.highlight(code, lexer, self.formatter).split("\n")]


### PR DESCRIPTION
Hi gcovr team !

The latest version `jinja2==3.1.0` breaks `gcovr==5.0`: `gcovr` tries to import `Markup` from `jinja2`, but it's not available anymore.

This is documented in `jinja2` change note: https://jinja.palletsprojects.com/en/3.1.x/changes/#version-3-1-0

This is my first contribution, and I drafted this PR quite quickly as I suppose many people will soon be impacted. Please tell me if I forgot something important :)

## Minimal reproducible example

```sh
# create venv with necessary tools
ptyhon3 -m venv env
source env/bin/activate
pip install gcovr==5.0 jinja2==3.1.0

# run compilation and coverage - see source below
bash run.sh
```

with the following files

```cc
// main.cc

int main()
{
    int a = 1;
    return a;
}
```
```sh
# run.sh
gcc --coverage -g -O0 main.cc -o out
./out
gcovr -r . --html --html-details -o cov.html
```

I get the output

```py
Traceback (most recent call last):
  File "<REDACTED>/gcovr_bug_jinja/env/bin/gcovr", line 8, in <module>
    sys.exit(main())
  File "<REDACTED>/gcovr_bug_jinja/env/lib/python3.8/site-packages/gcovr/__main__.py", line 280, in main
    error_occurred = print_reports(covdata, options, logger)
  File "<REDACTED>/gcovr_bug_jinja/env/lib/python3.8/site-packages/gcovr/__main__.py", line 432, in print_reports
    if generator(covdata, output.abspath, options):
  File "<REDACTED>/gcovr_bug_jinja/env/lib/python3.8/site-packages/gcovr/writer/html.py", line 401, in print_html_report
    lines = formatter.highlighter_for_file(data['filename'])(source_file.read())
  File "<REDACTED>/gcovr_bug_jinja/env/lib/python3.8/site-packages/gcovr/writer/html.py", line 159, in highlighter_for_file
    from jinja2 import Markup
ImportError: cannot import name 'Markup' from 'jinja2' (<REDACTED>/gcovr_bug_jinja/env/lib/python3.8/site-packages/jinja2/__init__.py)
```
