### PR TITLE
Install ninja in CI with package manager

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,17 +52,19 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('noxfile.py', 'doc/requirements.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-
-    - name: Install GCC
+    - name: Install build commands and GCC
       run: |
         sudo apt update
-        sudo apt-get install -y make $CC $(echo $CC | sed -e 's/gcc/g\+\+/')
+        sudo apt-get install -y \
+          make \
+          ninja-build \
+          $CC \
+          $(echo $CC | sed -e 's/gcc/g\+\+/')
         sudo apt-get clean
     - name: Install libxml2
       run: |
         sudo apt-get install -y libxml2-utils
         sudo apt-get clean
-    - name: Install ninja
-      uses: seanmiddleditch/gha-setup-ninja@master
     - name: Install dependencies
       run: |
         python -m pip install nox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,19 +129,26 @@ jobs:
       uses: msys2/setup-msys2@v2
       with:
         install: gcc make
-    - name: Install GCC (Linux)
+    - name: Install ninja (Windows)
+      if: ${{ startsWith(matrix.os,'windows-') }}
+      run: |
+        choco install ninja
+    - name: Install build commands and GCC (Linux)
       if: ${{ startsWith(matrix.os,'ubuntu-') }}
       run: |
         sudo apt update
-        sudo apt-get install -y make ${{ matrix.gcc }} $(echo ${{ matrix.gcc }} | sed -e 's/gcc/g\+\+/')
+        sudo apt-get install -y \
+          make \
+          ninja-build \
+          ${{ matrix.gcc }} \
+          $(echo ${{ matrix.gcc }} | sed -e 's/gcc/g\+\+/')
         sudo apt-get clean
     - name: Install libxml2
       if: ${{ startsWith(matrix.os,'ubuntu-') }}
       run: |
-        sudo apt-get install -y libxml2-utils
+        sudo apt-get install -y \
+          libxml2-utils
         sudo apt-get clean
-    - name: Install ninja
-      uses: seanmiddleditch/gha-setup-ninja@master
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,7 +41,8 @@ Internal changes:
 - Select the :option:`--html-theme` using CSS classes. (:issue:`650`)
 - Change and extend ``cmake`` tests. (:issue:`676`)
 - Detect ``gcc`` version for running tests. (:issue:`686`)
-- Use scrubbed data for ``--update_reference`` option (:issue:`698`)
+- Use scrubbed data for ``--update_reference`` option. (:issue:`698`)
+- Install ninja with package manager instead of GitHub action. (:issue:`699`)
 
 5.2 (06 August 2022)
 --------------------


### PR DESCRIPTION
In the CI there is the following warning:

```
Node.js 12 actions are deprecated. For more information see:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
Please update the following actions to use Node.js 16: seanmiddleditch/gha-setup-ninja@master
```

There is now response for https://github.com/seanmiddleditch/gha-setup-ninja/pull/15 since nearly two months. To get rid of the warning we install it now with the package manager.

