### PR TITLE
Detect compiler version from gcc output if not specified.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
     - name: For a dry run, don't verify tags and documentation
       if: ${{ ! startsWith(github.event.ref, 'refs/tags/') }}
       run: |
-        echo EXTRA_CHECKLIST_ARGS="--no-verify-tags --no-verify-docs-next-version" >> $GITHUB_ENV
+        echo "EXTRA_CHECKLIST_ARGS=--no-verify-tags --no-verify-docs-next-version" >> $GITHUB_ENV
     - name: Run release_checklist
       run: |
         admin/release_checklist $EXTRA_CHECKLIST_ARGS 5.2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
         admin/release_checklist $EXTRA_CHECKLIST_ARGS 5.2
 
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: release-check
 
     env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ env.PYTHON_VERSION }}
     - name: Cache pip

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
     continue-on-error: ${{ startsWith(github.event.ref,'refs/heads/') }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: fetch all tags  # need annotated tags for release checklist
       run: |
         git fetch --force --tags --depth=1
@@ -37,13 +37,13 @@ jobs:
       CC: "gcc-8"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ env.PYTHON_VERSION }}
     - name: Cache pip
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         # This path is specific to Ubuntu
         path: ~/.cache/pip
@@ -82,7 +82,7 @@ jobs:
         nox --non-interactive --session build_wheel
     - name: Upload distribution
       if: ${{ success() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: dist
         path: dist/**

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,7 +140,7 @@ jobs:
     - name: Install ninja
       uses: seanmiddleditch/gha-setup-ninja@master
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       PR_MILESTONE: "${{ github.event.pull_request.milestone.number }}"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Check if PR is assigned to a milestone
       if: ${{ github.event_name == 'pull_request' }}
       run: |
@@ -37,7 +37,7 @@ jobs:
       CHANGELOG_ISSUE: ":issue:`${{ github.event.pull_request.number }}`"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Check if PR is mentioned in changelog
       if: ${{ always() }}
       run: |
@@ -113,7 +113,7 @@ jobs:
             python-version: '3.10'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup environment
       run: |
         # Enable coverage for specific target configurations
@@ -143,11 +143,11 @@ jobs:
     - name: Install ninja
       uses: seanmiddleditch/gha-setup-ninja@master
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache pip
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         # This path is specific to Ubuntu
         path: ~/.cache/pip
@@ -166,7 +166,7 @@ jobs:
         nox --non-interactive --session "tests_compiler(${{ matrix.gcc }})" -- --archive_differences
     - name: Upload pytest test results
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: diffs-${{ matrix.os }}-${{ matrix.gcc }}-${{ matrix.python-version }}
         path: gcovr/tests/diff.zip
@@ -195,7 +195,7 @@ jobs:
     - name: Install dependencies
       run: |
         python3 -m pip install nox
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build Docker
       run: |
         python3 -m nox --non-interactive --session "docker_qa_build_compiler(${{ matrix.gcc }})"
@@ -204,7 +204,7 @@ jobs:
         python3 -m nox --non-interactive --session "docker_qa_run_compiler(${{ matrix.gcc }})"
     - name: Upload pytest test results
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: diffs-docker-${{ matrix.gcc }}
         path: gcovr/tests/diff.zip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,7 +119,7 @@ jobs:
           ubuntu-20.04/gcc-9/3.9) USE_COVERAGE=true ;;
           *)                      USE_COVERAGE=false ;;
         esac
-        echo USE_COVERAGE=$USE_COVERAGE >> $GITHUB_ENV
+        echo "USE_COVERAGE=$USE_COVERAGE" >> $GITHUB_ENV
       shell: bash
     - name: Install msys with GCC (Windows)
       if: ${{ startsWith(matrix.os,'windows-') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
 jobs:
 
   milestone-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     continue-on-error: true
 
@@ -30,7 +30,7 @@ jobs:
         exit 0
 
   changelog-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     env:
       PR_BODY: "${{ github.event.pull_request.body }}"
@@ -93,15 +93,12 @@ jobs:
         include:
 
           # Test additional compilers with Linux.
-          # Note that Clang-10 and Clang-13 is handled via Docker.
-          - os: ubuntu-18.04
-            gcc: gcc-5
-            python-version: '3.8'
-          - os: ubuntu-18.04
-            gcc: gcc-6
-            python-version: '3.8'
+          # Note that gcc-5, gcc-6, clang-10 and clang-13 is handled via Docker.
           - os: ubuntu-20.04
             gcc: gcc-9
+            python-version: '3.9'
+          - os: ubuntu-22.04
+            gcc: gcc-11
             python-version: '3.10'
 
           # Test minimum and maximum Python version on Windows.
@@ -119,7 +116,7 @@ jobs:
         # Enable coverage for specific target configurations
         case "${{ matrix.os }}/${{ matrix.gcc }}/${{ matrix.python-version }}" in
           windows-2019/gcc-8/3.7) USE_COVERAGE=true ;;
-          ubuntu-18.04/gcc-6/3.8) USE_COVERAGE=true ;;
+          ubuntu-20.04/gcc-9/3.9) USE_COVERAGE=true ;;
           *)                      USE_COVERAGE=false ;;
         esac
         echo USE_COVERAGE=$USE_COVERAGE >> $GITHUB_ENV
@@ -183,7 +180,7 @@ jobs:
         make doc
 
   run-docker:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     needs: [milestone-check, changelog-check]
 
     strategy:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,7 +24,6 @@ New features and notable changes:
 Bug fixes and small improvements:
 
 - Fix :option:`--html-tab-size` feature. (:issue:`650`)
-
 - Do not ignore returncode of `gcov`. (:issue:`653`)
 
 Documentation:
@@ -33,6 +32,7 @@ Internal changes:
 
 - Select the :option:`--html-theme` using CSS classes. (:issue:`650`)
 - Change and extend ``cmake`` tests. (:issue:`676`)
+- Detect the verion of the ``gcc``. (:issue:`686`)
 
 5.2 (06 August 2022)
 --------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,7 +32,7 @@ Internal changes:
 
 - Select the :option:`--html-theme` using CSS classes. (:issue:`650`)
 - Change and extend ``cmake`` tests. (:issue:`676`)
-- Detect the verion of the ``gcc``. (:issue:`686`)
+- Detect ``gcc`` version for running tests. (:issue:`686`)
 
 5.2 (06 August 2022)
 --------------------

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -144,8 +144,8 @@ How to set up a development environment
 ---------------------------------------
 
 For working on gcovr, you will need a supported version of Python 3,
-GCC version 5, 6 or 8 (other GCC versions are supported by gcovr,
-but will cause spurious test failures) or clang version 10, ``make``,
+GCC version 5, 6, 8, 9, 10 and 11 (other GCC versions are supported by gcovr,
+but will cause spurious test failures) or clang version 10 and 13, ``make``,
 ``cmake`` and ``ninja``.
 Please make sure that the tools are in the system ``PATH``.
 On **Windows**, you will need to install a GCC toolchain as the
@@ -168,11 +168,12 @@ is needed.
     -  clang-13/clang++-13/llvm-cov
 
     are available everything is OK.
-    For gcc-6, gcc-8, gcc-9, gcc-10, gcc-11, clang-10 and clang-13 you should use the
-    option ``CC=...`` see :ref:`run and filter tests <run tests>`.
-    If this isn't OK you
-    can set the reference data to use by setting the environment ``CC_REFERENCE=gcc-8``
-    or you have to create symlinks for the gcc executables with the following steps.
+    The test suite uses the newest GCC found in the PATH. To use another one you
+    need to set the environment ``CC=...`` see
+    :ref:`run and filter tests <run tests>`.
+    If you only have ``gcc`` in your path the version is detected to select the
+    correct reference.
+    You can also create symlinks for the gcc executables with the following steps.
     You can check the GCC version with gcc --version. If the output says
     version 8, you should also be able to run gcc-8 --version. Your Linux
     distribution should have set all of this up already.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -144,8 +144,8 @@ How to set up a development environment
 ---------------------------------------
 
 For working on gcovr, you will need a supported version of Python 3,
-GCC version 5, 6, 8, 9, 10 and 11 (other GCC versions are supported by gcovr,
-but will cause spurious test failures) or clang version 10 and 13, ``make``,
+GCC version 5, 6, 8, 9, 10 or 11 (other GCC versions are supported by gcovr,
+but will cause spurious test failures) or clang version 10 or 13, ``make``,
 ``cmake`` and ``ninja``.
 Please make sure that the tools are in the system ``PATH``.
 On **Windows**, you will need to install a GCC toolchain as the

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -34,4 +34,4 @@ Operating System:
 Compiler:
     GCC and Clang.
 
-    The automated tests run on GCC 5, 6, and 8.
+    The automated tests run on GCC 5, 6, 8, 9, 10, 11 and clang 10 and 13.

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -29,7 +29,7 @@ Python:
 Operating System:
     Linux, Windows, and macOS.
 
-    The automated tests run on Ubuntu 18.04 and 20.04 and Windows Server 2019.
+    The automated tests run on Ubuntu 20.04, 22.04 and Windows Server 2019.
 
 Compiler:
     GCC and Clang.

--- a/gcovr/tests/test_gcovr.py
+++ b/gcovr/tests/test_gcovr.py
@@ -307,6 +307,14 @@ def pytest_generate_tests(metafunc):
                     reason="On MacOS the constructor is called twice",
                 ),
                 pytest.mark.xfail(
+                    name in ["decisions-neg-delta"] and IS_MACOS,
+                    reason="On MacOS there is no branch for std::vector",
+                ),
+                pytest.mark.xfail(
+                    name in ["excl-line-branch"] and IS_MACOS,
+                    reason="On MacOS there are different number of branches generated",
+                ),
+                pytest.mark.xfail(
                     name == "gcc-abspath"
                     and (
                         not env["CC"].startswith("gcc-")


### PR DESCRIPTION
This PR selects the latest GCC version on the system for the tests. If only `gcc` is available the version is detected from the output of `gcc --version`.

If using `qa_compiler` session the default is switched from `gcc-5` to `gcc-11` (the current latest version for the reference data).