### PR TITLE
Allow annotations for not executed branches.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ New features and notable changes:
 - Print a warning if root directory contains symlinks. (:issue:`652`)
 - New :option:`--no-exclude-noncode-lines` to not exclude noncode lines. (:issue:`704`)
 - Change :option:`--keep` when calling gcov internaly. (:issue:`703`)
+- Allow annotations for never executed branches. (:issue:`711`)
 
 Bug fixes and small improvements:
 

--- a/gcovr/gcov_parser.py
+++ b/gcovr/gcov_parser.py
@@ -94,7 +94,7 @@ _RE_FUNCTION_LINE = _line_pattern(
     r"function (.*?) called (INT) returned (VALUE) blocks executed (VALUE)"
 )
 _RE_BRANCH_LINE = _line_pattern(
-    r"branch (INT) (?:taken (VALUE)(?: \((\w+)\))?|never executed)"
+    r"branch (INT) (?:taken (VALUE)|never executed)(?: \((\w+)\))?"
 )
 _RE_CALL_LINE = _line_pattern(r"call (INT) (?:returned (VALUE)|never executed)")
 _RE_UNCONDITIONAL_LINE = _line_pattern(
@@ -535,6 +535,8 @@ def _parse_line(line: str) -> _Line:
     _BranchLine(branchno=17, hits=1, annotation='throw')
     >>> _parse_line('branch  0 never executed')
     _BranchLine(branchno=0, hits=0, annotation=None)
+    >>> _parse_line('branch  0 never executed (fallthrough)')
+    _BranchLine(branchno=0, hits=0, annotation='fallthrough')
     >>> _parse_line('branch 2 with some unknown format')
     Traceback (most recent call last):
     gcovr.gcov_parser.UnknownLineType: branch 2 with some unknown format


### PR DESCRIPTION
Since the patch discussed in #677 is merged to latest `gcc` thwe output is not recognized by `gcovr` anymore (#710).

This PR allows the annotations also for not executed branches and a doctest is added for this new case.

Closes #710 