### PR TITLE
Type checking + refactoring for the coverage data model

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@
 Next Release
 ------------
 
+Known bugs:
+
+- Cobertura XML output: package-level function coverage statistics are incorrect.
+  (:issue:`600`)
+- Aggregated branch coverage does not properly respect excluded/noncode lines.
+  (:issue:`600`)
+
 Breaking changes:
 
 New features and notable changes:
@@ -20,6 +27,7 @@ Bug fixes and small improvements:
 - Accept metadata lines without values (introduced in gcc-11). (:issue:`601`)
 - Properly close <a> element in detailed HTML report. (:issue:`602`)
 - Use `≥` sign instead of `>=` in HTML legend. (:issue:`603`)
+- Using :option:`--add-tracefile` will now correctly merge branch coverage. (:issue:`600`)
 
 Documentation:
 
@@ -28,6 +36,7 @@ Internal changes:
 - Fix black check to fail on format errors. (:issue:`594`)
 - Change session black with no arguments to format all files. (:issue:`595`)
 - Add gcc-10 and gcc-11 to the test suite. (:issue:`597`)
+- Improved internal coverage data model to simplify processing. (:issue:`600`)
 
 5.1 (26 March 2022)
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Known bugs:
   (:issue:`600`)
 - Aggregated branch coverage does not properly respect excluded/noncode lines.
   (:issue:`600`)
+- Decision coverage analysis can resurrect excluded coverage. (:issue:`600`)
 
 Breaking changes:
 

--- a/gcovr/__main__.py
+++ b/gcovr/__main__.py
@@ -48,7 +48,7 @@ from .utils import (
 )
 from .version import __version__
 from .workers import Workers
-from .coverage import CovData, get_global_stats
+from .coverage import CovData, SummarizedStats
 from .merging import merge_covdata
 
 # generators
@@ -70,20 +70,14 @@ logger = logging.getLogger("gcovr")
 # Exits with status 2 if below threshold
 #
 def fail_under(covdata: CovData, threshold_line, threshold_branch):
-    (
-        lines_total,
-        lines_covered,
-        percent_lines,
-        functions_total,
-        functions_covered,
-        percent_functions,
-        branches_total,
-        branches_covered,
-        percent_branches,
-    ) = get_global_stats(covdata)
+    stats = SummarizedStats.from_covdata(covdata)
 
-    if branches_total == 0:
-        percent_branches = 100.0
+    # If there are no lines, mark as uncovered
+    # (indicates no data at all, likely an error).
+    percent_lines = stats.line.percent_or(0.0)
+
+    # Allow data with no branches.
+    percent_branches = stats.branch.percent_or(100.0)
 
     line_nok = False
     branch_nok = False

--- a/gcovr/coverage.py
+++ b/gcovr/coverage.py
@@ -17,21 +17,13 @@
 #
 # ****************************************************************************
 
+from __future__ import annotations
+from typing import Dict, Iterable, Optional, Tuple, Union
+
 from .utils import calculate_coverage
 
-# for type annotations:
-if False:
-    from typing import (  # noqa, pylint: disable=all
-        Callable,
-        Dict,
-        Iterable,
-        List,
-        Optional,
-        Tuple,
-    )
 
-
-class BranchCoverage(object):
+class BranchCoverage:
     r"""Represent coverage information about a branch.
 
     Args:
@@ -45,8 +37,12 @@ class BranchCoverage(object):
 
     __slots__ = "count", "fallthrough", "throw"
 
-    def __init__(self, count, fallthrough=None, throw=None):
-        # type: (int, Optional[bool], Optional[bool]) -> None
+    def __init__(
+        self,
+        count: int,
+        fallthrough: Optional[bool] = None,
+        throw: Optional[bool] = None,
+    ) -> None:
         assert count >= 0
 
         self.count = count
@@ -54,12 +50,10 @@ class BranchCoverage(object):
         self.throw = throw
 
     @property
-    def is_covered(self):
-        # type: () -> bool
+    def is_covered(self) -> bool:
         return self.count > 0
 
-    def update(self, other):
-        # type: (BranchCoverage) -> None
+    def update(self, other: BranchCoverage) -> None:
         r"""Merge BranchCoverage information"""
         self.count += other.count
         if other.fallthrough is not None:
@@ -68,41 +62,30 @@ class BranchCoverage(object):
             self.throw = other.throw
 
 
-class DecisionCoverageUncheckable(object):
-    r"""Represent coverage information about a decision.
+class DecisionCoverageUncheckable:
+    r"""Represent coverage information about a decision."""
 
-    Args:
-        count (int):
-            Number of times this decision was made.
-
-    """
-
-    def __init__(self):
-        # type: () -> None
+    def __init__(self) -> None:
         pass
 
     @property
-    def is_uncheckable(self):
-        # type: () -> bool
+    def is_uncheckable(self) -> bool:
         return True
 
     @property
-    def is_conditional(self):
-        # type: () -> bool
+    def is_conditional(self) -> bool:
         return False
 
     @property
-    def is_switch(self):
-        # type: () -> bool
+    def is_switch(self) -> bool:
         return False
 
-    def update(self, other):
-        # type: (DecisionCoverageUncheckable) -> None
+    def update(self, other: DecisionCoverageUncheckable) -> None:
         r"""Merge DecisionCoverage information"""
         pass
 
 
-class DecisionCoverageConditional(object):
+class DecisionCoverageConditional:
     r"""Represent coverage information about a decision.
 
     Args:
@@ -116,36 +99,31 @@ class DecisionCoverageConditional(object):
 
     __slots__ = "count_true", "count_false"
 
-    def __init__(self, count_true, count_false):
-        # type: (int, int) -> None
+    def __init__(self, count_true: int, count_false: int) -> None:
         assert count_true >= 0
         self.count_true = count_true
         assert count_false >= 0
         self.count_false = count_false
 
     @property
-    def is_uncheckable(self):
-        # type: () -> bool
+    def is_uncheckable(self) -> bool:
         return False
 
     @property
-    def is_conditional(self):
-        # type: () -> bool
+    def is_conditional(self) -> bool:
         return True
 
     @property
-    def is_switch(self):
-        # type: () -> bool
+    def is_switch(self) -> bool:
         return False
 
-    def update(self, other):
-        # type: (DecisionCoverageConditional) -> None
+    def update(self, other: DecisionCoverageConditional) -> None:
         r"""Merge DecisionCoverage information"""
         self.count_true += other.count_true
         self.count_false += other.count_false
 
 
-class DecisionCoverageSwitch(object):
+class DecisionCoverageSwitch:
     r"""Represent coverage information about a decision.
 
     Args:
@@ -155,44 +133,44 @@ class DecisionCoverageSwitch(object):
 
     __slots__ = "count"
 
-    def __init__(self, count):
-        # type: (int) -> None
+    def __init__(self, count: int) -> None:
         assert count >= 0
         self.count = count
 
     @property
-    def is_uncheckable(self):
-        # type: () -> bool
+    def is_uncheckable(self) -> bool:
         return False
 
     @property
-    def is_conditional(self):
-        # type: () -> bool
+    def is_conditional(self) -> bool:
         return False
 
     @property
-    def is_switch(self):
-        # type: () -> bool
+    def is_switch(self) -> bool:
         return True
 
-    def update(self, other):
-        # type: (DecisionCoverageSwitch) -> None
+    def update(self, other: DecisionCoverageSwitch) -> None:
         r"""Merge DecisionCoverage information"""
         self.count += other.count
 
 
-class FunctionCoverage(object):
+DecisionCoverage = Union[
+    DecisionCoverageUncheckable,
+    DecisionCoverageConditional,
+    DecisionCoverageSwitch,
+]
+
+
+class FunctionCoverage:
     __slots__ = "lineno", "count", "name"
 
-    def __init__(self, name, call_count=0):
-        # type: (int, int) -> None
+    def __init__(self, name: str, call_count: int = 0) -> None:
         assert call_count >= 0
         self.count = call_count
         self.lineno = 0
         self.name = name
 
-    def update(self, other):
-        # type: (FunctionCoverage) -> None
+    def update(self, other: FunctionCoverage) -> None:
         r"""Merge FunctionCoverage information"""
         self.count += other.count
         if self.lineno == 0:
@@ -201,7 +179,7 @@ class FunctionCoverage(object):
             assert self.lineno == other.lineno
 
 
-class LineCoverage(object):
+class LineCoverage:
     r"""Represent coverage information about a line.
 
     Args:
@@ -225,45 +203,42 @@ class LineCoverage(object):
         "functions",
     )
 
-    def __init__(self, lineno, count=0, noncode=False, excluded=False):
-        # type: (int, int, bool) -> None
+    def __init__(
+        self, lineno: int, count: int = 0, noncode: bool = False, excluded: bool = False
+    ) -> None:
         assert lineno > 0
         assert count >= 0
 
-        self.lineno = lineno  # type: int
-        self.count = count  # type: int
-        self.noncode = noncode
-        self.excluded = excluded
-        self.branches = {}  # type: Dict[int, BranchCoverage]
-        self.decision = None
+        self.lineno: int = lineno
+        self.count: int = count
+        self.noncode: bool = noncode
+        self.excluded: bool = excluded
+        self.branches: Dict[int, BranchCoverage] = {}
+        self.decision: Optional[DecisionCoverage] = None
 
         # There can be only one (user) function per line but:
         # * (multiple) template instantiations
         # * non explicitly defined destructors, called via base virtual destructor!
         # For that reason we need a dictionary instead of a scalar
