### PR TITLE
Print a warning if root directory contains symlinks.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,23 @@
 .. program is needed to resolve option links
 .. program::  gcovr
 
+Next Release
+------------
+
+Known bugs:
+
+Breaking changes:
+
+New features and notable changes:
+
+- Print a warning if root directory contains symlinks. (:issue:`652`)
+
+Bug fixes and small improvements:
+
+Documentation:
+
+Internal changes:
+
 5.2 (06 August 2022)
 --------------------
 

--- a/gcovr/__main__.py
+++ b/gcovr/__main__.py
@@ -255,6 +255,11 @@ def main(args=None):
 
     options.starting_dir = os.path.abspath(os.getcwd())
     options.root_dir = os.path.abspath(options.root)
+    if options.root_dir != os.path.realpath(options.root_dir):
+        logger.warning(
+            "It seems, that your root contains a symlink. This may result in problems. "
+            "See issue https://github.com/gcovr/gcovr/issues/635."
+        )
 
     #
     # Setup filters


### PR DESCRIPTION
As suggested in #635 print a warning if the root directory contains symlinks.

Closes #635