### PR TITLE
Fix parallel processing of gcov data.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ New features and notable changes:
 Bug fixes and small improvements:
 
 - Remove function coverage from sonarcube report (:issue:`591`)
+- Fix parallel processing of gcov data (:issue:`592`)
 
 Documentation:
 

--- a/gcovr/gcov.py
+++ b/gcovr/gcov.py
@@ -481,18 +481,18 @@ def run_gcov_and_process_files(abs_filename, covdata, options, error, toerase, c
                 chdir=chdir,
             )
 
-        if unknown_cla_re.search(err):
-            # gcov tossed errors: throw exception
-            raise RuntimeError("Error in gcov command line: {}".format(err))
-        elif source_re.search(err):
-            # gcov tossed errors: try the next potential_wd
-            error(err)
-            done = False
-        else:
-            # Process *.gcov files
-            for fname in active_gcov_files:
-                process_gcov_data(fname, covdata, abs_filename, options)
-            done = True
+            if unknown_cla_re.search(err):
+                # gcov tossed errors: throw exception
+                raise RuntimeError("Error in gcov command line: {}".format(err))
+            elif source_re.search(err):
+                # gcov tossed errors: try the next potential_wd
+                error(err)
+                done = False
+            else:
+                # Process *.gcov files
+                for fname in active_gcov_files:
+                    process_gcov_data(fname, covdata, abs_filename, options)
+                done = True
     except Exception:
         logger.error(
             f"Trouble processing {abs_filename!r} with working directory {chdir!r}.\n"


### PR DESCRIPTION
The directory lock is only for running gcov but not for parsing the data. The next run can override the data and than "FileNotFoundError" (#587) and "KeyError: 'Source'" (#588) occur.

Closes #587 
Closes #588