-        self.functions = {}  # type: Dict[str, FunctionCoverage]
+        self.functions: Dict[str, FunctionCoverage] = {}
 
     @property
-    def is_excluded(self):
-        # type: () -> bool
+    def is_excluded(self) -> bool:
         return self.excluded
 
     @property
-    def is_covered(self):
-        # type: () -> bool
+    def is_covered(self) -> bool:
         if self.noncode:
             return False
         return self.count > 0
 
     @property
-    def is_uncovered(self):
-        # type: () -> bool
+    def is_uncovered(self) -> bool:
         if self.noncode:
             return False
         return self.count == 0
 
-    def branch(self, branch_id):
-        # type: (int) -> BranchCoverage
+    def branch(self, branch_id: int) -> BranchCoverage:
         r"""Get or create the BranchCoverage for that branch_id."""
         try:
             return self.branches[branch_id]
@@ -271,8 +246,7 @@ class LineCoverage(object):
             self.branches[branch_id] = branch_cov = BranchCoverage(0)
             return branch_cov
 
-    def update(self, other):
-        # type: (LineCoverage) -> None
+    def update(self, other: LineCoverage) -> None:
         r"""Merge LineCoverage information."""
         assert self.lineno == other.lineno
         self.count += other.count
@@ -288,8 +262,7 @@ class LineCoverage(object):
         else:
             self.decision.update(other.decision)
 
-    def branch_coverage(self):
-        # type: () -> Tuple[int, int, Optional[float]]
+    def branch_coverage(self) -> Tuple[int, int, Optional[float]]:
         total = len(self.branches)
         cover = 0
         for branch in self.branches.values():
@@ -299,8 +272,7 @@ class LineCoverage(object):
         percent = calculate_coverage(cover, total, nan_value=None)
         return total, cover, percent
 
-    def decision_coverage(self):
-        # type: () -> Tuple[int, int, int, Optional[float]]
+    def decision_coverage(self) -> Tuple[int, int, int, Optional[float]]:
         total = 0
         cover = 0
         unchecked = False
@@ -325,17 +297,15 @@ class LineCoverage(object):
         return total, cover, unchecked, percent
 
 
-class FileCoverage(object):
+class FileCoverage:
     __slots__ = "filename", "functions", "lines"
 
-    def __init__(self, filename):
-        # type: (str) -> None
+    def __init__(self, filename: str) -> None:
         self.filename = filename
-        self.functions = {}  # type: Dict[str, FunctionCoverage]
-        self.lines = {}  # type: Dict[int, LineCoverage]
+        self.functions: Dict[str, FunctionCoverage] = {}
+        self.lines: Dict[int, LineCoverage] = {}
 
-    def line(self, lineno, **defaults):
-        # type: (int) -> LineCoverage
+    def line(self, lineno: int, **defaults) -> LineCoverage:
         r"""Get or create the LineCoverage for that lineno."""
         try:
             return self.lines[lineno]
@@ -343,8 +313,7 @@ class FileCoverage(object):
             self.lines[lineno] = line_cov = LineCoverage(lineno, **defaults)
             return line_cov
 
-    def function(self, function_name):
-        # type: (str) -> FunctionCoverage
+    def function(self, function_name: str) -> FunctionCoverage:
         r"""Get or create the FunctionCoverage for that function."""
         try:
             return self.functions[function_name]
@@ -354,7 +323,7 @@ class FileCoverage(object):
             )
             return function_cov
 
-    def add_function(self, function):
+    def add_function(self, function: FunctionCoverage) -> None:
         assert function is not None
         if function.name in self.functions:
             self.functions[
@@ -365,8 +334,7 @@ class FileCoverage(object):
         else:
             self.functions[function.name] = function
 
-    def update(self, other):
-        # type: (FileCoverage) -> None
+    def update(self, other: FileCoverage) -> None:
         r"""Merge FileCoverage information."""
         assert self.filename == other.filename
         for lineno, line_cov in other.lines.items():
@@ -374,8 +342,7 @@ class FileCoverage(object):
         for fct_name, fct_cov in other.functions.items():
             self.function(fct_name).update(fct_cov)
 
-    def uncovered_lines_str(self):
-        # type: () -> str
+    def uncovered_lines_str(self) -> str:
         uncovered_lines = sorted(
             lineno for lineno, line in self.lines.items() if line.is_uncovered
         )
@@ -395,8 +362,7 @@ class FileCoverage(object):
             for first, last in _find_consecutive_ranges(uncovered_lines)
         )
 
-    def uncovered_branches_str(self):
-        # type: () -> str
+    def uncovered_branches_str(self) -> str:
         uncovered_lines = sorted(
             lineno
             for lineno, line in self.lines.items()
@@ -406,8 +372,7 @@ class FileCoverage(object):
         # Don't do any aggregation on branch results
         return ",".join(str(x) for x in uncovered_lines)
 
-    def function_coverage(self):
-        # type: () -> Tuple[int, int, Optional[float]]
+    def function_coverage(self) -> Tuple[int, int, Optional[float]]:
         total = len(self.functions.values())
         cover = 0
         for function in self.functions.values():
@@ -417,8 +382,7 @@ class FileCoverage(object):
 
         return total, cover, percent
 
-    def line_coverage(self):
-        # type: () -> Tuple[int, int, Optional[float]]
+    def line_coverage(self) -> Tuple[int, int, Optional[float]]:
         total = 0
         cover = 0
         for line in self.lines.values():
@@ -430,8 +394,7 @@ class FileCoverage(object):
         percent = calculate_coverage(cover, total, nan_value=None)
         return total, cover, percent
 
-    def branch_coverage(self):
-        # type: () -> Tuple[int, int, Optional[float]]
+    def branch_coverage(self) -> Tuple[int, int, Optional[float]]:
         total = 0
         cover = 0
         for line in self.lines.values():
@@ -442,8 +405,7 @@ class FileCoverage(object):
         percent = calculate_coverage(cover, total, nan_value=None)
         return total, cover, percent
 
-    def decision_coverage(self):
-        # type: () -> Tuple[int, int, Optional[float]]
+    def decision_coverage(self) -> Tuple[int, int, int, Optional[float]]:
         total = 0
         cover = 0
         unchecked = 0
@@ -457,7 +419,7 @@ class FileCoverage(object):
         return total, cover, unchecked, percent
 
 
-def _find_consecutive_ranges(items):
+def _find_consecutive_ranges(items: Iterable[int]) -> Iterable[Tuple[int, int]]:
     first = last = None
     for item in items:
         if last is None:
@@ -468,14 +430,16 @@ def _find_consecutive_ranges(items):
             last = item
             continue
 
+        assert first is not None
         yield first, last
         first = last = item
 
     if last is not None:
+        assert first is not None
         yield first, last
 
 
-def _format_range(first, last):
+def _format_range(first: int, last: int) -> str:
     if first == last:
         return str(first)
     return "{first}-{last}".format(first=first, last=last)

--- a/gcovr/coverage.py
+++ b/gcovr/coverage.py
@@ -216,12 +216,6 @@ class LineCoverage:
         self.branches: Dict[int, BranchCoverage] = {}
         self.decision: Optional[DecisionCoverage] = None
 
-        # There can be only one (user) function per line but:
-        # * (multiple) template instantiations
-        # * non explicitly defined destructors, called via base virtual destructor!
-        # For that reason we need a dictionary instead of a scalar
-        self.functions: Dict[str, FunctionCoverage] = {}
-
     @property
     def is_excluded(self) -> bool:
         return self.excluded
@@ -252,8 +246,7 @@ class LineCoverage:
         self.count += other.count
         self.noncode &= other.noncode
         self.excluded |= other.excluded
-        for other_function in other.functions.values():
-            self.add_function(other_function)
+
         for branch_id, branch_cov in other.branches.items():
             self.branch(branch_id).update(branch_cov)
 
@@ -322,17 +315,6 @@ class FileCoverage:
                 function_name
             )
             return function_cov
-
-    def add_function(self, function: FunctionCoverage) -> None:
-        assert function is not None
-        if function.name in self.functions:
-            self.functions[
-                function.name
-            ].count += (
-                function.count
-            )  # Add the calls to destructor via base class (virtual destructor)
-        else:
-            self.functions[function.name] = function
 
     def update(self, other: FileCoverage) -> None:
         r"""Merge FileCoverage information."""

--- a/gcovr/coverage.py
+++ b/gcovr/coverage.py
@@ -344,6 +344,7 @@ class FileCoverage:
         stat = CoverageStat.new_empty()
 
         for line in self.lines.values():
+            # FIXME: should only count if line.is_covered or line.is_uncovered
             stat += line.branch_coverage()
 
         return stat
@@ -352,6 +353,7 @@ class FileCoverage:
         stat = DecisionCoverageStat.new_empty()
 
         for line in self.lines.values():
+            # FIXME: should only count if line.is_covered or line.is_uncovered
             stat += line.decision_coverage()
 
         return stat

--- a/gcovr/coverage.py
+++ b/gcovr/coverage.py
@@ -75,20 +75,10 @@ class BranchCoverage:
 class DecisionCoverageUncheckable:
     r"""Represent coverage information about a decision."""
 
