### PR TITLE
Change black session to reformat files

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,12 +16,13 @@ Bug fixes and small improvements:
 
 - Remove function coverage from sonarcube report. (:issue:`591`)
 - Fix parallel processing of gcov data. (:issue:`592`)
-- Fix black session to fail on format errors. (:issue:`594`)
 
 Documentation:
 
 Internal changes:
 
+- Fix black check to fail on format errors. (:issue:`594`)
+- Change session black with no arguments to format all files. (:issue:`595`)
 
 5.1 (26 March 2022)
 -------------------

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -256,7 +256,7 @@ and a comprehensive corpus of example projects
 that are executed as the ``test_gcovr.py`` integration test.
 Each ``gcovr/tests/*`` directory is one such example project.
 
-You can format files with ``python3 -m nox --session black FileToFormat``)
+You can format files with ``python3 -m nox --session black``)
 
 To get a list of all available sessions run ``python3 -m nox -l``.
 
@@ -264,6 +264,10 @@ The next sections discuss
 the :ref:`structure of integration tests <integration tests>`,
 how to :ref:`run and filter tests <run tests>`,
 and how to :ref:`run tests with Docker <docker tests>`.
+
+.. versionchanged:: NEXT
+   If black is called without arguments, all files aare reformatted
+   instead of checked. To check the format use the session lint.
 
 .. _integration tests:
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -97,9 +97,7 @@ def black(session: nox.Session) -> None:
     if session.posargs:
         session.run("python", "-m", "black", *session.posargs)
     else:
-        session.run(
-            "python", "-m", "black", "--diff", "--check", *DEFAULT_LINT_ARGUMENTS
-        )
+        session.run("python", "-m", "black", *DEFAULT_LINT_ARGUMENTS)
 
 
 @nox.session


### PR DESCRIPTION
If no argument is given all files are reformatted instead of checked. See also #594.