### PR TITLE
Fix deadlog on gcov error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,7 @@ Bug fixes and small improvements:
 - Fix problem in decision parser if open block brace is on same line. (:issue:`681`)
 - Add Python 3.11 to test matrix. (:issue:`717`)
 - Fix casing of files if filesystem is case insensitive. (:issue:`694`)
+- Fix deadlock if :option:`-j` is used and there are errors from ``gcov`` execution. (:issue:`719`)
 
 Documentation:
 

--- a/gcovr/workers.py
+++ b/gcovr/workers.py
@@ -56,9 +56,14 @@ def locked_directory(dir_):
     """
     Context for doing something in a locked directory
     """
-    locked_directory.global_object.run_in(dir_)
-    yield
-    locked_directory.global_object.done(dir_)
+    try:
+        locked_directory.global_object.run_in(dir_)
+        yield
+        locked_directory.global_object.done(dir_)
+    except Exception:
+        # unlock the directory and reraise the exception.
+        locked_directory.global_object.done(dir_)
+        raise
 
 
 locked_directory.global_object = LockedDirectories()


### PR DESCRIPTION
If `gcovr` is lcalled with `--jobs` and the `gcov` command fails we stay stuck. I reproduced this by adding a unknown option to the `gcov` execution.
As mentioned in https://github.com/gcovr/gcovr/issues/673#issuecomment-1255427992 the problem was the directory lock. This PR catches the exception which can occur in the yield, unlocks the directory and reraise the exception. 

Closes #673