+    __slots__ = ()
+
     def __init__(self) -> None:
         pass
-
-    @property
-    def is_uncheckable(self) -> bool:
-        return True
-
-    @property
-    def is_conditional(self) -> bool:
-        return False
-
-    @property
-    def is_switch(self) -> bool:
-        return False
 
 
 class DecisionCoverageConditional:
@@ -111,18 +101,6 @@ class DecisionCoverageConditional:
         assert count_false >= 0
         self.count_false = count_false
 
-    @property
-    def is_uncheckable(self) -> bool:
-        return False
-
-    @property
-    def is_conditional(self) -> bool:
-        return True
-
-    @property
-    def is_switch(self) -> bool:
-        return False
-
 
 class DecisionCoverageSwitch:
     r"""Represent coverage information about a decision.
@@ -137,18 +115,6 @@ class DecisionCoverageSwitch:
     def __init__(self, count: int) -> None:
         assert count >= 0
         self.count = count
-
-    @property
-    def is_uncheckable(self) -> bool:
-        return False
-
-    @property
-    def is_conditional(self) -> bool:
-        return False
-
-    @property
-    def is_switch(self) -> bool:
-        return True
 
 
 DecisionCoverage = Union[

--- a/gcovr/coverage.py
+++ b/gcovr/coverage.py
@@ -127,10 +127,10 @@ DecisionCoverage = Union[
 class FunctionCoverage:
     __slots__ = "lineno", "count", "name"
 
-    def __init__(self, name: str, call_count: int = 0) -> None:
+    def __init__(self, name: str, *, lineno: int = 0, call_count: int = 0) -> None:
         assert call_count >= 0
         self.count = call_count
-        self.lineno = 0
+        self.lineno = lineno
         self.name = name
 
 
@@ -191,14 +191,6 @@ class LineCoverage:
     def has_uncovered_branch(self) -> bool:
         return not all(branch.is_covered for branch in self.branches.values())
 
-    def branch(self, branch_id: int) -> BranchCoverage:
-        r"""Get or create the BranchCoverage for that branch_id."""
-        try:
-            return self.branches[branch_id]
-        except KeyError:
-            self.branches[branch_id] = branch_cov = BranchCoverage(0)
-            return branch_cov
-
     def branch_coverage(self) -> CoverageStat:
         total = len(self.branches)
         covered = 0
@@ -239,24 +231,6 @@ class FileCoverage:
         self.filename = filename
         self.functions: Dict[str, FunctionCoverage] = {}
         self.lines: Dict[int, LineCoverage] = {}
-
-    def line(self, lineno: int, **defaults) -> LineCoverage:
-        r"""Get or create the LineCoverage for that lineno."""
-        try:
-            return self.lines[lineno]
-        except KeyError:
-            self.lines[lineno] = line_cov = LineCoverage(lineno, **defaults)
-            return line_cov
-
-    def function(self, function_name: str) -> FunctionCoverage:
-        r"""Get or create the FunctionCoverage for that function."""
-        try:
-            return self.functions[function_name]
-        except KeyError:
-            self.functions[function_name] = function_cov = FunctionCoverage(
-                function_name
-            )
-            return function_cov
 
     def function_coverage(self) -> CoverageStat:
         total = len(self.functions.values())

--- a/gcovr/coverage.py
+++ b/gcovr/coverage.py
@@ -420,19 +420,6 @@ class SummarizedStats:
             decision=filecov.decision_coverage(),
         )
 
-    @property
-    def to_global_stats(
-        self,
-    ) -> Tuple[
-        int, int, Optional[float], int, int, Optional[float], int, int, Optional[float]
-    ]:
-        """for migration only"""
-        return (
-            *self.line.to_tuple,
-            *self.function.to_tuple,
-            *self.branch.to_tuple,
-        )
-
     def __iadd__(self, other: SummarizedStats) -> SummarizedStats:
         self.line += other.line
         self.branch += other.branch
@@ -490,11 +477,6 @@ class CoverageStat:
         ratio = self.covered / self.total
         return min(99.9, round(ratio * 100.0, 1))
 
-    @property
-    def to_tuple(self) -> Tuple[int, int, Optional[float]]:
-        """for migration only: (total, covered, percent)"""
-        return self.total, self.covered, self.percent
-
     def __iadd__(self, other: CoverageStat) -> CoverageStat:
         self.covered += other.covered
         self.total += other.total
@@ -524,27 +506,8 @@ class DecisionCoverageStat:
     def percent_or(self, default: _T) -> Union[float, _T]:
         return self.to_coverage_stat.percent_or(default)
 
-    @property
-    def to_tuple(self) -> Tuple[int, int, int, Optional[float]]:
-        """for migration only: (total, covered, uncheckable, percent)"""
-        return self.total, self.covered, self.uncheckable, self.percent
-
     def __iadd__(self, other: DecisionCoverageStat) -> DecisionCoverageStat:
         self.covered += other.covered
         self.uncheckable += other.uncheckable
         self.total += other.total
         return self
-
-
-def get_global_stats(covdata: CovData):
-    """Get global statistics"""
-
-    return SummarizedStats.from_covdata(covdata).to_global_stats
-
-
-def calculate_coverage(
-    covered: int,
-    total: int,
-    nan_value: _T = 0.0,
-) -> Union[float, _T]:
-    return CoverageStat(covered=covered, total=total).percent_or(nan_value)

--- a/gcovr/gcov.py
+++ b/gcovr/gcov.py
@@ -29,10 +29,9 @@ from typing import Optional
 
 from .utils import search_file, commonpath
 from .workers import locked_directory
-from .coverage import FileCoverage
 from .gcov_parser import parse_metadata, parse_coverage, ParserFlags
 from .coverage import CovData
-from .merging import merge_file
+from .merging import insert_file_coverage
 
 logger = logging.getLogger("gcovr")
 
@@ -163,7 +162,7 @@ def process_gcov_data(
         exclude_pattern_prefix=options.exclude_pattern_prefix,
         flags=parser_flags,
     )
-    covdata[key] = merge_file(covdata.get(key, FileCoverage(key)), coverage)
+    insert_file_coverage(covdata, coverage)
 
 
 def guess_source_file_name(

--- a/gcovr/gcov_parser.py
+++ b/gcovr/gcov_parser.py
@@ -383,7 +383,7 @@ def parse_coverage(
         _add_coverage_for_function(coverage, state.lineno + 1, function, context)
 
     if flags & ParserFlags.PARSE_DECISIONS:
-        decision_parser = DecisionParser(filename, coverage, src_lines)
+        decision_parser = DecisionParser(coverage, src_lines)
         decision_parser.parse_all_lines()
 
     _report_lines_with_errors(lines_with_errors, context)

--- a/gcovr/merging.py
+++ b/gcovr/merging.py
@@ -36,8 +36,18 @@ must behave somewhat like an addition operator:
   so that ``merge(a, empty)`` and ``merge(emtpy, a)`` and ``a`` all match.
   However, the empty state might be implied by “parent dict does not contain an entry”,
   or must contain matching information like the same line number.
+
+The insertion functions insert a single coverage item into a larger structure,
+for example inserting BranchCoverage into a LineCoverage object.
+The target/parent structure is updated in-place,
+otherwise this has equivalent semantics to merging.
+In particular, if there already is coverage data in the target with the same ID,
+then the contents are merged.
+The insertion functions return the coverage structure that is saved in the target,
+which may not be the same as the input value.
 """
 
