### PR TITLE
Issue 684: Fix sorting of html reports when there are symlinks.

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -68,6 +68,7 @@ The following developers contributed to gcovr (ordered alphabetically):
     TFA-N,
     Thibault Gasc,
     Tilo Wiedera,
+    Tyler W. Mace,
     trapzero,
     Will Thompson,
     William Hart,

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,8 +24,8 @@ New features and notable changes:
 Bug fixes and small improvements:
 
 - Fix :option:`--html-tab-size` feature. (:issue:`650`)
-
 - Do not ignore returncode of `gcov`. (:issue:`653`)
+- Fix alphabetical sort of html report, for when there are symlinks. (:issue:`685`)
 
 Documentation:
 

--- a/gcovr/tests/linked/reference/clang-10/coverage.html
+++ b/gcovr/tests/linked/reference/clang-10/coverage.html
@@ -90,6 +90,22 @@
 
   <tr>
     <th scope="row">
+      <a href="coverage.file6.cpp.37f4b31e3e12086d7b0f11d140944edf.html">A/C/D/file6.cpp</a>
+    </th>
+    <td>
+      <meter class="coverage-medium" min="0" max="100" value="80.0" title="80.0%">80.0</meter>
+    </td>
+    <td class="CoverValue line-coverage coverage-medium">80.0%</td>
+    <td class="CoverValue line-coverage coverage-medium">4 / 5</td>
+    <td class="CoverValue function-coverage coverage-high">100.0%</td>
+    <td class="CoverValue function-coverage coverage-high">1 / 1</td>
+    <td class="CoverValue branch-coverage coverage-low">50.0%</td>
+    <td class="CoverValue branch-coverage coverage-low">1 / 2</td>
+  </tr>
+
+
+  <tr>
+    <th scope="row">
       <a href="coverage.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html">A/C/file5.cpp</a>
     </th>
     <td>
@@ -197,22 +213,6 @@
     <td class="CoverValue function-coverage coverage-high">1 / 1</td>
     <td class="CoverValue branch-coverage coverage-unknown">-%</td>
     <td class="CoverValue branch-coverage coverage-unknown">0 / 0</td>
-  </tr>
-
-
-  <tr>
-    <th scope="row">
-      <a href="coverage.file6.cpp.37f4b31e3e12086d7b0f11d140944edf.html">A/C/D/file6.cpp</a>
-    </th>
-    <td>
-      <meter class="coverage-medium" min="0" max="100" value="80.0" title="80.0%">80.0</meter>
-    </td>
-    <td class="CoverValue line-coverage coverage-medium">80.0%</td>
-    <td class="CoverValue line-coverage coverage-medium">4 / 5</td>
-    <td class="CoverValue function-coverage coverage-high">100.0%</td>
-    <td class="CoverValue function-coverage coverage-high">1 / 1</td>
-    <td class="CoverValue branch-coverage coverage-low">50.0%</td>
-    <td class="CoverValue branch-coverage coverage-low">1 / 2</td>
   </tr>
 
 </table>

--- a/gcovr/tests/linked/reference/gcc-5/coverage.html
+++ b/gcovr/tests/linked/reference/gcc-5/coverage.html
@@ -90,6 +90,22 @@
 
   <tr>
     <th scope="row">
+      <a href="coverage.file6.cpp.37f4b31e3e12086d7b0f11d140944edf.html">A/C/D/file6.cpp</a>
+    </th>
+    <td>
+      <meter class="coverage-medium" min="0" max="100" value="75.0" title="75.0%">75.0</meter>
+    </td>
+    <td class="CoverValue line-coverage coverage-medium">75.0%</td>
+    <td class="CoverValue line-coverage coverage-medium">3 / 4</td>
+    <td class="CoverValue function-coverage coverage-high">100.0%</td>
+    <td class="CoverValue function-coverage coverage-high">1 / 1</td>
+    <td class="CoverValue branch-coverage coverage-low">50.0%</td>
+    <td class="CoverValue branch-coverage coverage-low">1 / 2</td>
+  </tr>
+
+
+  <tr>
+    <th scope="row">
       <a href="coverage.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html">A/C/file5.cpp</a>
     </th>
     <td>
