### PR TITLE
Rework exception handling as described in #719

### DIFF
--- a/gcovr/workers.py
+++ b/gcovr/workers.py
@@ -56,14 +56,11 @@ def locked_directory(dir_):
     """
     Context for doing something in a locked directory
     """
+    locked_directory.global_object.run_in(dir_)
     try:
-        locked_directory.global_object.run_in(dir_)
         yield
+    finally:
         locked_directory.global_object.done(dir_)
-    except Exception:
-        # unlock the directory and reraise the exception.
-        locked_directory.global_object.done(dir_)
-        raise
 
 
 locked_directory.global_object = LockedDirectories()


### PR DESCRIPTION
In https://github.com/gcovr/gcovr/pull/719#discussion_r1112973194 a easier way for the exception handling is defined. This PR changes the handling to use a  `finally` block.

[no changelog]