### PR TITLE
Use ubuntu-20.04 for gcc-8 in docker.

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -231,7 +231,7 @@ def docker_container_os(session: nox.Session) -> str:
 
 def docker_container_id(session: nox.Session, version: str) -> str:
     """Get the docker container ID."""
-    return f"gcovr-qa-{docker_container_os(session)}-{version}-uid_{os.geteuid()}"
+    return f"gcovr-qa-{docker_container_os(session).replace(':', '_')}-{version}-uid_{os.geteuid()}"
 
 
 @nox.session(python=False)

--- a/noxfile.py
+++ b/noxfile.py
@@ -224,7 +224,7 @@ def upload_wheel(session: nox.Session) -> None:
 def docker_container_os(session: nox.Session) -> str:
     if session.env["CC"] in ["gcc-5", "gcc-6"]:
         return "ubuntu:18.04"
-    elif session.env["CC"] in ["gcc-9", "clang-10"]:
+    elif session.env["CC"] in ["gcc-8", "gcc-9", "clang-10"]:
         return "ubuntu:20.04"
     return "ubuntu:22.04"
 


### PR DESCRIPTION
In #597 for gcc-9 Ubuntu 20.04 was used but for gcc-8 the newer 22.04.
In 22.04 the gcc-8 isn't available anymore.

[no changelog]