@@ -197,22 +213,6 @@
     <td class="CoverValue function-coverage coverage-high">1 / 1</td>
     <td class="CoverValue branch-coverage coverage-low">50.0%</td>
     <td class="CoverValue branch-coverage coverage-low">2 / 4</td>
-  </tr>
-
-
-  <tr>
-    <th scope="row">
-      <a href="coverage.file6.cpp.37f4b31e3e12086d7b0f11d140944edf.html">A/C/D/file6.cpp</a>
-    </th>
-    <td>
-      <meter class="coverage-medium" min="0" max="100" value="75.0" title="75.0%">75.0</meter>
-    </td>
-    <td class="CoverValue line-coverage coverage-medium">75.0%</td>
-    <td class="CoverValue line-coverage coverage-medium">3 / 4</td>
-    <td class="CoverValue function-coverage coverage-high">100.0%</td>
-    <td class="CoverValue function-coverage coverage-high">1 / 1</td>
-    <td class="CoverValue branch-coverage coverage-low">50.0%</td>
-    <td class="CoverValue branch-coverage coverage-low">1 / 2</td>
   </tr>
 
 </table>

--- a/gcovr/tests/linked/reference/gcc-8/coverage.html
+++ b/gcovr/tests/linked/reference/gcc-8/coverage.html
@@ -90,6 +90,22 @@
 
   <tr>
     <th scope="row">
+      <a href="coverage.file6.cpp.37f4b31e3e12086d7b0f11d140944edf.html">A/C/D/file6.cpp</a>
+    </th>
+    <td>
+      <meter class="coverage-medium" min="0" max="100" value="75.0" title="75.0%">75.0</meter>
+    </td>
+    <td class="CoverValue line-coverage coverage-medium">75.0%</td>
+    <td class="CoverValue line-coverage coverage-medium">3 / 4</td>
+    <td class="CoverValue function-coverage coverage-high">100.0%</td>
+    <td class="CoverValue function-coverage coverage-high">1 / 1</td>
+    <td class="CoverValue branch-coverage coverage-low">50.0%</td>
+    <td class="CoverValue branch-coverage coverage-low">1 / 2</td>
+  </tr>
+
+
+  <tr>
+    <th scope="row">
       <a href="coverage.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html">A/C/file5.cpp</a>
     </th>
     <td>
@@ -197,22 +213,6 @@
     <td class="CoverValue function-coverage coverage-high">1 / 1</td>
     <td class="CoverValue branch-coverage coverage-unknown">-%</td>
     <td class="CoverValue branch-coverage coverage-unknown">0 / 0</td>
-  </tr>
-
-
-  <tr>
-    <th scope="row">
-      <a href="coverage.file6.cpp.37f4b31e3e12086d7b0f11d140944edf.html">A/C/D/file6.cpp</a>
-    </th>
-    <td>
-      <meter class="coverage-medium" min="0" max="100" value="75.0" title="75.0%">75.0</meter>
-    </td>
-    <td class="CoverValue line-coverage coverage-medium">75.0%</td>
-    <td class="CoverValue line-coverage coverage-medium">3 / 4</td>
-    <td class="CoverValue function-coverage coverage-high">100.0%</td>
-    <td class="CoverValue function-coverage coverage-high">1 / 1</td>
-    <td class="CoverValue branch-coverage coverage-low">50.0%</td>
-    <td class="CoverValue branch-coverage coverage-low">1 / 2</td>
   </tr>
 
 </table>

--- a/gcovr/writer/html.py
+++ b/gcovr/writer/html.py
@@ -378,6 +378,7 @@ def print_html_report(covdata: CovData, output_file, options):
     keys = sort_coverage(
         covdata,
         show_branch=False,
+        filename_uses_relative_pathname=True,
         by_num_uncovered=options.sort_uncovered,
         by_percent_uncovered=options.sort_percent,
     )


### PR DESCRIPTION
This change fixes the sorting of html reports, for when there are symlinks within the nested directory structure. The sorting of filename will consider the absolute paths, which is already what it renders in the report with.

Note, since we only do the relative-path trick for the html report, we only make this sort-fix for the html report. The other reports are still showing the alternate path, as seen in the linked-txt test report.

Closes #684