### PR TITLE
Forward nox options to call inside docker.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Breaking changes:
 
 New features and notable changes:
 
-- Log additional infop on gcov parsing errors. (:issue:`589`)
+- Log additional info on gcov parsing errors. (:issue:`589`)
 
 Bug fixes and small improvements:
 
@@ -38,6 +38,7 @@ Internal changes:
 - Add gcc-10 and gcc-11 to the test suite. (:issue:`597`)
 - Improved internal coverage data model to simplify processing. (:issue:`600`)
 - Use pretty print for cobertura and coveralls in test suite. (:issue:`606`)
+- Forward nox options `--reuse-existing-virtualenvs` and `--no-install` to call inside docker. (:issue:`616`)
 
 5.1 (26 March 2022)
 -------------------

--- a/admin/Dockerfile.qa
+++ b/admin/Dockerfile.qa
@@ -62,4 +62,4 @@ ENV LC_ALL=C.UTF-8 LANG=C.UTF-8
 
 CMD ( echo docker | sudo -S -p "Running chmod with sudo..." chown -R docker:docker /gcovr/gcovr ) && \
   echo "\ndone\nStarting test..." && \
-  python3 -m nox --envdir $NOX_ENV_DIR --non-interactive
+  python3 -m nox --envdir $NOX_ENV_DIR --non-interactive $NOX_OPTIONS --


### PR DESCRIPTION
Recreating the virtual environment and installing the requirements needs some time. If the session `docker_qa_compiler(all)` to update the test data this takes a long time even if the requirements aren't changed.

The sessions for docker don't use python and a virtual environment, therefore the options `--reuse-existing-virtualenvs` and `--no-install` are useless and this PR forwards this options to the `nox` call inside docker.

Here are my measurements for the call `python3 -m nox -s 'docker_qa_compiler(gcc-5) ...`:
- `... -- -k nested`: `0,28s user 0,22s system 0% cpu 2:45,78 total`
- `... --reuse-existing-virtualenvs -- -k nested`: `0,33s user 0,23s system 1% cpu 36,365 total` --> ~ 5 times faster
- `... --reuse-existing-virtualenvs --no-install -- -k nested`: `0,33s user 0,23s system 2% cpu 24,872 total` --> ~ 6 times faster
