### PR TITLE
Accept `NAN %` which is used in GCOV 7.5.0 instead of an invalid value.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,22 @@
 .. program is needed to resolve option links
 .. program::  gcovr
 
+Next Release
+------------
+
+Known bugs:
+
+Breaking changes:
+
+New features and notable changes:
+- Accept `NAN %` which is used in GCOV 7.5.0 instead of an invalid value. (:issue:`651`)
+
+Bug fixes and small improvements:
+
+Documentation:
+
+Internal changes:
+
 5.2 (06 August 2022)
 --------------------
 

--- a/gcovr/gcov_parser.py
+++ b/gcovr/gcov_parser.py
@@ -88,7 +88,7 @@ def _line_pattern(pattern: str) -> Pattern[str]:
     """
     pattern = pattern.replace(" ", r"[ ]+")
     pattern = pattern.replace("INT", r"[0-9]+")
-    pattern = pattern.replace("VALUE", r"[0-9.]+[%kMGTPEZY]?")
+    pattern = pattern.replace("VALUE", r"(?:NAN %|[0-9.]+[%kMGTPEZY]?)")
     return re.compile("^" + pattern + "$")
 
 
@@ -1256,8 +1256,8 @@ def _int_from_gcov_unit(formatted: str) -> int:
     Examples:
     >>> _int_from_gcov_unit('123')
     123
-    >>> [_int_from_gcov_unit(value) for value in ('17.2%', '0%')]
-    [1, 0]
+    >>> [_int_from_gcov_unit(value) for value in ('NAN %', '17.2%', '0%')]
+    [0, 1, 0]
     >>> [_int_from_gcov_unit(value) for value in ('1.7k', '0.5G')]
     [1700, 500000000]
     """


### PR DESCRIPTION
Fix parser error:
```
(WARNING) Exception during parsing:
	UnknownLineType: function prop8_view_postfilter called 8092 returned NAN % blocks executed 19%
```
Closes #627