### PR TITLE
Add check for required metadata.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,7 @@ Bug fixes and small improvements:
 - Remove function coverage from sonarcube report. (:issue:`591`)
 - Fix parallel processing of gcov data. (:issue:`592`)
 - Fix black session to fail on format errors. (:issue:`594`)
-- Check resuired metadata keys. (:issue:`593`)
+- Better diagnostics when dealing with corrupted input files. (:issue:`593`)
 
 Documentation:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,8 +14,9 @@ New features and notable changes:
 
 Bug fixes and small improvements:
 
-- Remove function coverage from sonarcube report (:issue:`591`)
-- Fix parallel processing of gcov data (:issue:`592`)
+- Remove function coverage from sonarcube report. (:issue:`591`)
+- Fix parallel processing of gcov data. (:issue:`592`)
+- Check resuired metadata keys. (:issue:`593`)
 
 Documentation:
 

--- a/gcovr/gcov_parser.py
+++ b/gcovr/gcov_parser.py
@@ -243,7 +243,7 @@ def parse_metadata(lines: List[str]) -> Dict[str, str]:
 
     if "Source" not in collected:
         data = "\n".join(lines)
-        raise RuntimeError(f"Missing key 'Source' in metadata. GCOV data was:\n{data}")
+        raise RuntimeError(f"Missing key 'Source' in metadata. GCOV data was >>{data}<< End of GCOV data")
 
     return collected
 

--- a/gcovr/gcov_parser.py
+++ b/gcovr/gcov_parser.py
@@ -210,16 +210,16 @@ def parse_metadata(lines: List[str]) -> Dict[str, str]:
     Collect the header/metadata lines from a gcov file.
 
     Example:
-    >>> parse_metadata('''\
+    >>> parse_metadata('''
     ...   -: 0:Foo:bar
     ...   -: 0:Key:123
     ... '''.splitlines())
     Traceback (most recent call last):
        ...
-    RuntimeError: Missing key 'Source' in metadata. GCOV data was:
+    RuntimeError: Missing key 'Source' in metadata. GCOV data was >>
       -: 0:Foo:bar
-      -: 0:Key:123
-    >>> parse_metadata('''\
+      -: 0:Key:123<< End of GCOV data
+    >>> parse_metadata('''
     ...   -: 0:Source:file
     ...   -: 0:Foo:bar
     ...   -: 0:Key:123

--- a/gcovr/gcov_parser.py
+++ b/gcovr/gcov_parser.py
@@ -242,10 +242,8 @@ def parse_metadata(lines: List[str]) -> Dict[str, str]:
             break  # stop at the first line that is not metadata
 
     if "Source" not in collected:
-        data = '\n'.join(lines)
-        raise RuntimeError(
-            f"Missing key 'Source' in metadata. GCOV data was:\n{data}"
-        )
+        data = "\n".join(lines)
+        raise RuntimeError(f"Missing key 'Source' in metadata. GCOV data was:\n{data}")
 
     return collected
 

--- a/gcovr/gcov_parser.py
+++ b/gcovr/gcov_parser.py
@@ -210,11 +210,21 @@ def parse_metadata(lines: List[str]) -> Dict[str, str]:
     Collect the header/metadata lines from a gcov file.
 
     Example:
-    >>> parse_metadata('''
+    >>> parse_metadata('''\
     ...   -: 0:Foo:bar
     ...   -: 0:Key:123
     ... '''.splitlines())
-    {'Foo': 'bar', 'Key': '123'}
+    Traceback (most recent call last):
+       ...
+    RuntimeError: Missing key 'Source' in metadata. GCOV data was:
+      -: 0:Foo:bar
+      -: 0:Key:123
+    >>> parse_metadata('''\
+    ...   -: 0:Source:file
+    ...   -: 0:Foo:bar
+    ...   -: 0:Key:123
+    ... '''.splitlines())
+    {'Source': 'file', 'Foo': 'bar', 'Key': '123'}
     """
     collected = {}
     for line in lines:
@@ -230,6 +240,12 @@ def parse_metadata(lines: List[str]) -> Dict[str, str]:
             collected[key] = value
         else:
             break  # stop at the first line that is not metadata
+
+    if "Source" not in collected:
+        data = '\n'.join(lines)
+        raise RuntimeError(
+            f"Missing key 'Source' in metadata. GCOV data was:\n{data}"
+        )
 
     return collected
 

--- a/gcovr/gcov_parser.py
+++ b/gcovr/gcov_parser.py
@@ -243,7 +243,9 @@ def parse_metadata(lines: List[str]) -> Dict[str, str]:
 
     if "Source" not in collected:
         data = "\n".join(lines)
-        raise RuntimeError(f"Missing key 'Source' in metadata. GCOV data was >>{data}<< End of GCOV data")
+        raise RuntimeError(
+            f"Missing key 'Source' in metadata. GCOV data was >>{data}<< End of GCOV data"
+        )
 
     return collected
 


### PR DESCRIPTION
The check is tested with doctest and prints the gcov data on failure.