### PR TITLE
Add python 3.11 to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,7 +91,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         gcc: [gcc-8]
-        python-version: ['3.8', '3.9', '3.10', 'pypy-3.7'] # 3.7 is used in Docker
+        python-version: ['3.8', '3.9', '3.10', '3.11', 'pypy-3.7'] # 3.7 is used in Docker
 
         include:
 
@@ -102,7 +102,7 @@ jobs:
             python-version: '3.9'
           - os: ubuntu-22.04
             gcc: gcc-11
-            python-version: '3.10'
+            python-version: '3.11'
 
           # Test minimum and maximum Python version on Windows.
           - os: windows-2019
@@ -110,7 +110,7 @@ jobs:
             python-version: '3.7'
           - os: windows-2019
             gcc: gcc-8
-            python-version: '3.10'
+            python-version: '3.11'
 
     steps:
     - uses: actions/checkout@v3

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,8 @@ Bug fixes and small improvements:
 - Fix handling for nonexistent source code for HTML-details and Coveralls reports (:issue:`663`)
 - Exclude functions with :ref:`Exclusion markers` (:issue:`713`)
 - Fix problem in decision parser if open block brace is on same line. (:issue:`681`)
+- Add Python 3.11 to test matrix. (:issue:`717`)
+
 
 Documentation:
 


### PR DESCRIPTION
Add python 3.11 to our test matrix and update the special test combinations which use 3.10 to 3.11.