### PR TITLE
Handle option `--version` before parsing config file.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,7 @@ Bug fixes and small improvements:
 - Fix :option:`--html-tab-size` feature. (:issue:`650`)
 - Do not ignore returncode of `gcov`. (:issue:`653`)
 - Fix alphabetical sort of html report, for when there are symlinks. (:issue:`685`)
+- Handle :option:`--version` before parsing the configuration file. (:issue:`696`)
 
 Documentation:
 

--- a/gcovr/__main__.py
+++ b/gcovr/__main__.py
@@ -116,6 +116,7 @@ def create_argument_parser():
     )
     options.add_argument(
         "--version",
+        config=False,
         help="Print the version number, then exit.",
         action="store_true",
         dest="version",
@@ -162,6 +163,10 @@ def main(args=None):
     parser = create_argument_parser()
     cli_options = parser.parse_args(args=args)
 
+    if cli_options.version:
+        sys.stdout.write(f"gcovr {__version__}\n\n{COPYRIGHT}")
+        sys.exit(0)
+
     # load the config
     cfg_name = find_config_name(cli_options)
     cfg_options = {}
@@ -176,10 +181,6 @@ def main(args=None):
 
     if options.verbose:
         logger.setLevel(logging.DEBUG)
-
-    if cli_options.version:
-        sys.stdout.write(f"gcovr {__version__}\n\n{COPYRIGHT}")
-        sys.exit(0)
 
     if options.html_title == "":
         logger.error("an empty --html_title= is not allowed.")

--- a/gcovr/__main__.py
+++ b/gcovr/__main__.py
@@ -116,7 +116,6 @@ def create_argument_parser():
     )
     options.add_argument(
         "--version",
-        config=False,
         help="Print the version number, then exit.",
         action="store_true",
         dest="version",


### PR DESCRIPTION
If a gcovr.cfg is in the project directory and you run `gcovr --version` the configuration file is read first. This can result in an error.

Closes #695