+from dataclasses import dataclass
 from typing import Callable, Optional, TypeVar, Dict
 from .coverage import (
     BranchCoverage,
@@ -52,6 +62,14 @@ from .coverage import (
 )
 
 
+@dataclass
+class MergeOptions:
+    ignore_function_lineno: bool = False
+
+
+DEFAULT_MERGE_OPTIONS = MergeOptions()
+
+
 _Key = TypeVar("_Key", int, str)
 _T = TypeVar("_T")
 
@@ -59,13 +77,16 @@ _T = TypeVar("_T")
 def _merge_dict(
     left: Dict[_Key, _T],
     right: Dict[_Key, _T],
-    merge_item: Callable[[_T, _T], _T],
+    merge_item: Callable[[_T, _T, MergeOptions], _T],
+    options: MergeOptions,
 ) -> Dict[_Key, _T]:
     """
     Helper function to merge items in a dictionary.
 
     Example:
-    >>> _merge_dict(dict(a=2, b=3), dict(b=1, c=5), lambda a, b: a + b)
+    >>> _merge_dict(dict(a=2, b=3), dict(b=1, c=5),
+    ...             lambda a, b, _: a + b,
+    ...             DEFAULT_MERGE_OPTIONS)
     {'a': 2, 'b': 4, 'c': 5}
     """
     # Ensure that "left" is the larger dict,
@@ -74,10 +95,7 @@ def _merge_dict(
         left, right = right, left
 
     for key, right_item in right.items():
-        if key in left:
-            left[key] = merge_item(left[key], right_item)
-        else:
-            left[key] = right_item
+        _insert_coverage_item(left, key, right_item, merge_item, options)
 
     # At this point, "left" contains all merged items.
     # The caller should access neither the "left" nor "right" objects.
@@ -88,16 +106,63 @@ def _merge_dict(
     return left
 
 
-def merge_covdata(left: CovData, right: CovData) -> CovData:
+def _insert_coverage_item(
+    target_dict: Dict[_Key, _T],
+    key: _Key,
+    new_item: _T,
+    merge_item: Callable[[_T, _T, MergeOptions], _T],
+    options: MergeOptions,
+) -> _T:
+    """
+    Insert a single item into a coverage dictionary.
+
+    That means::
+
+        merge(left, { key: item })
+
+    and::
+
+        insert_coverage_item(left, key, item, ...)
+
+    should be equivalent with respect to their side effects.
+
+    However, the target dict is updated in place,
+    and the return value differs!
+    """
+
+    if key in target_dict:
+        merged_item = merge_item(target_dict[key], new_item, options)
+    else:
+        merged_item = new_item
+    target_dict[key] = merged_item
+    return merged_item
+
+
+def merge_covdata(
+    left: CovData, right: CovData, options: MergeOptions = DEFAULT_MERGE_OPTIONS
+) -> CovData:
     """
     Merge CovData information.
 
     Do not use 'left' or 'right' objects afterwards!
     """
-    return _merge_dict(left, right, merge_file)
+    return _merge_dict(left, right, merge_file, options)
 
 
-def merge_file(left: FileCoverage, right: FileCoverage) -> FileCoverage:
+def insert_file_coverage(
+    target: CovData,
+    file: FileCoverage,
+    options: MergeOptions = DEFAULT_MERGE_OPTIONS,
+) -> FileCoverage:
+    """Insert FileCoverage into CovData."""
+    return _insert_coverage_item(target, file.filename, file, merge_file, options)
+
+
+def merge_file(
+    left: FileCoverage,
+    right: FileCoverage,
+    options: MergeOptions = DEFAULT_MERGE_OPTIONS,
+) -> FileCoverage:
     """
     Merge FileCoverage information.
 
@@ -108,13 +173,49 @@ def merge_file(left: FileCoverage, right: FileCoverage) -> FileCoverage:
 
     assert left.filename == right.filename
 
-    left.lines = _merge_dict(left.lines, right.lines, merge_line)
-    left.functions = _merge_dict(left.functions, right.functions, merge_function)
+    left.lines = _merge_dict(left.lines, right.lines, merge_line, options)
+    left.functions = _merge_dict(
+        left.functions, right.functions, merge_function, options
+    )
 
     return left
 
 
-def merge_line(left: LineCoverage, right: LineCoverage) -> LineCoverage:
+def insert_line_coverage(
+    target: FileCoverage,
+    line: LineCoverage,
+    options: MergeOptions = DEFAULT_MERGE_OPTIONS,
+) -> LineCoverage:
+    """Insert LineCoverage into FileCoverage."""
+    return _insert_coverage_item(target.lines, line.lineno, line, merge_line, options)
+
+
+# FIXME: use of this function is almost always a bug
+def get_or_create_line_coverage(target: FileCoverage, lineno: int) -> LineCoverage:
+    """Get the LineCoverage object for that line, or insert a new one if necessary.
+
+    Use of this function is almost always a bug,
+    but it's needed for migration.
+
+    The function is almost equivalent to::
+
+        insert_line_coverage(target, LineCoverage(lineno))
+
+    except that this function is guaranteed to not affect the ``noncode`` status
+    if any is present.
+    """
+    try:
+        return target.lines[lineno]
+    except KeyError:
+        target.lines[lineno] = new_line = LineCoverage(lineno)
+        return new_line
+
+
+def merge_line(
+    left: LineCoverage,
+    right: LineCoverage,
+    options: MergeOptions = DEFAULT_MERGE_OPTIONS,
+) -> LineCoverage:
     """
     Merge LineCoverage information.
 
@@ -125,31 +226,71 @@ def merge_line(left: LineCoverage, right: LineCoverage) -> LineCoverage:
     assert left.lineno == right.lineno
 
     left.count += right.count
+    # FIXME LineCoverage(lineno) is not the neutral element
+    # because the default is "noncode=False", which can flip the other argument to "&"
     left.noncode &= right.noncode
     left.excluded |= right.excluded
-    left.branches = _merge_dict(left.branches, right.branches, merge_branch)
-    left.decision = merge_decision(left.decision, right.decision)
+    left.branches = _merge_dict(left.branches, right.branches, merge_branch, options)
+    left.decision = merge_decision(left.decision, right.decision, options)
 
     return left
 
 
-def merge_function(left: FunctionCoverage, right: FunctionCoverage) -> FunctionCoverage:
+def insert_function_coverage(
+    target: FileCoverage,
+    function: FunctionCoverage,
+    options: MergeOptions = DEFAULT_MERGE_OPTIONS,
+) -> FunctionCoverage:
+    """Insert FunctionCoverage into FileCoverage"""
+    return _insert_coverage_item(
+        target.functions, function.name, function, merge_function, options
+    )
+
+
+def merge_function(
+    left: FunctionCoverage,
+    right: FunctionCoverage,
+    options: MergeOptions = DEFAULT_MERGE_OPTIONS,
+) -> FunctionCoverage:
     """
     Merge FunctionCoverage information.
 
     Do not use 'left' or 'right' objects afterwards!
 
     Precondition: both objects must have same name and lineno.
+
+    If ``options.ignore_function_lineno`` is set,
+    the two function coverage objects can have differing line numbers.
     """
     assert left.name == right.name
-    assert left.lineno == right.lineno
+    if not options.ignore_function_lineno:
+        assert left.lineno == right.lineno
 
     left.count += right.count
+
+    if options.ignore_function_lineno:
+        left.lineno = max(left.lineno, right.lineno)
 
     return left
 
 
-def merge_branch(left: BranchCoverage, right: BranchCoverage) -> BranchCoverage:
+def insert_branch_coverage(
+    target: LineCoverage,
+    branch_id: int,
+    branch: BranchCoverage,
+    options: MergeOptions = DEFAULT_MERGE_OPTIONS,
+) -> BranchCoverage:
+    """Insert BranchCoverage into LineCoverage."""
+    return _insert_coverage_item(
+        target.branches, branch_id, branch, merge_branch, options
+    )
+
+
+def merge_branch(
+    left: BranchCoverage,
+    right: BranchCoverage,
+    options: MergeOptions = DEFAULT_MERGE_OPTIONS,
+) -> BranchCoverage:
     """
     Merge BranchCoverage information.
 
@@ -163,8 +304,20 @@ def merge_branch(left: BranchCoverage, right: BranchCoverage) -> BranchCoverage:
     return left
 
 
+def insert_decision_coverage(
+    target: LineCoverage,
+    decision: Optional[DecisionCoverage],
+    options: MergeOptions = DEFAULT_MERGE_OPTIONS,
+) -> Optional[DecisionCoverage]:
+    """Insert DecisionCoverage into LineCoverage."""
+    target.decision = merge_decision(target.decision, decision)
+    return target.decision
+
+
 def merge_decision(
-    left: Optional[DecisionCoverage], right: Optional[DecisionCoverage]
+    left: Optional[DecisionCoverage],
+    right: Optional[DecisionCoverage],
+    options: MergeOptions = DEFAULT_MERGE_OPTIONS,
 ) -> Optional[DecisionCoverage]:
     """
     Merge DecisionCoverage information.

--- a/gcovr/merging.py
+++ b/gcovr/merging.py
@@ -1,0 +1,202 @@
+# -*- coding:utf-8 -*-
+
+#  ************************** Copyrights and license ***************************
+#
+# This file is part of gcovr 5.1, a parsing and reporting tool for gcov.
+# https://gcovr.com/en/stable
+#
+# _____________________________________________________________________________
+#
+# Copyright (c) 2013-2022 the gcovr authors
+# Copyright (c) 2013 Sandia Corporation.
+# This software is distributed under the BSD License.
+# Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+# the U.S. Government retains certain rights in this software.
+# For more information, see the README.rst file.
+#
+# ****************************************************************************
+
+"""
+Merge coverage data.
+
+All of these merging function have the signature
+``merge(T, T) -> T``.
+That is, they take two coverage data items and combine them,
+returning the combined coverage.
+This may change the input objects, so that they should be used afterwards.
+
+In a mathematical sense, all of these ``merge()`` functions
+must behave somewhat like an addition operator:
+
+* commutative: order of arguments must not matter,
+  so that ``merge(a, b)`` must match ``merge(a, b)``.
+* associative: order of merging must not matter,
+  so that ``merge(a, merge(b, c))`` must match ``merge(merge(a, b), c)``.
+* identity element: there must be an empty element,
+  so that ``merge(a, empty)`` and ``merge(emtpy, a)`` and ``a`` all match.
+  However, the empty state might be implied by “parent dict does not contain an entry”,
+  or must contain matching information like the same line number.
+"""
+
+from typing import Callable, Optional, TypeVar, Dict
+from .coverage import (
+    BranchCoverage,
+    CovData,
+    DecisionCoverage,
+    DecisionCoverageConditional,
+    DecisionCoverageSwitch,
+    DecisionCoverageUncheckable,
+    FileCoverage,
+    FunctionCoverage,
+    LineCoverage,
+)
+
+
+_Key = TypeVar("_Key", int, str)
+_T = TypeVar("_T")
+
+
+def _merge_dict(
+    left: Dict[_Key, _T],
+    right: Dict[_Key, _T],
+    merge_item: Callable[[_T, _T], _T],
+) -> Dict[_Key, _T]:
+    """
+    Helper function to merge items in a dictionary.
+
+    Example:
+    >>> _merge_dict(dict(a=2, b=3), dict(b=1, c=5), lambda a, b: a + b)
+    {'a': 2, 'b': 4, 'c': 5}
+    """
+    # ensure that "left" is the larger dict
+    if len(left) < len(right):
+        left, right = right, left
+
+    for key, right_item in right.items():
+        if key in left:
+            left[key] = merge_item(left[key], right_item)
+        else:
+            left[key] = right_item
+    return left
+
+
+def merge_covdata(left: CovData, right: CovData) -> CovData:
+    """
+    Merge CovData information.
+
+    Do not use 'left' or 'right' objects afterwards!
+    """
+    return _merge_dict(left, right, merge_file)
+
+
+def merge_file(left: FileCoverage, right: FileCoverage) -> FileCoverage:
+    """
+    Merge FileCoverage information.
+
+    Do not use 'left' or 'right' objects afterwards!
+
+    Precondition: both objects have same filename.
+    """
+
+    assert left.filename == right.filename
+
+    left.lines = _merge_dict(left.lines, right.lines, merge_line)
+    left.functions = _merge_dict(left.functions, right.functions, merge_function)
+
+    return left
+
+
+def merge_line(left: LineCoverage, right: LineCoverage) -> LineCoverage:
+    """
+    Merge LineCoverage information.
+
+    Do not use 'left' or 'right' objects afterwards!
+
+    Precondition: both objects must have same lineno.
+    """
+    assert left.lineno == right.lineno
+
+    left.count += right.count
+    left.noncode &= right.noncode
+    left.excluded |= right.excluded
+    left.branches = _merge_dict(left.branches, right.branches, merge_branch)
+    left.decision = merge_decision(left.decision, right.decision)
+
+    return left
+
+
+def merge_function(left: FunctionCoverage, right: FunctionCoverage) -> FunctionCoverage:
+    """
+    Merge FunctionCoverage information.
+
+    Do not use 'left' or 'right' objects afterwards!
+
+    Precondition: both objects must have same name and lineno.
+    """
+    assert left.name == right.name
+    assert left.lineno == right.lineno
+
+    left.count += right.count
+
+    return left
+
+
+def merge_branch(left: BranchCoverage, right: BranchCoverage) -> BranchCoverage:
+    """
+    Merge BranchCoverage information.
+
+    Do not use 'left' or 'right' objects afterwards!
+    """
+
+    left.count += right.count
+    left.fallthrough = left.fallthrough or right.fallthrough
+    left.throw = left.throw or right.throw
+
+    return left
+
+
+def merge_decision(
+    left: Optional[DecisionCoverage], right: Optional[DecisionCoverage]
+) -> Optional[DecisionCoverage]:
+    """
+    Merge DecisionCoverage information.
+
+    Do not use 'left' or 'right' objects afterwards!
+
+    The DecisionCoverage has different states:
+
+    - None (no known decision)
+    - Uncheckable (there was a decision, but it can't be analyzed properly)
+    - Conditional
+    - Switch
+
+    If there is a conflict between different types, Uncheckable will be returned.
+    """
+
+    # If decision coverage is not know for one side, return the other.
+    if left is None:
+        return right
+    if right is None:
+        return left
+
+    # If any decision is Uncheckable, the result is Uncheckable.
+    if isinstance(left, DecisionCoverageUncheckable):
+        return left
+    if isinstance(right, DecisionCoverageUncheckable):
+        return right
+
+    # Merge Conditional decisions.
+    Conditional = DecisionCoverageConditional
+    if isinstance(left, Conditional) and isinstance(right, Conditional):
+        left.count_true += right.count_true
+        left.count_false += right.count_false
+        return left
+
+    # Merge Switch decisions.
+    Switch = DecisionCoverageSwitch
+    if isinstance(left, Switch) and isinstance(right, Switch):
+        left.count += right.count
+        return left
+
+    # If the decisions have conflicting types, the result is Uncheckable.
+    return DecisionCoverageUncheckable()

--- a/gcovr/tests/test_gcov_parser.py
+++ b/gcovr/tests/test_gcov_parser.py
@@ -275,17 +275,17 @@ GCOV_8_SOURCES = dict(
 )
 
 GCOV_8_EXPECTED_UNCOVERED_LINES = dict(
-    gcov_8_example="33",
-    gcov_8_exclude_throw="33",
-    nautilus_example="51-52,54",
-    gcov_8_example_2="33",
+    gcov_8_example=[33],
+    gcov_8_exclude_throw=[33],
+    nautilus_example=[51, 52, 54],
+    gcov_8_example_2=[33],
 )
 
 GCOV_8_EXPECTED_UNCOVERED_BRANCHES = dict(
-    gcov_8_example="21,23,24,30,32,33,35",
-    gcov_8_exclude_throw="30,32,33",
-    nautilus_example="51",
-    gcov_8_example_2="21,23,24,30,32,33,35",
+    gcov_8_example=[21, 23, 24, 30, 32, 33, 35],
+    gcov_8_exclude_throw=[30, 32, 33],
+    nautilus_example=[51],
+    gcov_8_example_2=[21, 23, 24, 30, 32, 33, 35],
 )
 
 GCOV_8_EXCLUDE_THROW_BRANCHES = dict(
@@ -320,8 +320,12 @@ def test_gcov_8(capsys, sourcename):
         flags=flags,
     )
 
-    uncovered_lines = coverage.uncovered_lines_str()
-    uncovered_branches = coverage.uncovered_branches_str()
+    uncovered_lines = [
+        line.lineno for line in coverage.lines.values() if line.is_uncovered
+    ]
+    uncovered_branches = [
+        line.lineno for line in coverage.lines.values() if line.has_uncovered_branch
+    ]
     assert uncovered_lines == expected_uncovered_lines
     assert uncovered_branches == expected_uncovered_branches
 
@@ -355,10 +359,14 @@ def test_unknown_tags(caplog, ignore_errors):
     if ignore_errors:
         coverage = run_the_parser()
 
-        uncovered_lines = coverage.uncovered_lines_str()
-        uncovered_branches = coverage.uncovered_branches_str()
-        assert uncovered_lines == ""
-        assert uncovered_branches == ""
+        uncovered_lines = [
+            line.lineno for line in coverage.lines.values() if line.is_uncovered
+        ]
+        uncovered_branches = [
+            line.lineno for line in coverage.lines.values() if line.has_uncovered_branch
+        ]
+        assert uncovered_lines == []
+        assert uncovered_branches == []
     else:
         with pytest.raises(Exception):
             coverage = run_the_parser()

--- a/gcovr/utils.py
+++ b/gcovr/utils.py
@@ -26,7 +26,7 @@ import re
 import sys
 from contextlib import contextmanager
 
-from .coverage import CovData, CoverageStat, SummarizedStats, FileCoverage
+from .coverage import CovData, CoverageStat
 
 logger = logging.getLogger("gcovr")
 
@@ -150,18 +150,6 @@ def commonpath(files):
     if prefix_path:
         prefix_path = os.path.join(os.path.relpath(prefix_path), "")
     return prefix_path
-
-
-def summarize_file_coverage(coverage: FileCoverage, root_filter):
-    filename = presentable_filename(coverage.filename, root_filter=root_filter)
-
-    stats = SummarizedStats.from_file(coverage)
-    return (
-        filename,
-        *stats.line.to_tuple,
-        *stats.branch.to_tuple,
-        *stats.function.to_tuple,
-    )
 
 
 class FilterOption:

--- a/gcovr/utils.py
+++ b/gcovr/utils.py
@@ -442,8 +442,7 @@ def open_binary_for_writing(filename=None, default_filename=None, **kwargs):
             fh.close()
 
 
-def presentable_filename(filename, root_filter):
-    # type: (str, re.Regex) -> str
+def presentable_filename(filename: str, root_filter: re.Pattern) -> str:
     """mangle a filename so that it is suitable for a report"""
 
     normalized = root_filter.sub("", filename)

--- a/gcovr/writer/cobertura.py
+++ b/gcovr/writer/cobertura.py
@@ -21,9 +21,10 @@ from lxml import etree
 
 from ..version import __version__
 from ..utils import open_binary_for_writing, presentable_filename
+from ..coverage import CovData
 
 
-def print_cobertura_report(covdata, output_file, options):
+def print_cobertura_report(covdata: CovData, output_file, options):
     """produce an XML report in the Cobertura format"""
     functionTotal = 0
     functionCovered = 0

--- a/gcovr/writer/cobertura.py
+++ b/gcovr/writer/cobertura.py
@@ -101,7 +101,7 @@ def print_cobertura_report(covdata: CovData, output_file, options):
         c.set("branch-rate", _rate(class_branch))
         c.set("complexity", "0.0")
 
-        package.classess_xml[className] = c
+        package.classes_xml[className] = c
         package.line += stats.line
         package.branch += class_branch
         package.function = stats.function  # FIXME this must use "+=" operator
@@ -111,8 +111,8 @@ def print_cobertura_report(covdata: CovData, output_file, options):
         package = etree.Element("package")
         packageXml.append(package)
         classes = etree.SubElement(package, "classes")
-        for className in sorted(packageData.classess_xml):
-            classes.append(packageData.classess_xml[className])
+        for className in sorted(packageData.classes_xml):
+            classes.append(packageData.classes_xml[className])
         package.set("name", packageName.replace("/", "."))
         package.set("line-rate", _rate(packageData.line))
         package.set("function-rate", _rate(packageData.function))
@@ -136,7 +136,7 @@ def print_cobertura_report(covdata: CovData, output_file, options):
 
 @dataclass
 class PackageData:
-    classess_xml: Dict[str, etree.Element]
+    classes_xml: Dict[str, etree.Element]
     line: CoverageStat
     branch: CoverageStat
     function: CoverageStat

--- a/gcovr/writer/cobertura.py
+++ b/gcovr/writer/cobertura.py
@@ -34,17 +34,17 @@ def print_cobertura_report(covdata: CovData, output_file, options):
     lineCovered = 0
 
     for key in covdata.keys():
-        (total, covered, _) = covdata[key].function_coverage()
+        (total, covered, _) = covdata[key].function_coverage().to_tuple
         functionTotal += total
         functionCovered += covered
 
     for key in covdata.keys():
-        (total, covered, _) = covdata[key].branch_coverage()
+        (total, covered, _) = covdata[key].branch_coverage().to_tuple
         branchTotal += total
         branchCovered += covered
 
     for key in covdata.keys():
-        (total, covered, _) = covdata[key].line_coverage()
+        (total, covered, _) = covdata[key].line_coverage().to_tuple
         lineTotal += total
         lineCovered += covered
 
@@ -118,7 +118,8 @@ def print_cobertura_report(covdata: CovData, output_file, options):
             if not branches:
                 L.set("branch", "false")
             else:
-                b_total, b_hits, coverage = line_cov.branch_coverage()
+                b_total, b_hits, coverage = line_cov.branch_coverage().to_tuple
+                assert coverage is not None  # we know this because len(branches) > 0
                 L.set("branch", "true")
                 L.set("condition-coverage", f"{int(coverage)}% ({b_hits}/{b_total})")
                 cond = etree.Element("condition")
@@ -126,7 +127,7 @@ def print_cobertura_report(covdata: CovData, output_file, options):
                 cond.set("type", "jump")
                 cond.set("coverage", f"{int(coverage)}%")
                 class_branch_hits += b_hits
-                class_branches += float(len(branches))
+                class_branches += len(branches)
                 conditions = etree.Element("conditions")
                 conditions.append(cond)
                 L.append(conditions)

--- a/gcovr/writer/coveralls.py
+++ b/gcovr/writer/coveralls.py
@@ -26,9 +26,10 @@ import os
 import re
 import shutil
 import subprocess
-
 from hashlib import md5
+
 from ..utils import presentable_filename, open_text_for_writing
+from ..coverage import CovData
 
 PRETTY_JSON_INDENT = 4
 
@@ -51,7 +52,7 @@ def _write_coveralls_result(gcovr_json_dict, output_file, pretty):
         write_json(gcovr_json_dict, fh)
 
 
-def print_coveralls_report(covdata, output_file, options):
+def print_coveralls_report(covdata: CovData, output_file, options):
     """
     Outputs a JSON report in the Coveralls API coverage format
 

--- a/gcovr/writer/csv.py
+++ b/gcovr/writer/csv.py
@@ -20,9 +20,10 @@
 import csv
 
 from ..utils import sort_coverage, summarize_file_coverage, open_text_for_writing
+from ..coverage import CovData
 
 
-def print_csv_report(covdata, output_file, options):
+def print_csv_report(covdata: CovData, output_file, options):
     """produce gcovr csv report"""
 
     with open_text_for_writing(output_file, "coverage.csv") as fh:

--- a/gcovr/writer/csv.py
+++ b/gcovr/writer/csv.py
@@ -18,9 +18,10 @@
 # ****************************************************************************
 
 import csv
+from typing import Tuple, Optional
 
-from ..utils import sort_coverage, summarize_file_coverage, open_text_for_writing
-from ..coverage import CovData
+from ..utils import sort_coverage, presentable_filename, open_text_for_writing
+from ..coverage import CovData, CoverageStat, SummarizedStats
 
 
 def print_csv_report(covdata: CovData, output_file, options):
@@ -50,37 +51,21 @@ def print_csv_report(covdata: CovData, output_file, options):
             )
         )
         for key in keys:
-            (
-                filename,
-                line_total,
-                line_covered,
-                line_percent,
-                branch_total,
-                branch_covered,
-                branch_percent,
-                function_total,
-                function_covered,
-                function_percent,
-            ) = summarize_file_coverage(covdata[key], options.root_filter)
-            line_percent = fixup_percent(line_percent)
-            branch_percent = fixup_percent(branch_percent)
-            function_percent = fixup_percent(function_percent)
+            filename = presentable_filename(covdata[key].filename, options.root_filter)
+            stats = SummarizedStats.from_file(covdata[key])
             writer.writerow(
                 [
                     filename,
-                    line_total,
-                    line_covered,
-                    line_percent,
-                    branch_total,
-                    branch_covered,
-                    branch_percent,
-                    function_total,
-                    function_covered,
-                    function_percent,
+                    *_stat_tuple(stats.line),
+                    *_stat_tuple(stats.branch),
+                    *_stat_tuple(stats.function),
                 ]
             )
 
 
-def fixup_percent(percent):
-    # output csv percent values in range [0,1.0]
-    return percent / 100 if percent is not None else None
+def _stat_tuple(stat: CoverageStat) -> Tuple[int, int, Optional[float]]:
+    """creates tuple (total, covered, ratio) with ratio in range 0..1 incl"""
+    percent = stat.percent
+    if percent is not None:
+        percent = percent / 100.0
+    return stat.total, stat.covered, percent

--- a/gcovr/writer/html.py
+++ b/gcovr/writer/html.py
@@ -235,11 +235,11 @@ class RootInfo:
     def get_directory(self):
         return "." if self.directory == "" else self.directory.replace("\\", "/")
 
-    def calculate_branch_coverage(self, covdata):
+    def calculate_branch_coverage(self, covdata: CovData):
         branch_total = 0
         branch_covered = 0
         for key in covdata.keys():
-            (total, covered, _percent) = covdata[key].branch_coverage()
+            (total, covered, _percent) = covdata[key].branch_coverage().to_tuple
             branch_total += total
             branch_covered += covered
         self.branches["exec"] = branch_covered
@@ -248,12 +248,14 @@ class RootInfo:
         self.branches["coverage"] = "-" if coverage is None else coverage
         self.branches["class"] = self._coverage_to_class(coverage)
 
-    def calculate_decision_coverage(self, covdata):
+    def calculate_decision_coverage(self, covdata: CovData):
         decision_total = 0
         decision_covered = 0
         decision_unchecked = 0
         for key in covdata.keys():
-            (total, covered, unchecked, _percent) = covdata[key].decision_coverage()
+            (total, covered, unchecked, _percent) = (
+                covdata[key].decision_coverage().to_tuple
+            )
             decision_total += total
             decision_covered += covered
             decision_unchecked += unchecked
@@ -264,11 +266,11 @@ class RootInfo:
         self.decisions["coverage"] = "-" if coverage is None else coverage
         self.decisions["class"] = self._coverage_to_class(coverage)
 
-    def calculate_function_coverage(self, covdata):
+    def calculate_function_coverage(self, covdata: CovData):
         function_total = 0
         function_covered = 0
         for key in covdata.keys():
-            (total, covered, _percent) = covdata[key].function_coverage()
+            (total, covered, _percent) = covdata[key].function_coverage().to_tuple
             function_total += total
             function_covered += covered
         self.functions["exec"] = function_covered
@@ -277,11 +279,11 @@ class RootInfo:
         self.functions["coverage"] = "-" if coverage is None else coverage
         self.functions["class"] = self._coverage_to_class(coverage)
 
-    def calculate_line_coverage(self, covdata):
+    def calculate_line_coverage(self, covdata: CovData):
         line_total = 0
         line_covered = 0
         for key in covdata.keys():
-            (total, covered, _percent) = covdata[key].line_coverage()
+            (total, covered, _percent) = covdata[key].line_coverage().to_tuple
             line_total += total
             line_covered += covered
         self.lines["exec"] = line_covered
@@ -291,15 +293,15 @@ class RootInfo:
         self.lines["class"] = self._coverage_to_class(coverage)
 
     def add_file(self, cdata, link_report, cdata_fname):
-        lines_total, lines_exec, _ = cdata.line_coverage()
-        branches_total, branches_exec, _ = cdata.branch_coverage()
+        lines_total, lines_exec, _ = cdata.line_coverage().to_tuple
+        branches_total, branches_exec, _ = cdata.branch_coverage().to_tuple
         (
             decisions_total,
             decisions_exec,
             decisions_unchecked,
             _,
-        ) = cdata.decision_coverage()
-        functions_total, functions_exec, _ = cdata.function_coverage()
+        ) = cdata.decision_coverage().to_tuple
+        functions_total, functions_exec, _ = cdata.function_coverage().to_tuple
 
         line_coverage = calculate_coverage(lines_exec, lines_total, nan_value=100.0)
         branch_coverage = calculate_coverage(
@@ -506,7 +508,7 @@ def print_html_report(covdata: CovData, output_file, options):
             functions["total"],
             functions["exec"],
             functions["coverage"],
-        ) = cdata.function_coverage()
+        ) = cdata.function_coverage().to_tuple
         functions["class"] = coverage_to_class(
             functions["coverage"], medium_threshold, high_threshold
         )
@@ -520,7 +522,7 @@ def print_html_report(covdata: CovData, output_file, options):
             branches["total"],
             branches["exec"],
             branches["coverage"],
-        ) = cdata.branch_coverage()
+        ) = cdata.branch_coverage().to_tuple
         branches["class"] = coverage_to_class(
             branches["coverage"], medium_threshold, high_threshold
         )
@@ -535,7 +537,7 @@ def print_html_report(covdata: CovData, output_file, options):
             decisions["exec"],
             decisions["unchecked"],
             decisions["coverage"],
-        ) = cdata.decision_coverage()
+        ) = cdata.decision_coverage().to_tuple
         decisions["class"] = coverage_to_class(
             decisions["coverage"], medium_threshold, high_threshold
         )
@@ -545,7 +547,11 @@ def print_html_report(covdata: CovData, output_file, options):
 
         lines = dict()
         data["lines"] = lines
-        lines["total"], lines["exec"], lines["coverage"] = cdata.line_coverage()
+        (
+            lines["total"],
+            lines["exec"],
+            lines["coverage"],
+        ) = cdata.line_coverage().to_tuple
         lines["class"] = coverage_to_class(
             lines["coverage"], medium_threshold, high_threshold
         )

--- a/gcovr/writer/html.py
+++ b/gcovr/writer/html.py
@@ -28,9 +28,9 @@ from ..utils import (
     realpath,
     commonpath,
     sort_coverage,
-    calculate_coverage,
     open_text_for_writing,
 )
+from ..coverage import CovData, calculate_coverage
 
 logger = logging.getLogger("gcovr")
 
@@ -369,7 +369,7 @@ class RootInfo:
 #
 # Produce an HTML report
 #
-def print_html_report(covdata, output_file, options):
+def print_html_report(covdata: CovData, output_file, options):
     css_data = CssRenderer.render(options)
     medium_threshold = options.html_medium_threshold
     high_threshold = options.html_high_threshold

--- a/gcovr/writer/json.py
+++ b/gcovr/writer/json.py
@@ -31,6 +31,7 @@ from ..utils import (
 )
 from ..coverage import (
     CovData,
+    DecisionCoverage,
     DecisionCoverageConditional,
     DecisionCoverageSwitch,
     DecisionCoverageUncheckable,
@@ -227,19 +228,19 @@ def _json_from_branch(branch):
     return json_branch
 
 
-def _json_from_decision(decision):
+def _json_from_decision(decision: DecisionCoverage) -> dict:
     json_decision = {}
-    if decision.is_uncheckable:
+    if isinstance(decision, DecisionCoverageUncheckable):
         json_decision["type"] = "uncheckable"
-    elif decision.is_conditional:
+    elif isinstance(decision, DecisionCoverageConditional):
         json_decision["type"] = "conditional"
         json_decision["count_true"] = decision.count_true
         json_decision["count_false"] = decision.count_false
-    elif decision.is_switch:
+    elif isinstance(decision, DecisionCoverageSwitch):
         json_decision["type"] = "switch"
         json_decision["count"] = decision.count
     else:
-        RuntimeError("Unknown decision type")
+        raise RuntimeError("Unknown decision type: {decision!r}")
 
     return json_decision
 

--- a/gcovr/writer/json.py
+++ b/gcovr/writer/json.py
@@ -21,21 +21,21 @@ import json
 import logging
 import os
 import functools
-from ..gcov import apply_filter_include_exclude
 
+from ..gcov import apply_filter_include_exclude
 from ..utils import (
-    get_global_stats,
     presentable_filename,
     sort_coverage,
     summarize_file_coverage,
     open_text_for_writing,
 )
-
 from ..coverage import (
     DecisionCoverageUncheckable,
     DecisionCoverageConditional,
     DecisionCoverageSwitch,
     FileCoverage,
+    CovData,
+    get_global_stats,
 )
 
 logger = logging.getLogger("gcovr")
@@ -67,7 +67,7 @@ def _write_json_result(gcovr_json_dict, output_file, default_filename, pretty):
 #
 # Produce gcovr JSON report
 #
-def print_json_report(covdata, output_file, options):
+def print_json_report(covdata: CovData, output_file, options):
     r"""produce an JSON report in the format partially
     compatible with gcov JSON output"""
 

--- a/gcovr/writer/sonarqube.py
+++ b/gcovr/writer/sonarqube.py
@@ -20,9 +20,10 @@
 from lxml import etree
 
 from ..utils import open_binary_for_writing, presentable_filename
+from ..coverage import CovData
 
 
-def print_sonarqube_report(covdata, output_file, options):
+def print_sonarqube_report(covdata: CovData, output_file, options):
     """produce an XML report in the Sonarqube generic coverage format"""
 
     root = etree.Element("coverage")

--- a/gcovr/writer/sonarqube.py
+++ b/gcovr/writer/sonarqube.py
@@ -50,9 +50,9 @@ def print_sonarqube_report(covdata: CovData, output_file, options):
 
             branches = line_cov.branches
             if branches:
-                b_total, b_hits, coverage = line_cov.branch_coverage()
-                L.set("branchesToCover", str(b_total))
-                L.set("coveredBranches", str(b_hits))
+                b = line_cov.branch_coverage()
+                L.set("branchesToCover", str(b.total))
+                L.set("coveredBranches", str(b.covered))
 
             fileNode.append(L)
 

--- a/gcovr/writer/summary.py
+++ b/gcovr/writer/summary.py
@@ -19,7 +19,7 @@
 
 import sys
 
-from ..coverage import CovData, get_global_stats
+from ..coverage import CovData, CoverageStat, SummarizedStats
 
 
 def print_summary(covdata: CovData):
@@ -27,30 +27,15 @@ def print_summary(covdata: CovData):
     Output the percentage, covered and total lines and branches.
     """
 
-    (
-        lines_total,
-        lines_covered,
-        percent,
-        functions_total,
-        functions_covered,
-        percent_functions,
-        branches_total,
-        branches_covered,
-        percent_branches,
-    ) = get_global_stats(covdata)
+    def print_stat(name: str, stat: CoverageStat):
+        percent = stat.percent_or(0.0)
+        covered = stat.covered
+        total = stat.total
+        sys.stdout.write(f"{name}: {percent:0.1f}% ({covered} out of {total})\n")
 
-    lines_out = "lines: %0.1f%% (%s out of %s)" % (percent, lines_covered, lines_total)
-    functions_out = "functions: %0.1f%% (%s out of %s)" % (
-        percent_functions,
-        functions_covered,
-        functions_total,
-    )
-    branches_out = "branches: %0.1f%% (%s out of %s)" % (
-        percent_branches,
-        branches_covered,
-        branches_total,
-    )
+    stats = SummarizedStats.from_covdata(covdata)
 
-    sys.stdout.write(lines_out + "\n")
-    sys.stdout.write(functions_out + "\n")
-    sys.stdout.write(branches_out + "\n")
+    print_stat("lines", stats.line)
+    print_stat("functions", stats.function)
+    print_stat("branches", stats.branch)
+    sys.stdout.flush()

--- a/gcovr/writer/summary.py
+++ b/gcovr/writer/summary.py
@@ -19,10 +19,10 @@
 
 import sys
 
-from ..utils import get_global_stats
+from ..coverage import CovData, get_global_stats
 
 
-def print_summary(covdata):
+def print_summary(covdata: CovData):
     """Print a small report to the standard output.
     Output the percentage, covered and total lines and branches.
     """

--- a/gcovr/writer/txt.py
+++ b/gcovr/writer/txt.py
@@ -18,14 +18,14 @@
 # ****************************************************************************
 
 from ..utils import (
-    calculate_coverage,
     sort_coverage,
     presentable_filename,
     open_text_for_writing,
 )
+from ..coverage import CovData, calculate_coverage
 
 
-def print_text_report(covdata, output_file, options):
+def print_text_report(covdata: CovData, output_file, options):
     """produce the classic gcovr text report"""
 
     with open_text_for_writing(output_file, "coverage.txt") as fh:

--- a/gcovr/writer/txt.py
+++ b/gcovr/writer/txt.py
@@ -61,10 +61,10 @@ def print_text_report(covdata: CovData, output_file, options):
                 filename = filename + "\n" + " " * 40
 
             if options.show_branch:
-                total, cover, percent = coverage.branch_coverage()
+                total, cover, percent = coverage.branch_coverage().to_tuple
                 uncovered_lines = coverage.uncovered_branches_str()
             else:
-                total, cover, percent = coverage.line_coverage()
+                total, cover, percent = coverage.line_coverage().to_tuple
                 uncovered_lines = coverage.uncovered_lines_str()
             percent = "--" if percent is None else str(int(percent))
             return (

--- a/gcovr/writer/txt.py
+++ b/gcovr/writer/txt.py
@@ -24,29 +24,40 @@ from ..utils import (
 )
 from ..coverage import CovData, CoverageStat, FileCoverage
 
+# Widths of the various columns
+COL_FILE_WIDTH = 40
+COL_TOTAL_COUNT_WIDTH = 8
+COL_COVERED_COUNT_WIDTH = 8
+COL_PERCENTAGE_WIDTH = 7  # including "%" percentage sign
+MISSING_SEPARATOR = "   "
+LINE_WIDTH = 78
+
 
 def print_text_report(covdata: CovData, output_file, options):
     """produce the classic gcovr text report"""
 
     with open_text_for_writing(output_file, "coverage.txt") as fh:
         # Header
-        fh.write("-" * 78 + "\n")
-        fh.write(" " * 27 + "GCC Code Coverage Report\n")
+        fh.write("-" * LINE_WIDTH + "\n")
+        fh.write("GCC Code Coverage Report".center(LINE_WIDTH).rstrip() + "\n")
+        # fh.write(" " * 27 + "GCC Code Coverage Report\n")
         fh.write("Directory: " + options.root + "\n")
 
-        fh.write("-" * 78 + "\n")
+        fh.write("-" * LINE_WIDTH + "\n")
         title_total = "Branches" if options.show_branch else "Lines"
         title_covered = "Taken" if options.show_branch else "Exec"
+        title_percentage = "Cover"
         title_missing = "Missing"
         fh.write(
-            "File".ljust(40)
-            + title_total.rjust(8)
-            + title_covered.rjust(8)
-            + "  Cover   "
+            "File".ljust(COL_FILE_WIDTH)
+            + title_total.rjust(COL_TOTAL_COUNT_WIDTH)
+            + title_covered.rjust(COL_COVERED_COUNT_WIDTH)
+            + title_percentage.rjust(COL_PERCENTAGE_WIDTH)
+            + MISSING_SEPARATOR
             + title_missing
             + "\n"
         )
-        fh.write("-" * 78 + "\n")
+        fh.write("-" * LINE_WIDTH + "\n")
 
         # Data
         keys = sort_coverage(
@@ -63,9 +74,9 @@ def print_text_report(covdata: CovData, output_file, options):
             fh.write(txt + "\n")
 
         # Footer & summary
-        fh.write("-" * 78 + "\n")
+        fh.write("-" * LINE_WIDTH + "\n")
         fh.write(_format_line("TOTAL", total_stat, "") + "\n")
-        fh.write("-" * 78 + "\n")
+        fh.write("-" * LINE_WIDTH + "\n")
 
 
 def _summarize_file_coverage(coverage: FileCoverage, options):
@@ -88,19 +99,19 @@ def _format_line(name: str, stat: CoverageStat, uncovered_lines: str) -> str:
     else:
         percent = str(int(raw_percent))
 
-    name = name.ljust(40)
+    name = name.ljust(COL_FILE_WIDTH)
     if len(name) > 40:
-        name = name + "\n" + " " * 40
+        name = name + "\n" + " " * COL_FILE_WIDTH
 
     line = (
         name
-        + str(stat.total).rjust(8)
-        + str(stat.covered).rjust(8)
-        + percent.rjust(6)
+        + str(stat.total).rjust(COL_TOTAL_COUNT_WIDTH)
+        + str(stat.covered).rjust(COL_COVERED_COUNT_WIDTH)
+        + percent.rjust(COL_PERCENTAGE_WIDTH - 1)
         + "%"
     )
 
     if uncovered_lines:
-        line += "   " + uncovered_lines
+        line += MISSING_SEPARATOR + uncovered_lines
 
     return line


### PR DESCRIPTION
As a “dividend” from dropping support for Python 3.6, various improvements have become possible. This PR focuses on adding more type annotations for the `gcovr.coverage` data model, externalizing the merging logic, and replacing the increasingly large tuples from `get_global_stats()` and so on with more useful classes. In doing so, a number of bugs were found, but not necessarily fixed as part of this PR.

For reviewing this PR, moving one commit at a time is recommended. The commit messages provide further explanation. Here, I summarize the central changes and consequences.

## `gcovr.coverage` must be a leaf module

Python doesn't handle cyclic dependencies very well. Since the coverage data model now provides types that are used in type annotations throughout the code, the `gcovr.coverage` module now cannot have dependencies on other gcovr modules.

In particular, the `CovData` type alias describes the top-level filename → FileCoverage dictionary.

As part of adding type annotations, some dead code regarding function coverage could be removed.

## New `CoverageStat`, `DecisionCoverageStat`, `SummarizedStats` types

The functions like `file.branch_coverage()` now return a `CoverageStat(covered, total)` object. This has a `percent` property that replaces the need to call `calculate_coverage()`. In case a default value other than None is desired, the `percent_or(default)` method can be used.

Since decision coverage has an additional `uncheckable` count, a separate but otherwise equivalent `DecisionCoverageStat` type is needed.

The `SummarizedStats` type aggregates line, branch, function, and decision coverage for a file or for the entire project, depending on which constructor function is used. This replaces the `get_global_stats()` and `summarize_file_coverage()` functions.

As a benefit of this, the different writers can now share common logic for aggregating coverage statistics, instead of doing everything themselves. Updating the writers uncovered some potential bugs, which are described below but not yet fixed.

## Merging coverage data with `merged = merge_file(left, right)` instead of `left.update(right)`

Previously, coverage data structures were merged with the `update()` method. This had a number of issues:

* It can't handle the different `DecisionCoverage` types reasonably.
* Mutable state obscures the data flow in some parts of the code.
* It may become necessary to make the merging logic dependent on command line options (perhaps for #586), but this won't work well if the merging logic is part of the `gcovr.coverage` module (as it must now be a leaf module).

To support this more “functional” style, some functions in other parts (`__main__` and `gcov`) were updated to return CovData instead of updating it in-place.

To insert individual elements, the merging module also provides functions like `insert_line_coverage(file, line)`.

Auditing the merging logic found a bug in the interplay of `--add-tracefile` + branch coverage and in the decision coverage analysis.

## Fixed bug: correctly merge branch coverage data from `--add-tracefile`

In BranchCoverage, the `fallthrough` and `throw` flags used to be tri-state booleans None/False/True where `None` meant “unknown” and `True` meant “known and set”. But the JSON writer coerced those to boolean False/True. This caused a problem because the old merging logic only checked whether the flag was None, and if so choose the other value. This meant the order of updates would become relevant when merging data loaded via `--add-tracefile`. In pseudocode:

```python
>>> BranchCoverage(throw=False).update(BranchCoverage(throw=True)
BranchCoverage(throw=False)  # keep left value

>>> BranchCoverage(throw=True).update(BranchCoverage(throw=False)
BranchCoverage(throw=True)  # keep left value
```

The correct result in either case would be `throw=True` because it should override the “unknown” state.

Now the flags use False for “unknown” and True for “known and set”, which allows the JSON output to remain stable.

## Open bug: package-level function coverage in Cobertura is entirely wrong

In pseudocode, the problem is that the Cobertura writer does its own coverage aggregation, but just overwrites instead of adding up function coverage stats:

```python
for package in packages:
  function_stat = CoverageState.new_empty()
  for file_cov in package.files:
    function_stat = file_cov.function_coverage()  # should be "+="
  report(function_stat)
```

## Open bug: branch coverage also counts noncode lines

For calculating line coverage, only the following lines are counted:

```python
if line.is_covered or line.is_uncovered: ...
```

Notably, this excludes `noncode` lines.

The `branch_coverage()` method has no such check, and will also consider branches on noncode lines!

This shouldn't matter since the gcovr_parser tries to check whether a line should contain branches, but there seems to be some discrepancy. Adding the noncode check in the coverage data model would cause a lot of test failures. Further investigation is needed to understand what's going on.

## Open bug: decision analysis can resurrect excluded lines

The decision analysis accesses coverage data via the `file.line(lineno)` method (before this PR) / `get_or_create_line_coverage(file, lineno)` (after this PR). But if no LineCoverage data structure already exists for that line, it will be created. The default LineCoverage also sets noncode=False, so that the newly-created lines will be counted as uncovered.

I haven't created a testcase to check this, but fixing this issue and moving to read-only access seems to break the tests, so correct behavior should be determined in a separate issue.

## Surprising discrepancy: null coverage in JSON-Summary writer

A never-ending problem is the default value if a coverage percentage is NaN. In the JSON-Summary writer, the project-summary and file-summary percentage fields seem to have different defaults. Whereas the project-summary defaults to 0%, the file-summary renders as null. I've kept this behaviour, for now, but it would probably make sense to figure out an unified approach eventually.

This kind of discrepancy was much easier to find when using the unified `CoverageStat.percent` method and when using a type checker such as MyPy.

## Obstacles to more type checking

At this point, more linting and more type-checking is not directly possible because there are still tons of spurious errors. In particular, heterogeneous dicts are tricky, e.g. if one dict entry contains a list and another a string. Our HTML writer is full of those. Eventually, these dicts can be replaced with dataclasses, but that is out of scope for this PR. Another problem is the Options type in the main function, since some fields change their types during execution (e.g. compiling filters). I do not intend to add MyPy to the CI process anytime soon, but I would like fewer type errors in order to have a better development experience, especially for people using IDEs or LSP-enabled editors like VS Code.