### PR TITLE
Add base path for json.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Breaking changes:
 
 New features and notable changes:
 - Accept `NAN %` which is used in GCOV 7.5.0 instead of an invalid value. (:issue:`651`)
+- New :option:`--json-base` to define a base bath used in JSON reports. (:issue:`656`)
 
 Bug fixes and small improvements:
 - Fix :option:`--html-tab-size` feature. (:issue:`650`)

--- a/doc/source/guide/merging.rst
+++ b/doc/source/guide/merging.rst
@@ -1,3 +1,7 @@
+
+.. program is needed to resolve option links
+.. program::  gcovr
+
 .. _merging_coverage:
 
 Merging Coverage Data
@@ -27,8 +31,7 @@ you have to place your pathnames with wildcards in double quotation marks::
     gcovr --add-tracefile "run-*.json" --html-details coverage.html
 
 If you want to merge coverage reports generated in different `--root` directories you
-can use the option `--json-base=dir/to/prepend` to get the same root directory for all
-reports.
+can use the :option:`--json-base` to get the same root directory for all reports.
 
 .. versionadded:: NEXT
 

--- a/doc/source/guide/merging.rst
+++ b/doc/source/guide/merging.rst
@@ -25,3 +25,11 @@ duplicating :option:`-a/--add-tracefile<gcovr --add-tracefile>`. With this optio
 you have to place your pathnames with wildcards in double quotation marks::
 
     gcovr --add-tracefile "run-*.json" --html-details coverage.html
+
+If you want to merge coverage reports generated in different `--root` directories you
+can use the option `--json-base=dir/to/prepend` to get the same root directory for all
+reports.
+
+.. versionadded:: NEXT
+
+   The :option:`gcovr --json-base` option.

--- a/gcovr/configuration.py
+++ b/gcovr/configuration.py
@@ -28,7 +28,7 @@ import datetime
 import os
 import re
 
-from .utils import FilterOption
+from .utils import FilterOption, force_unix_separator
 from .writer.html import CssRenderer
 
 
