### PR TITLE
Properly close `<a>` element in detailed HTML report

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -16,6 +16,7 @@ The following developers contributed to gcovr (ordered alphabetically):
     Cezary Gapiński,
     Christian Taedcke,
     Dave George,
+    Davide Pesavento,
     Dom Postorivo,
     ebmmy,
     Elektrobit Automotive GmbH,

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Bug fixes and small improvements:
 - Fix parallel processing of gcov data. (:issue:`592`)
 - Better diagnostics when dealing with corrupted input files. (:issue:`593`)
 - Accept metadata lines without values (introduced in gcc-11). (:issue:`601`)
+- Properly close <a> element in detailed HTML report. (:issue:`602`)
 
 Documentation:
 

--- a/doc/examples/example_html.details.html
+++ b/doc/examples/example_html.details.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="example_html.details.functions.html">List of functions</summary>
+<a href="example_html.details.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/templates/root_page.html
+++ b/gcovr/templates/root_page.html
@@ -69,8 +69,8 @@
 
 {% block navigation %}
 {% if info.details %}
-<a href="{{ FUNCTIONS_FNAME }}">List of functions</summary>
-{% endif -%}
+<a href="{{ FUNCTIONS_FNAME }}">List of functions</a>
+{% endif %}
 {% endblock %}
 
 {% block content %}

