### PR TITLE
Fix black check: Option --check needed.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,12 +10,13 @@ Breaking changes:
 
 New features and notable changes:
 
-- Log additional infop on gcov parsing errors (:issue:`589`)
+- Log additional infop on gcov parsing errors. (:issue:`589`)
 
 Bug fixes and small improvements:
 
-- Remove function coverage from sonarcube report (:issue:`591`)
-- Fix parallel processing of gcov data (:issue:`592`)
+- Remove function coverage from sonarcube report. (:issue:`591`)
+- Fix parallel processing of gcov data. (:issue:`592`)
+- Fix black session to fail on format errors. (:issue:`594`)
 
 Documentation:
 

--- a/admin/bump_version.py
+++ b/admin/bump_version.py
@@ -148,7 +148,9 @@ def updateCallOfReleaseChecklist(filename: str, lines: List[str]):
             callFound = True
         newLines.append(line)
     if not callFound:
-        raise RuntimeError(f"Call of {callReleaseChecklist!r} not found in {filename!r}.")
+        raise RuntimeError(
+            f"Call of {callReleaseChecklist!r} not found in {filename!r}."
+        )
 
     return newLines
 
@@ -186,7 +188,7 @@ def updatDocumentation(filename: str, lines: List[str]):
             line = re.sub(
                 r"(\.\. (?:versionadded|versionchanged|deprecated):: )NEXT",
                 r"\g<1>" + VERSION,
-                line
+                line,
             )
         newLines.append(line)
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -83,7 +83,7 @@ def lint(session: nox.Session) -> None:
     session.run("flake8", *args)
 
     if platform.python_implementation() == "CPython":
-        session.run("python", "-m", "black", "--diff", *args)
+        session.run("python", "-m", "black", "--diff", "--check", *args)
     else:
         session.log(
             f"Skip black because of platform {platform.python_implementation()}."
@@ -97,7 +97,9 @@ def black(session: nox.Session) -> None:
     if session.posargs:
         session.run("python", "-m", "black", *session.posargs)
     else:
-        session.run("python", "-m", "black", "--diff", *DEFAULT_LINT_ARGUMENTS)
+        session.run(
+            "python", "-m", "black", "--diff", "--check", *DEFAULT_LINT_ARGUMENTS
+        )
 
 
 @nox.session


### PR DESCRIPTION
The option was removed by accident when reformatting all files and apply check to all files. Session isn't failing on error.