@@ -1087,7 +1087,7 @@ GCOVR_CONFIG_OPTIONS = [
         group="output_options",
         metavar="PATH",
         help="Prepend the given path to all file paths in JSON report.",
-        type=str,
+        type=lambda p: force_unix_separator(os.path.normpath(p)),
         default=None,
     ),
     GcovrConfigOption(

--- a/gcovr/configuration.py
+++ b/gcovr/configuration.py
@@ -1082,6 +1082,15 @@ GCOVR_CONFIG_OPTIONS = [
         action="store_true",
     ),
     GcovrConfigOption(
+        "json_base",
+        ["--json-base"],
+        group="output_options",
+        metavar="PATH",
+        help="Prepend the given path to all file paths in JSON report.",
+        type=str,
+        default=None,
+    ),
+    GcovrConfigOption(
         "csv",
         ["--csv"],
         group="output_options",

--- a/gcovr/tests/simple1/Makefile
+++ b/gcovr/tests/simple1/Makefile
@@ -48,11 +48,11 @@ sonarqube:
 
 json_summary:
 	./testcase
-	$(GCOVR) -d --json-summary-pretty -o summary_coverage.json
+	$(GCOVR) -d --json-base test\\dir --json-summary-pretty -o summary_coverage.json
 
 json:
 	./testcase
-	$(GCOVR) --json-pretty --json coverage.json
+	$(GCOVR) --json-base test\\dir --json-pretty --json coverage.json
 
 coveralls:
 	./testcase

--- a/gcovr/tests/simple1/reference/clang-10/coverage.json
+++ b/gcovr/tests/simple1/reference/clang-10/coverage.json
@@ -1,7 +1,7 @@
 {
     "files": [
         {
-            "file": "main.cpp",
+            "file": "test/dir/main.cpp",
             "functions": [
                 {
                     "execution_count": 1,

--- a/gcovr/tests/simple1/reference/clang-10/summary_coverage.json
+++ b/gcovr/tests/simple1/reference/clang-10/summary_coverage.json
@@ -7,7 +7,7 @@
             "branch_covered": 2,
             "branch_percent": 50.0,
             "branch_total": 4,
-            "filename": "main.cpp",
+            "filename": "test/dir/main.cpp",
             "function_covered": 2,
             "function_percent": 100.0,
             "function_total": 2,

--- a/gcovr/tests/simple1/reference/clang-13/coverage.json
+++ b/gcovr/tests/simple1/reference/clang-13/coverage.json
@@ -1,7 +1,7 @@
 {
     "files": [
         {
-            "file": "main.cpp",
+            "file": "test/dir/main.cpp",
             "functions": [
                 {
                     "execution_count": 1,

--- a/gcovr/tests/simple1/reference/gcc-5/coverage.json
+++ b/gcovr/tests/simple1/reference/gcc-5/coverage.json
@@ -1,7 +1,7 @@
 {
     "files": [
         {
-            "file": "main.cpp",
+            "file": "test/dir/main.cpp",
             "functions": [
                 {
                     "execution_count": 1,

--- a/gcovr/tests/simple1/reference/gcc-5/summary_coverage.json
+++ b/gcovr/tests/simple1/reference/gcc-5/summary_coverage.json
@@ -7,7 +7,7 @@
             "branch_covered": 4,
             "branch_percent": 50.0,
             "branch_total": 8,
-            "filename": "main.cpp",
+            "filename": "test/dir/main.cpp",
             "function_covered": 2,
             "function_percent": 100.0,
             "function_total": 2,

--- a/gcovr/tests/simple1/reference/gcc-8/coverage.json
+++ b/gcovr/tests/simple1/reference/gcc-8/coverage.json
@@ -1,7 +1,7 @@
 {
     "files": [
         {
-            "file": "main.cpp",
+            "file": "test/dir/main.cpp",
             "functions": [
                 {
                     "execution_count": 1,

--- a/gcovr/tests/simple1/reference/gcc-8/summary_coverage.json
+++ b/gcovr/tests/simple1/reference/gcc-8/summary_coverage.json
@@ -7,7 +7,7 @@
             "branch_covered": 2,
             "branch_percent": 50.0,
             "branch_total": 4,
-            "filename": "main.cpp",
+            "filename": "test/dir/main.cpp",
             "function_covered": 2,
             "function_percent": 100.0,
             "function_total": 2,

--- a/gcovr/tests/test_gcovr.py
+++ b/gcovr/tests/test_gcovr.py
@@ -32,8 +32,10 @@ import zipfile
 
 from yaxmldiff import compare_xml
 
-python_interpreter = sys.executable.replace(
-    "\\", "/"
+from gcovr.utils import force_unix_separator
+
+python_interpreter = force_unix_separator(
+    sys.executable
 )  # use forward slash on windows as well
 env = os.environ
 env["GCOVR"] = python_interpreter + " -m gcovr"
@@ -118,8 +120,7 @@ def scrub_txt(contents):
 def scrub_csv(contents):
     contents = contents.replace("\r", "")
     contents = contents.replace("\n\n", "\n")
-    # Replace windows file separator for html reports generated in Windows
-    contents = contents.replace("\\", "/")
+    contents = force_unix_separator(contents)
     return contents
 
 
@@ -136,8 +137,7 @@ def scrub_html(contents):
     contents = RE_HTML_FOOTER_VERSION.sub("\\1 4.x\\2", contents)
     contents = RE_HTML_HEADER_DATE.sub("\\1>0000-00-00 00:00:00<\\2", contents)
     contents = contents.replace("\r", "")
-    # Replace windows file separator for html reports generated in Windows
-    contents = contents.replace("\\", "/")
+    contents = force_unix_separator(contents)
     return contents
 
 

--- a/gcovr/utils.py
+++ b/gcovr/utils.py
@@ -376,6 +376,10 @@ def open_binary_for_writing(filename=None, default_filename=None, **kwargs):
             fh.close()
 
 
+def force_unix_separator(path: str) -> str:
+    return path.replace("\\", "/")
+
+
 def presentable_filename(filename: str, root_filter: re.Pattern) -> str:
     """mangle a filename so that it is suitable for a report"""
 
@@ -390,4 +394,4 @@ def presentable_filename(filename: str, root_filter: re.Pattern) -> str:
         # at the beginning of the string
         normalized = filename
 
-    return normalized.replace("\\", "/")
+    return force_unix_separator(normalized)

--- a/gcovr/writer/cobertura.py
+++ b/gcovr/writer/cobertura.py
@@ -23,7 +23,7 @@ from typing import Dict
 from lxml import etree  # type: ignore
 
 from ..version import __version__
-from ..utils import open_binary_for_writing, presentable_filename
+from ..utils import force_unix_separator, open_binary_for_writing, presentable_filename
 from ..coverage import CovData, CoverageStat, LineCoverage, SummarizedStats
 
 
@@ -120,7 +120,9 @@ def print_cobertura_report(covdata: CovData, output_file, options):
         package.set("complexity", "0.0")
 
     # Populate the <sources> element: this is the root directory
-    etree.SubElement(sources, "source").text = options.root.strip().replace("\\", "/")
+    etree.SubElement(sources, "source").text = force_unix_separator(
+        options.root.strip()
+    )
 
     with open_binary_for_writing(output_file, "coverage.xml") as fh:
         fh.write(

--- a/gcovr/writer/html.py
+++ b/gcovr/writer/html.py
@@ -26,6 +26,7 @@ from typing import Callable, Optional, Union
 
 from ..version import __version__
 from ..utils import (
+    force_unix_separator,
     realpath,
     commonpath,
     sort_coverage,
@@ -220,7 +221,7 @@ class RootInfo:
         self.directory = directory
 
     def get_directory(self):
-        return "." if self.directory == "" else self.directory.replace("\\", "/")
+        return "." if self.directory == "" else force_unix_separator(self.directory)
 
     def set_coverage(self, covdata: CovData) -> None:
         """Update this RootInfo with a summary of the CovData."""
@@ -262,9 +263,9 @@ class RootInfo:
             "class": self._coverage_to_class(stats.decision.percent),
         }
 
-        display_filename = os.path.relpath(
-            realpath(cdata_fname), self.directory
-        ).replace("\\", "/")
+        display_filename = force_unix_separator(
+            os.path.relpath(realpath(cdata_fname), self.directory)
+        )
 
         if link_report is not None:
             if self.relative_anchors:

--- a/gcovr/writer/json.py
+++ b/gcovr/writer/json.py
@@ -66,7 +66,7 @@ def set_filename_function(options):
 
         def _get_filename(filename: str):
             filename = presentable_filename(filename, options.root_filter)
-            return os.path.join(options.json_base, filename)
+            return "/".join([options.json_base, filename])
 
     else:
 

--- a/gcovr/writer/txt.py
+++ b/gcovr/writer/txt.py
@@ -20,6 +20,7 @@
 from typing import Iterable, Tuple
 
 from ..utils import (
+    force_unix_separator,
     sort_coverage,
     presentable_filename,
     open_text_for_writing,
@@ -43,7 +44,7 @@ def print_text_report(covdata: CovData, output_file, options):
         fh.write("-" * LINE_WIDTH + "\n")
         fh.write("GCC Code Coverage Report".center(LINE_WIDTH).rstrip() + "\n")
         # fh.write(" " * 27 + "GCC Code Coverage Report\n")
-        fh.write("Directory: " + options.root.replace("\\", "/") + "\n")
+        fh.write("Directory: " + force_unix_separator(options.root) + "\n")
 
         fh.write("-" * LINE_WIDTH + "\n")
         title_total = "Branches" if options.show_branch else "Lines"


### PR DESCRIPTION
As suggested in #397 an option `--json-base` is added which is prepended to the file names in the JSON reports. The value is normalized first and `\`are replaced by `/`.

Closes #397 