--- a/gcovr/tests/add_coverages/reference/clang-10/coverage.html
+++ b/gcovr/tests/add_coverages/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/add_coverages/reference/gcc-5/coverage.html
+++ b/gcovr/tests/add_coverages/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/add_coverages/reference/gcc-8/coverage.html
+++ b/gcovr/tests/add_coverages/reference/gcc-8/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/bad++char/reference/clang-10/coverage.html
+++ b/gcovr/tests/bad++char/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/bad++char/reference/gcc-5/coverage.html
+++ b/gcovr/tests/bad++char/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/bad++char/reference/gcc-8/coverage.html
+++ b/gcovr/tests/bad++char/reference/gcc-8/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/cmake_oos/reference/clang-10/coverage.html
+++ b/gcovr/tests/cmake_oos/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/cmake_oos/reference/gcc-5/coverage.html
+++ b/gcovr/tests/cmake_oos/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/cmake_oos/reference/gcc-8/coverage.html
+++ b/gcovr/tests/cmake_oos/reference/gcc-8/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/cmake_oos_ninja/reference/clang-10/coverage.html
+++ b/gcovr/tests/cmake_oos_ninja/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/cmake_oos_ninja/reference/gcc-5/coverage.html
+++ b/gcovr/tests/cmake_oos_ninja/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/cmake_oos_ninja/reference/gcc-8/coverage.html
+++ b/gcovr/tests/cmake_oos_ninja/reference/gcc-8/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/decisions/reference/clang-10/coverage.html
+++ b/gcovr/tests/decisions/reference/clang-10/coverage.html
@@ -76,7 +76,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/decisions/reference/gcc-11/coverage.html
+++ b/gcovr/tests/decisions/reference/gcc-11/coverage.html
@@ -76,7 +76,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/decisions/reference/gcc-5/coverage.html
+++ b/gcovr/tests/decisions/reference/gcc-5/coverage.html
@@ -76,7 +76,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/decisions/reference/gcc-8/coverage.html
+++ b/gcovr/tests/decisions/reference/gcc-8/coverage.html
@@ -76,7 +76,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/dot/reference/clang-10/coverage.html
+++ b/gcovr/tests/dot/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/dot/reference/gcc-5/coverage.html
+++ b/gcovr/tests/dot/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/dot/reference/gcc-8/coverage.html
+++ b/gcovr/tests/dot/reference/gcc-8/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/excl-branch/reference/clang-10/coverage.html
+++ b/gcovr/tests/excl-branch/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/excl-branch/reference/clang-13/coverage.html
+++ b/gcovr/tests/excl-branch/reference/clang-13/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/excl-branch/reference/gcc-5/coverage.html
+++ b/gcovr/tests/excl-branch/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/excl-branch/reference/gcc-8/coverage.html
+++ b/gcovr/tests/excl-branch/reference/gcc-8/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/excl-line-custom/reference/clang-10/coverage.html
+++ b/gcovr/tests/excl-line-custom/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/excl-line-custom/reference/gcc-5/coverage.html
+++ b/gcovr/tests/excl-line-custom/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/excl-line-custom/reference/gcc-8/coverage.html
+++ b/gcovr/tests/excl-line-custom/reference/gcc-8/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/excl-line/reference/clang-10/coverage.html
+++ b/gcovr/tests/excl-line/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/excl-line/reference/gcc-5/coverage.html
+++ b/gcovr/tests/excl-line/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/excl-line/reference/gcc-8/coverage.html
+++ b/gcovr/tests/excl-line/reference/gcc-8/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/exclude-directories-relative/reference/clang-10/coverage.html
+++ b/gcovr/tests/exclude-directories-relative/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/exclude-directories-relative/reference/gcc-5/coverage.html
+++ b/gcovr/tests/exclude-directories-relative/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/exclude-directories-relative/reference/gcc-8/coverage.html
+++ b/gcovr/tests/exclude-directories-relative/reference/gcc-8/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/exclude-lines-by-pattern/reference/clang-10/coverage.html
+++ b/gcovr/tests/exclude-lines-by-pattern/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/exclude-lines-by-pattern/reference/gcc-5/coverage.html
+++ b/gcovr/tests/exclude-lines-by-pattern/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/exclude-lines-by-pattern/reference/gcc-8/coverage.html
+++ b/gcovr/tests/exclude-lines-by-pattern/reference/gcc-8/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/exclude-relative-from-unfiltered-tracefile/reference/clang-10/coverage.html
+++ b/gcovr/tests/exclude-relative-from-unfiltered-tracefile/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/exclude-relative-from-unfiltered-tracefile/reference/gcc-5/coverage.html
+++ b/gcovr/tests/exclude-relative-from-unfiltered-tracefile/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/exclude-relative-from-unfiltered-tracefile/reference/gcc-8/coverage.html
+++ b/gcovr/tests/exclude-relative-from-unfiltered-tracefile/reference/gcc-8/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/exclude-relative/reference/clang-10/coverage.html
+++ b/gcovr/tests/exclude-relative/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/exclude-relative/reference/gcc-5/coverage.html
+++ b/gcovr/tests/exclude-relative/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/exclude-relative/reference/gcc-8/coverage.html
+++ b/gcovr/tests/exclude-relative/reference/gcc-8/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/exclude-throw-branches/reference/clang-10/coverage-excl-throw.html
+++ b/gcovr/tests/exclude-throw-branches/reference/clang-10/coverage-excl-throw.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage-excl-throw.functions.html">List of functions</summary>
+<a href="coverage-excl-throw.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/exclude-throw-branches/reference/clang-10/coverage-throw.html
+++ b/gcovr/tests/exclude-throw-branches/reference/clang-10/coverage-throw.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage-throw.functions.html">List of functions</summary>
+<a href="coverage-throw.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-10/coverage-excl-throw.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-10/coverage-excl-throw.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage-excl-throw.functions.html">List of functions</summary>
+<a href="coverage-excl-throw.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-10/coverage-throw.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-10/coverage-throw.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage-throw.functions.html">List of functions</summary>
+<a href="coverage-throw.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-11/coverage-excl-throw.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-11/coverage-excl-throw.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage-excl-throw.functions.html">List of functions</summary>
+<a href="coverage-excl-throw.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-11/coverage-throw.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-11/coverage-throw.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage-throw.functions.html">List of functions</summary>
+<a href="coverage-throw.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-5/coverage-excl-throw.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-5/coverage-excl-throw.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage-excl-throw.functions.html">List of functions</summary>
+<a href="coverage-excl-throw.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-5/coverage-throw.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-5/coverage-throw.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage-throw.functions.html">List of functions</summary>
+<a href="coverage-throw.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-6/coverage-excl-throw.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-6/coverage-excl-throw.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage-excl-throw.functions.html">List of functions</summary>
+<a href="coverage-excl-throw.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-6/coverage-throw.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-6/coverage-throw.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage-throw.functions.html">List of functions</summary>
+<a href="coverage-throw.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-8-Windows/coverage-excl-throw.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-8-Windows/coverage-excl-throw.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage-excl-throw.functions.html">List of functions</summary>
+<a href="coverage-excl-throw.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-8-Windows/coverage-throw.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-8-Windows/coverage-throw.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage-throw.functions.html">List of functions</summary>
+<a href="coverage-throw.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-8/coverage-excl-throw.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-8/coverage-excl-throw.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage-excl-throw.functions.html">List of functions</summary>
+<a href="coverage-excl-throw.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-8/coverage-throw.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-8/coverage-throw.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage-throw.functions.html">List of functions</summary>
+<a href="coverage-throw.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/filter-absolute-from-unfiltered-tracefile/reference/clang-10/coverage.html
+++ b/gcovr/tests/filter-absolute-from-unfiltered-tracefile/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/filter-absolute-from-unfiltered-tracefile/reference/gcc-5/coverage.html
+++ b/gcovr/tests/filter-absolute-from-unfiltered-tracefile/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/filter-absolute-from-unfiltered-tracefile/reference/gcc-8/coverage.html
+++ b/gcovr/tests/filter-absolute-from-unfiltered-tracefile/reference/gcc-8/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/filter-absolute/reference/clang-10/coverage.html
+++ b/gcovr/tests/filter-absolute/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/filter-absolute/reference/gcc-5/coverage.html
+++ b/gcovr/tests/filter-absolute/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/filter-absolute/reference/gcc-8/coverage.html
+++ b/gcovr/tests/filter-absolute/reference/gcc-8/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/filter-relative-from-unfiltered-tracefile/reference/clang-10/coverage.html
+++ b/gcovr/tests/filter-relative-from-unfiltered-tracefile/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/filter-relative-from-unfiltered-tracefile/reference/gcc-5/coverage.html
+++ b/gcovr/tests/filter-relative-from-unfiltered-tracefile/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/filter-relative-from-unfiltered-tracefile/reference/gcc-8/coverage.html
+++ b/gcovr/tests/filter-relative-from-unfiltered-tracefile/reference/gcc-8/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/filter-relative-lib-from-unfiltered-tracefile/reference/clang-10/coverage.html
+++ b/gcovr/tests/filter-relative-lib-from-unfiltered-tracefile/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/filter-relative-lib-from-unfiltered-tracefile/reference/gcc-5/coverage.html
+++ b/gcovr/tests/filter-relative-lib-from-unfiltered-tracefile/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/filter-relative-lib/reference/clang-10/coverage.html
+++ b/gcovr/tests/filter-relative-lib/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/filter-relative-lib/reference/gcc-5/coverage.html
+++ b/gcovr/tests/filter-relative-lib/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/filter-relative/reference/clang-10/coverage.html
+++ b/gcovr/tests/filter-relative/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/filter-relative/reference/gcc-5/coverage.html
+++ b/gcovr/tests/filter-relative/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/filter-relative/reference/gcc-8/coverage.html
+++ b/gcovr/tests/filter-relative/reference/gcc-8/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/html-default/reference/clang-10/coverage.html
+++ b/gcovr/tests/html-default/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/html-default/reference/gcc-5/coverage.html
+++ b/gcovr/tests/html-default/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/html-encoding-cp1252/reference/clang-10/coverage.html
+++ b/gcovr/tests/html-encoding-cp1252/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/html-encoding-cp1252/reference/gcc-5/coverage.html
+++ b/gcovr/tests/html-encoding-cp1252/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/html-encoding-iso-8859-15/reference/clang-10/coverage.html
+++ b/gcovr/tests/html-encoding-iso-8859-15/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/html-encoding-iso-8859-15/reference/gcc-5/coverage.html
+++ b/gcovr/tests/html-encoding-iso-8859-15/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/html-file-not-found/reference/clang-10/coverage.html
+++ b/gcovr/tests/html-file-not-found/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/html-file-not-found/reference/gcc-5/coverage.html
+++ b/gcovr/tests/html-file-not-found/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/html-high-100/reference/clang-10/coverage.html
+++ b/gcovr/tests/html-high-100/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/html-high-100/reference/gcc-5/coverage.html
+++ b/gcovr/tests/html-high-100/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/html-high-75/reference/clang-10/coverage.html
+++ b/gcovr/tests/html-high-75/reference/clang-10/coverage.html
@@ -69,7 +69,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/html-high-75/reference/gcc-5/coverage.html
+++ b/gcovr/tests/html-high-75/reference/gcc-5/coverage.html
@@ -69,7 +69,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/html-medium-100-high-100/reference/clang-10/coverage.html
+++ b/gcovr/tests/html-medium-100-high-100/reference/clang-10/coverage.html
@@ -69,7 +69,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/html-medium-100-high-100/reference/gcc-5/coverage.html
+++ b/gcovr/tests/html-medium-100-high-100/reference/gcc-5/coverage.html
@@ -69,7 +69,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/html-medium-50/reference/clang-10/coverage.html
+++ b/gcovr/tests/html-medium-50/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/html-medium-50/reference/gcc-5/coverage.html
+++ b/gcovr/tests/html-medium-50/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/html-no-syntax-highlighting/reference/clang-10/coverage.html
+++ b/gcovr/tests/html-no-syntax-highlighting/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/html-no-syntax-highlighting/reference/gcc-5/coverage.html
+++ b/gcovr/tests/html-no-syntax-highlighting/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/html-source-encoding-cp1252/reference/gcc-5/coverage.html
+++ b/gcovr/tests/html-source-encoding-cp1252/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/html-source-encoding-utf8/reference/clang-10/coverage.html
+++ b/gcovr/tests/html-source-encoding-utf8/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/html-source-encoding-utf8/reference/gcc-5/coverage.html
+++ b/gcovr/tests/html-source-encoding-utf8/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/html-themes/reference/clang-10/coverage.blue.html
+++ b/gcovr/tests/html-themes/reference/clang-10/coverage.blue.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.blue.functions.html">List of functions</summary>
+<a href="coverage.blue.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/html-themes/reference/clang-10/coverage.green.html
+++ b/gcovr/tests/html-themes/reference/clang-10/coverage.green.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.green.functions.html">List of functions</summary>
+<a href="coverage.green.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/html-themes/reference/gcc-10/coverage.blue.html
+++ b/gcovr/tests/html-themes/reference/gcc-10/coverage.blue.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.blue.functions.html">List of functions</summary>
+<a href="coverage.blue.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/html-themes/reference/gcc-10/coverage.green.html
+++ b/gcovr/tests/html-themes/reference/gcc-10/coverage.green.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.green.functions.html">List of functions</summary>
+<a href="coverage.green.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/html-themes/reference/gcc-11/coverage.blue.html
+++ b/gcovr/tests/html-themes/reference/gcc-11/coverage.blue.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.blue.functions.html">List of functions</summary>
+<a href="coverage.blue.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/html-themes/reference/gcc-11/coverage.green.html
+++ b/gcovr/tests/html-themes/reference/gcc-11/coverage.green.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.green.functions.html">List of functions</summary>
+<a href="coverage.green.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/html-themes/reference/gcc-5/coverage.blue.html
+++ b/gcovr/tests/html-themes/reference/gcc-5/coverage.blue.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.blue.functions.html">List of functions</summary>
+<a href="coverage.blue.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/html-themes/reference/gcc-5/coverage.green.html
+++ b/gcovr/tests/html-themes/reference/gcc-5/coverage.green.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.green.functions.html">List of functions</summary>
+<a href="coverage.green.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/html-themes/reference/gcc-6/coverage.blue.html
+++ b/gcovr/tests/html-themes/reference/gcc-6/coverage.blue.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.blue.functions.html">List of functions</summary>
+<a href="coverage.blue.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/html-themes/reference/gcc-6/coverage.green.html
+++ b/gcovr/tests/html-themes/reference/gcc-6/coverage.green.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.green.functions.html">List of functions</summary>
+<a href="coverage.green.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/html-themes/reference/gcc-8/coverage.blue.html
+++ b/gcovr/tests/html-themes/reference/gcc-8/coverage.blue.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.blue.functions.html">List of functions</summary>
+<a href="coverage.blue.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/html-themes/reference/gcc-8/coverage.green.html
+++ b/gcovr/tests/html-themes/reference/gcc-8/coverage.green.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.green.functions.html">List of functions</summary>
+<a href="coverage.green.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/html-title/reference/clang-10/coverage.html
+++ b/gcovr/tests/html-title/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/html-title/reference/gcc-5/coverage.html
+++ b/gcovr/tests/html-title/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/linked/reference/clang-10/coverage.html
+++ b/gcovr/tests/linked/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/linked/reference/gcc-5/coverage.html
+++ b/gcovr/tests/linked/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/linked/reference/gcc-8/coverage.html
+++ b/gcovr/tests/linked/reference/gcc-8/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/nested/reference/clang-10/coverage.html
+++ b/gcovr/tests/nested/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/nested/reference/gcc-5/coverage.html
+++ b/gcovr/tests/nested/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/nested/reference/gcc-8/coverage.html
+++ b/gcovr/tests/nested/reference/gcc-8/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/nested2-use-existing/reference/clang-10/coverage.html
+++ b/gcovr/tests/nested2-use-existing/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/nested2-use-existing/reference/gcc-5/coverage.html
+++ b/gcovr/tests/nested2-use-existing/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/nested2-use-existing/reference/gcc-8/coverage.html
+++ b/gcovr/tests/nested2-use-existing/reference/gcc-8/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/nested2/reference/clang-10/coverage.html
+++ b/gcovr/tests/nested2/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/nested2/reference/gcc-5/coverage.html
+++ b/gcovr/tests/nested2/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/nested2/reference/gcc-8/coverage.html
+++ b/gcovr/tests/nested2/reference/gcc-8/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/nested3/reference/clang-10/coverage.html
+++ b/gcovr/tests/nested3/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/nested3/reference/gcc-5/coverage.html
+++ b/gcovr/tests/nested3/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/nested3/reference/gcc-8/coverage.html
+++ b/gcovr/tests/nested3/reference/gcc-8/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/no-markers/reference/clang-10/coverage.html
+++ b/gcovr/tests/no-markers/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/no-markers/reference/gcc-5/coverage.html
+++ b/gcovr/tests/no-markers/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/no-markers/reference/gcc-8/coverage.html
+++ b/gcovr/tests/no-markers/reference/gcc-8/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/nobranch/reference/clang-10/coverage.html
+++ b/gcovr/tests/nobranch/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/nobranch/reference/gcc-5/coverage.html
+++ b/gcovr/tests/nobranch/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/oos/reference/clang-10/coverage.html
+++ b/gcovr/tests/oos/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/oos/reference/gcc-5/coverage.html
+++ b/gcovr/tests/oos/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/oos/reference/gcc-8/coverage.html
+++ b/gcovr/tests/oos/reference/gcc-8/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/oos2/reference/clang-10/coverage.html
+++ b/gcovr/tests/oos2/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/oos2/reference/gcc-5/coverage.html
+++ b/gcovr/tests/oos2/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/oos2/reference/gcc-8/coverage.html
+++ b/gcovr/tests/oos2/reference/gcc-8/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/rounding/reference/clang-10/coverage.html
+++ b/gcovr/tests/rounding/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/rounding/reference/gcc-5/coverage.html
+++ b/gcovr/tests/rounding/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/shadow/reference/clang-10/coverage.html
+++ b/gcovr/tests/shadow/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/shadow/reference/gcc-5/coverage.html
+++ b/gcovr/tests/shadow/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/shadow/reference/gcc-8/coverage.html
+++ b/gcovr/tests/shadow/reference/gcc-8/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/shared_lib/reference/clang-10/coverage.html
+++ b/gcovr/tests/shared_lib/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/shared_lib/reference/gcc-5/coverage.html
+++ b/gcovr/tests/shared_lib/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/shared_lib/reference/gcc-8/coverage.html
+++ b/gcovr/tests/shared_lib/reference/gcc-8/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/simple1-dir/reference/clang-10/coverage_details.html
+++ b/gcovr/tests/simple1-dir/reference/clang-10/coverage_details.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage_details.functions.html">List of functions</summary>
+<a href="coverage_details.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/simple1-dir/reference/gcc-5/coverage_details.html
+++ b/gcovr/tests/simple1-dir/reference/gcc-5/coverage_details.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage_details.functions.html">List of functions</summary>
+<a href="coverage_details.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/simple1-dir/reference/gcc-8/coverage_details.html
+++ b/gcovr/tests/simple1-dir/reference/gcc-8/coverage_details.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage_details.functions.html">List of functions</summary>
+<a href="coverage_details.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/simple1-drive-subst/reference/gcc-8-Windows/coverage-details-linkcss.html
+++ b/gcovr/tests/simple1-drive-subst/reference/gcc-8-Windows/coverage-details-linkcss.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage-details-linkcss.functions.html">List of functions</summary>
+<a href="coverage-details-linkcss.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/simple1/reference/clang-10/coverage-details-includecss.html
+++ b/gcovr/tests/simple1/reference/clang-10/coverage-details-includecss.html
@@ -636,7 +636,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     </header>
 
     <nav>
