### PR TITLE
Fix parsing of gcov metadata

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Bug fixes and small improvements:
 - Remove function coverage from sonarcube report. (:issue:`591`)
 - Fix parallel processing of gcov data. (:issue:`592`)
 - Better diagnostics when dealing with corrupted input files. (:issue:`593`)
+- Accept metadata lines without values (introduced in gcc-11). (:issue:`601`)
 
 Documentation:
 

--- a/gcovr/gcov.py
+++ b/gcovr/gcov.py
@@ -99,8 +99,11 @@ def process_gcov_data(data_fname, covdata, gcda_fname, options, currdir=None):
     # Find the source file
     # TODO: instead of heuristics, use "working directory" if available
     metadata = parse_metadata(lines)
+    source = metadata.get("Source")
+    if source is None:
+        raise RuntimeError("Unexpected value 'None' for metadata 'Source'.")
     fname = guess_source_file_name(
-        metadata["Source"].strip(),
+        source,
         data_fname,
         gcda_fname,
         root_dir=options.root_dir,

--- a/gcovr/gcov_parser.py
+++ b/gcovr/gcov_parser.py
@@ -220,11 +220,7 @@ def parse_metadata(lines: List[str]) -> Dict[str, str]:
     RuntimeError: Missing key 'Source' in metadata. GCOV data was >>
       -: 0:Foo:bar
       -: 0:Key:123<< End of GCOV data
-    >>> parse_metadata('''
-    ...   -: 0:Source:file
-    ...   -: 0:Foo:bar
-    ...   -: 0:Key:123
-    ... '''.splitlines())
+    >>> parse_metadata('-: 0:Source: file \n -: 0:Foo: bar \n -: 0:Key: 123 '.splitlines())
     {'Source': 'file', 'Foo': 'bar', 'Key': '123'}
     >>> parse_metadata('''
     ...   -: 0:Source:file

--- a/gcovr/gcov_parser.py
+++ b/gcovr/gcov_parser.py
@@ -122,7 +122,7 @@ class _MetadataLine(NamedTuple):
     """A gcov line with metadata: ``-: 0:KEY:VALUE``"""
 
     key: str
-    value: str
+    value: Optional[str]
 
 
 class _BlockLine(NamedTuple):
@@ -746,7 +746,7 @@ def _parse_line(line: str) -> _Line:
         if count_str == "-" and lineno == "0":
             if ":" in source_code:
                 key, value = source_code.split(":", 1)
-                return _MetadataLine(key, value)
+                return _MetadataLine(key, value.strip())
             else:
                 # Add a syntethic metadata with no value
                 return _MetadataLine(source_code, None)

--- a/gcovr/gcov_parser.py
+++ b/gcovr/gcov_parser.py
@@ -226,6 +226,12 @@ def parse_metadata(lines: List[str]) -> Dict[str, str]:
     ...   -: 0:Key:123
     ... '''.splitlines())
     {'Source': 'file', 'Foo': 'bar', 'Key': '123'}
+    >>> parse_metadata('''
+    ...   -: 0:Source:file
+    ...   -: 0:Foo:bar
+    ...   -: 0:Key
+    ... '''.splitlines())
+    {'Source': 'file', 'Foo': 'bar', 'Key': None}
     """
     collected = {}
     for line in lines:
@@ -738,8 +744,12 @@ def _parse_line(line: str) -> _Line:
 
         # METADATA (key, value)
         if count_str == "-" and lineno == "0":
-            key, value = source_code.split(":", 1)
-            return _MetadataLine(key, value)
+            if ":" in source_code:
+                key, value = source_code.split(":", 1)
+                return _MetadataLine(key, value)
+            else:
+                # Add a syntethic metadata with no value
+                return _MetadataLine(source_code, None)
 
         if count_str == "-":
             count = 0


### PR DESCRIPTION
Gcc-11 has metadata lines without values in the gcov file (see #596). This PR add support for this lines and uses as value `None`.

Closes #596.