-<a href="coverage-details-includecss.functions.html">List of functions</summary>
+<a href="coverage-details-includecss.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/simple1/reference/clang-10/coverage-details-linkcss.html
+++ b/gcovr/tests/simple1/reference/clang-10/coverage-details-linkcss.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage-details-linkcss.functions.html">List of functions</summary>
+<a href="coverage-details-linkcss.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/simple1/reference/gcc-5/coverage-details-includecss.html
+++ b/gcovr/tests/simple1/reference/gcc-5/coverage-details-includecss.html
@@ -636,7 +636,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     </header>
 
     <nav>
-<a href="coverage-details-includecss.functions.html">List of functions</summary>
+<a href="coverage-details-includecss.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/simple1/reference/gcc-5/coverage-details-linkcss.html
+++ b/gcovr/tests/simple1/reference/gcc-5/coverage-details-linkcss.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage-details-linkcss.functions.html">List of functions</summary>
+<a href="coverage-details-linkcss.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/simple1/reference/gcc-8/coverage-details-includecss.html
+++ b/gcovr/tests/simple1/reference/gcc-8/coverage-details-includecss.html
@@ -636,7 +636,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     </header>
 
     <nav>
-<a href="coverage-details-includecss.functions.html">List of functions</summary>
+<a href="coverage-details-includecss.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/simple1/reference/gcc-8/coverage-details-linkcss.html
+++ b/gcovr/tests/simple1/reference/gcc-8/coverage-details-linkcss.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage-details-linkcss.functions.html">List of functions</summary>
+<a href="coverage-details-linkcss.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/sort-percentage/reference/clang-10/coverage.html
+++ b/gcovr/tests/sort-percentage/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/sort-percentage/reference/gcc-5/coverage.html
+++ b/gcovr/tests/sort-percentage/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/sort-percentage/reference/gcc-8/coverage.html
+++ b/gcovr/tests/sort-percentage/reference/gcc-8/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/sort-uncovered/reference/clang-10/coverage.html
+++ b/gcovr/tests/sort-uncovered/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/sort-uncovered/reference/gcc-5/coverage.html
+++ b/gcovr/tests/sort-uncovered/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/sort-uncovered/reference/gcc-8/coverage.html
+++ b/gcovr/tests/sort-uncovered/reference/gcc-8/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/subfolder-includes/reference/clang-10/coverage.html
+++ b/gcovr/tests/subfolder-includes/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/subfolder-includes/reference/gcc-5/coverage.html
+++ b/gcovr/tests/subfolder-includes/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/subfolder-includes/reference/gcc-8/coverage.html
+++ b/gcovr/tests/subfolder-includes/reference/gcc-8/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/threaded/reference/clang-10/coverage.html
+++ b/gcovr/tests/threaded/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/threaded/reference/gcc-5/coverage.html
+++ b/gcovr/tests/threaded/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/threaded/reference/gcc-8/coverage.html
+++ b/gcovr/tests/threaded/reference/gcc-8/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/update-data/reference/clang-10/coverage.html
+++ b/gcovr/tests/update-data/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/update-data/reference/gcc-5/coverage.html
+++ b/gcovr/tests/update-data/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/use-existing/reference/clang-10/coverage.html
+++ b/gcovr/tests/use-existing/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/use-existing/reference/gcc-5/coverage.html
+++ b/gcovr/tests/use-existing/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/use-existing/reference/gcc-8/coverage.html
+++ b/gcovr/tests/use-existing/reference/gcc-8/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/wspace/reference/clang-10/coverage.html
+++ b/gcovr/tests/wspace/reference/clang-10/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/wspace/reference/gcc-5/coverage.html
+++ b/gcovr/tests/wspace/reference/gcc-5/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>

--- a/gcovr/tests/wspace/reference/gcc-8/coverage.html
+++ b/gcovr/tests/wspace/reference/gcc-8/coverage.html
@@ -70,7 +70,7 @@
     </header>
 
     <nav>
-<a href="coverage.functions.html">List of functions</summary>
+<a href="coverage.functions.html">List of functions</a>
     </nav>
 
     <main>


### PR DESCRIPTION
The `--html-details` generator produces invalid HTML in gcovr 5.1. For instance:

```html
    <nav>
<a href="coverage.functions.html">List of functions</summary>
    </nav>
```

This (untested) patch fixes the HTML document structure by using the correct closing tag.

I also see a large amount of test files in `gcovr/tests/` and examples in `doc/examples/` with the wrong HTML. I have not attempted to regenerate them.