### PR TITLE
Compare files by extension.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -63,6 +63,7 @@ Internal changes:
 - Install ninja with package manager instead of GitHub action. (:issue:`699`)
 - Rename the reference files coverage.xml to cobertura.xml and the test from xml to cobertura (:issue:`721`)
 - Add support for ``clang-14`` in our test suite and improve startup performance of docker image. (:issue:`731`)
+- Compare files by extension in test suite. (:issue:`733`)
 
 5.2 (06 August 2022)
 --------------------

--- a/doc/examples/example_html.details.example.cpp.9597a7a3397b8e3a48116e2a3afb4154.html
+++ b/doc/examples/example_html.details.example.cpp.9597a7a3397b8e3a48116e2a3afb4154.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="example_html.details.css">
+    <link rel="stylesheet" href="example_html.details.css"/>
   </head>
 
   <body>

--- a/doc/examples/example_html.details.functions.html
+++ b/doc/examples/example_html.details.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="example_html.details.css">
+    <link rel="stylesheet" href="example_html.details.css"/>
   </head>
 
   <body>

--- a/doc/examples/example_html.details.html
+++ b/doc/examples/example_html.details.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="example_html.details.css">
+    <link rel="stylesheet" href="example_html.details.css"/>
   </head>
 
   <body>

--- a/doc/examples/test_examples.py
+++ b/doc/examples/test_examples.py
@@ -24,7 +24,7 @@ import pytest
 import subprocess
 import sys
 
-from gcovr.tests.test_gcovr import SCRUBBERS, ASSERT_EQUALS
+from gcovr.tests.test_gcovr import SCRUBBERS, assert_equals
 
 IS_MACOS = platform.system() == "Darwin"
 
@@ -75,17 +75,13 @@ def test_example(example):
     baseline_file = example.baseline
     ext = os.path.splitext(baseline_file)[1][1:]
     scrub = SCRUBBERS[ext]
-    assert_equals = ASSERT_EQUALS.get(ext, None)
 
     startdir = os.getcwd()
     os.chdir(datadir)
     output = scrub(subprocess.check_output(cmd).decode().replace("\r\n", "\n"))
     with open(baseline_file) as f:
         baseline = scrub(f.read())
-    if assert_equals is not None:
-        assert_equals(output, baseline)
-    else:
-        assert output == baseline
+    assert_equals(baseline_file, baseline, None, output)
     os.chdir(startdir)
 
 

--- a/doc/examples/test_examples.py
+++ b/doc/examples/test_examples.py
@@ -81,7 +81,7 @@ def test_example(example):
     output = scrub(subprocess.check_output(cmd).decode().replace("\r\n", "\n"))
     with open(baseline_file) as f:
         baseline = scrub(f.read())
-    assert_equals(baseline_file, baseline, None, output)
+    assert_equals(baseline_file, baseline, "<STDOUT>", output, encoding="utf8")
     os.chdir(startdir)
 
 

--- a/gcovr/tests/add_coverages/reference/clang-10/coverage.bar.cpp.e7a3224e852d4c9e084f9127df0315df.html
+++ b/gcovr/tests/add_coverages/reference/clang-10/coverage.bar.cpp.e7a3224e852d4c9e084f9127df0315df.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/add_coverages/reference/clang-10/coverage.foo.cpp.da858f18e0c3a73a7b98ff456723b9ae.html
+++ b/gcovr/tests/add_coverages/reference/clang-10/coverage.foo.cpp.da858f18e0c3a73a7b98ff456723b9ae.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/add_coverages/reference/clang-10/coverage.html
+++ b/gcovr/tests/add_coverages/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/add_coverages/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/add_coverages/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/add_coverages/reference/clang-13/coverage.bar.cpp.e7a3224e852d4c9e084f9127df0315df.html
+++ b/gcovr/tests/add_coverages/reference/clang-13/coverage.bar.cpp.e7a3224e852d4c9e084f9127df0315df.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/add_coverages/reference/clang-13/coverage.foo.cpp.da858f18e0c3a73a7b98ff456723b9ae.html
+++ b/gcovr/tests/add_coverages/reference/clang-13/coverage.foo.cpp.da858f18e0c3a73a7b98ff456723b9ae.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/add_coverages/reference/gcc-5/coverage.bar.cpp.e7a3224e852d4c9e084f9127df0315df.html
+++ b/gcovr/tests/add_coverages/reference/gcc-5/coverage.bar.cpp.e7a3224e852d4c9e084f9127df0315df.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/add_coverages/reference/gcc-5/coverage.foo.cpp.da858f18e0c3a73a7b98ff456723b9ae.html
+++ b/gcovr/tests/add_coverages/reference/gcc-5/coverage.foo.cpp.da858f18e0c3a73a7b98ff456723b9ae.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/add_coverages/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/add_coverages/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/add_coverages/reference/gcc-5/coverage.html
+++ b/gcovr/tests/add_coverages/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/add_coverages/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/add_coverages/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/add_coverages/reference/gcc-8/coverage.functions.html
+++ b/gcovr/tests/add_coverages/reference/gcc-8/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/add_coverages/reference/gcc-8/coverage.html
+++ b/gcovr/tests/add_coverages/reference/gcc-8/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/add_coverages/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/add_coverages/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/bad++char/reference/clang-10/coverage.html
+++ b/gcovr/tests/bad++char/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/bad++char/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/bad++char/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/bad++char/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/bad++char/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/bad++char/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/bad++char/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/bad++char/reference/gcc-5/coverage.html
+++ b/gcovr/tests/bad++char/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/bad++char/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/bad++char/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/bad++char/reference/gcc-8/coverage.functions.html
+++ b/gcovr/tests/bad++char/reference/gcc-8/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/bad++char/reference/gcc-8/coverage.html
+++ b/gcovr/tests/bad++char/reference/gcc-8/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/bad++char/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/bad++char/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/calls/reference/clang-10/coverage.callcov.c.36709b3fa42dd955fc97329aec8b8b80.html
+++ b/gcovr/tests/calls/reference/clang-10/coverage.callcov.c.36709b3fa42dd955fc97329aec8b8b80.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/calls/reference/clang-10/coverage.functions.html
+++ b/gcovr/tests/calls/reference/clang-10/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/calls/reference/clang-10/coverage.html
+++ b/gcovr/tests/calls/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/calls/reference/clang-13/coverage.callcov.c.36709b3fa42dd955fc97329aec8b8b80.html
+++ b/gcovr/tests/calls/reference/clang-13/coverage.callcov.c.36709b3fa42dd955fc97329aec8b8b80.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/calls/reference/clang-13/coverage.functions.html
+++ b/gcovr/tests/calls/reference/clang-13/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/calls/reference/clang-13/coverage.html
+++ b/gcovr/tests/calls/reference/clang-13/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/calls/reference/gcc-5/coverage.callcov.c.36709b3fa42dd955fc97329aec8b8b80.html
+++ b/gcovr/tests/calls/reference/gcc-5/coverage.callcov.c.36709b3fa42dd955fc97329aec8b8b80.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/calls/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/calls/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/calls/reference/gcc-5/coverage.html
+++ b/gcovr/tests/calls/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/cmake_gtest/reference/clang-10/coverage.code.cpp.c512e29b00c3de6c3caa92cc341d9cb0.html
+++ b/gcovr/tests/cmake_gtest/reference/clang-10/coverage.code.cpp.c512e29b00c3de6c3caa92cc341d9cb0.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/cmake_gtest/reference/clang-10/coverage.functions.html
+++ b/gcovr/tests/cmake_gtest/reference/clang-10/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/cmake_gtest/reference/clang-10/coverage.html
+++ b/gcovr/tests/cmake_gtest/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/cmake_gtest/reference/clang-13/coverage.code.cpp.c512e29b00c3de6c3caa92cc341d9cb0.html
+++ b/gcovr/tests/cmake_gtest/reference/clang-13/coverage.code.cpp.c512e29b00c3de6c3caa92cc341d9cb0.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/cmake_gtest/reference/clang-13/coverage.functions.html
+++ b/gcovr/tests/cmake_gtest/reference/clang-13/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/cmake_gtest/reference/gcc-5/coverage.code.cpp.c512e29b00c3de6c3caa92cc341d9cb0.html
+++ b/gcovr/tests/cmake_gtest/reference/gcc-5/coverage.code.cpp.c512e29b00c3de6c3caa92cc341d9cb0.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/cmake_gtest/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/cmake_gtest/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/cmake_gtest/reference/gcc-5/coverage.html
+++ b/gcovr/tests/cmake_gtest/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/cmake_oos/reference/clang-10/coverage.html
+++ b/gcovr/tests/cmake_oos/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/cmake_oos/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/cmake_oos/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/cmake_oos/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/cmake_oos/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/cmake_oos/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/cmake_oos/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/cmake_oos/reference/gcc-5/coverage.html
+++ b/gcovr/tests/cmake_oos/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/cmake_oos/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/cmake_oos/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/cmake_oos/reference/gcc-8/coverage.functions.html
+++ b/gcovr/tests/cmake_oos/reference/gcc-8/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/cmake_oos/reference/gcc-8/coverage.html
+++ b/gcovr/tests/cmake_oos/reference/gcc-8/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/cmake_oos/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/cmake_oos/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/cmake_oos_ninja/reference/clang-10/coverage.html
+++ b/gcovr/tests/cmake_oos_ninja/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/cmake_oos_ninja/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/cmake_oos_ninja/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/cmake_oos_ninja/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/cmake_oos_ninja/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/cmake_oos_ninja/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/cmake_oos_ninja/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/cmake_oos_ninja/reference/gcc-5/coverage.html
+++ b/gcovr/tests/cmake_oos_ninja/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/cmake_oos_ninja/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/cmake_oos_ninja/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/cmake_oos_ninja/reference/gcc-8/coverage.functions.html
+++ b/gcovr/tests/cmake_oos_ninja/reference/gcc-8/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/cmake_oos_ninja/reference/gcc-8/coverage.html
+++ b/gcovr/tests/cmake_oos_ninja/reference/gcc-8/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/cmake_oos_ninja/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/cmake_oos_ninja/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/decisions-neg-delta/reference/clang-10/coverage.functions.html
+++ b/gcovr/tests/decisions-neg-delta/reference/clang-10/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/decisions-neg-delta/reference/clang-10/coverage.html
+++ b/gcovr/tests/decisions-neg-delta/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/decisions-neg-delta/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/decisions-neg-delta/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/decisions-neg-delta/reference/clang-13/coverage.functions.html
+++ b/gcovr/tests/decisions-neg-delta/reference/clang-13/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/decisions-neg-delta/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/decisions-neg-delta/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/decisions-neg-delta/reference/gcc-11/coverage.functions.html
+++ b/gcovr/tests/decisions-neg-delta/reference/gcc-11/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/decisions-neg-delta/reference/gcc-11/coverage.html
+++ b/gcovr/tests/decisions-neg-delta/reference/gcc-11/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/decisions-neg-delta/reference/gcc-11/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/decisions-neg-delta/reference/gcc-11/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/decisions-neg-delta/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/decisions-neg-delta/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/decisions-neg-delta/reference/gcc-5/coverage.html
+++ b/gcovr/tests/decisions-neg-delta/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/decisions-neg-delta/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/decisions-neg-delta/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/decisions-neg-delta/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/decisions-neg-delta/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/decisions/reference/clang-10/coverage.functions.html
+++ b/gcovr/tests/decisions/reference/clang-10/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/decisions/reference/clang-10/coverage.html
+++ b/gcovr/tests/decisions/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/decisions/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/decisions/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/decisions/reference/clang-13/coverage.functions.html
+++ b/gcovr/tests/decisions/reference/clang-13/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/decisions/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/decisions/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/decisions/reference/gcc-11/coverage.functions.html
+++ b/gcovr/tests/decisions/reference/gcc-11/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/decisions/reference/gcc-11/coverage.html
+++ b/gcovr/tests/decisions/reference/gcc-11/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/decisions/reference/gcc-11/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/decisions/reference/gcc-11/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/decisions/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/decisions/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/decisions/reference/gcc-5/coverage.html
+++ b/gcovr/tests/decisions/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/decisions/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/decisions/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/decisions/reference/gcc-8/coverage.functions.html
+++ b/gcovr/tests/decisions/reference/gcc-8/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/decisions/reference/gcc-8/coverage.html
+++ b/gcovr/tests/decisions/reference/gcc-8/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/decisions/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/decisions/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-separate/reference/clang-10/coverage.func.h.c6674364b75880bb30795cbac2760636.html
+++ b/gcovr/tests/different-function-lines-separate/reference/clang-10/coverage.func.h.c6674364b75880bb30795cbac2760636.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-separate/reference/clang-10/coverage.functions.html
+++ b/gcovr/tests/different-function-lines-separate/reference/clang-10/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-separate/reference/clang-10/coverage.html
+++ b/gcovr/tests/different-function-lines-separate/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-separate/reference/clang-10/coverage.main.c.2045016cb90d1e65d71c2407a2570927.html
+++ b/gcovr/tests/different-function-lines-separate/reference/clang-10/coverage.main.c.2045016cb90d1e65d71c2407a2570927.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-separate/reference/clang-13/coverage.func.h.c6674364b75880bb30795cbac2760636.html
+++ b/gcovr/tests/different-function-lines-separate/reference/clang-13/coverage.func.h.c6674364b75880bb30795cbac2760636.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-separate/reference/clang-13/coverage.functions.html
+++ b/gcovr/tests/different-function-lines-separate/reference/clang-13/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-separate/reference/gcc-5/coverage.func.h.c6674364b75880bb30795cbac2760636.html
+++ b/gcovr/tests/different-function-lines-separate/reference/gcc-5/coverage.func.h.c6674364b75880bb30795cbac2760636.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-separate/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/different-function-lines-separate/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-separate/reference/gcc-5/coverage.html
+++ b/gcovr/tests/different-function-lines-separate/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-separate/reference/gcc-5/coverage.main.c.2045016cb90d1e65d71c2407a2570927.html
+++ b/gcovr/tests/different-function-lines-separate/reference/gcc-5/coverage.main.c.2045016cb90d1e65d71c2407a2570927.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-use-0/reference/clang-10/coverage.func.h.c6674364b75880bb30795cbac2760636.html
+++ b/gcovr/tests/different-function-lines-use-0/reference/clang-10/coverage.func.h.c6674364b75880bb30795cbac2760636.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-use-0/reference/clang-10/coverage.functions.html
+++ b/gcovr/tests/different-function-lines-use-0/reference/clang-10/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-use-0/reference/clang-10/coverage.html
+++ b/gcovr/tests/different-function-lines-use-0/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-use-0/reference/clang-10/coverage.main.c.2045016cb90d1e65d71c2407a2570927.html
+++ b/gcovr/tests/different-function-lines-use-0/reference/clang-10/coverage.main.c.2045016cb90d1e65d71c2407a2570927.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-use-0/reference/clang-13/coverage.func.h.c6674364b75880bb30795cbac2760636.html
+++ b/gcovr/tests/different-function-lines-use-0/reference/clang-13/coverage.func.h.c6674364b75880bb30795cbac2760636.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-use-0/reference/clang-13/coverage.functions.html
+++ b/gcovr/tests/different-function-lines-use-0/reference/clang-13/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-use-0/reference/gcc-5/coverage.func.h.c6674364b75880bb30795cbac2760636.html
+++ b/gcovr/tests/different-function-lines-use-0/reference/gcc-5/coverage.func.h.c6674364b75880bb30795cbac2760636.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-use-0/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/different-function-lines-use-0/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-use-0/reference/gcc-5/coverage.html
+++ b/gcovr/tests/different-function-lines-use-0/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-use-0/reference/gcc-5/coverage.main.c.2045016cb90d1e65d71c2407a2570927.html
+++ b/gcovr/tests/different-function-lines-use-0/reference/gcc-5/coverage.main.c.2045016cb90d1e65d71c2407a2570927.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-use-max/reference/clang-10/coverage.func.h.c6674364b75880bb30795cbac2760636.html
+++ b/gcovr/tests/different-function-lines-use-max/reference/clang-10/coverage.func.h.c6674364b75880bb30795cbac2760636.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-use-max/reference/clang-10/coverage.functions.html
+++ b/gcovr/tests/different-function-lines-use-max/reference/clang-10/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-use-max/reference/clang-10/coverage.html
+++ b/gcovr/tests/different-function-lines-use-max/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-use-max/reference/clang-10/coverage.main.c.2045016cb90d1e65d71c2407a2570927.html
+++ b/gcovr/tests/different-function-lines-use-max/reference/clang-10/coverage.main.c.2045016cb90d1e65d71c2407a2570927.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-use-max/reference/clang-13/coverage.func.h.c6674364b75880bb30795cbac2760636.html
+++ b/gcovr/tests/different-function-lines-use-max/reference/clang-13/coverage.func.h.c6674364b75880bb30795cbac2760636.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-use-max/reference/clang-13/coverage.functions.html
+++ b/gcovr/tests/different-function-lines-use-max/reference/clang-13/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-use-max/reference/gcc-5/coverage.func.h.c6674364b75880bb30795cbac2760636.html
+++ b/gcovr/tests/different-function-lines-use-max/reference/gcc-5/coverage.func.h.c6674364b75880bb30795cbac2760636.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-use-max/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/different-function-lines-use-max/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-use-max/reference/gcc-5/coverage.html
+++ b/gcovr/tests/different-function-lines-use-max/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-use-max/reference/gcc-5/coverage.main.c.2045016cb90d1e65d71c2407a2570927.html
+++ b/gcovr/tests/different-function-lines-use-max/reference/gcc-5/coverage.main.c.2045016cb90d1e65d71c2407a2570927.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-use-min/reference/clang-10/coverage.func.h.c6674364b75880bb30795cbac2760636.html
+++ b/gcovr/tests/different-function-lines-use-min/reference/clang-10/coverage.func.h.c6674364b75880bb30795cbac2760636.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-use-min/reference/clang-10/coverage.functions.html
+++ b/gcovr/tests/different-function-lines-use-min/reference/clang-10/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-use-min/reference/clang-10/coverage.html
+++ b/gcovr/tests/different-function-lines-use-min/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-use-min/reference/clang-10/coverage.main.c.2045016cb90d1e65d71c2407a2570927.html
+++ b/gcovr/tests/different-function-lines-use-min/reference/clang-10/coverage.main.c.2045016cb90d1e65d71c2407a2570927.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-use-min/reference/clang-13/coverage.func.h.c6674364b75880bb30795cbac2760636.html
+++ b/gcovr/tests/different-function-lines-use-min/reference/clang-13/coverage.func.h.c6674364b75880bb30795cbac2760636.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-use-min/reference/clang-13/coverage.functions.html
+++ b/gcovr/tests/different-function-lines-use-min/reference/clang-13/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-use-min/reference/gcc-5/coverage.func.h.c6674364b75880bb30795cbac2760636.html
+++ b/gcovr/tests/different-function-lines-use-min/reference/gcc-5/coverage.func.h.c6674364b75880bb30795cbac2760636.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-use-min/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/different-function-lines-use-min/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-use-min/reference/gcc-5/coverage.html
+++ b/gcovr/tests/different-function-lines-use-min/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/different-function-lines-use-min/reference/gcc-5/coverage.main.c.2045016cb90d1e65d71c2407a2570927.html
+++ b/gcovr/tests/different-function-lines-use-min/reference/gcc-5/coverage.main.c.2045016cb90d1e65d71c2407a2570927.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/dot/reference/clang-10/coverage.file1.cpp.e4b34f3a937a38f4f36ad7d4400aa49c.html
+++ b/gcovr/tests/dot/reference/clang-10/coverage.file1.cpp.e4b34f3a937a38f4f36ad7d4400aa49c.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/dot/reference/clang-10/coverage.file2.cpp.d6f57cdf75749662672decd0e9380e9e.html
+++ b/gcovr/tests/dot/reference/clang-10/coverage.file2.cpp.d6f57cdf75749662672decd0e9380e9e.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/dot/reference/clang-10/coverage.file3.cpp.2f75129acf13033c6475b68d314e376c.html
+++ b/gcovr/tests/dot/reference/clang-10/coverage.file3.cpp.2f75129acf13033c6475b68d314e376c.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/dot/reference/clang-10/coverage.file4.cpp.a8cdb399bbaa0894976d9ad0d61c7cad.html
+++ b/gcovr/tests/dot/reference/clang-10/coverage.file4.cpp.a8cdb399bbaa0894976d9ad0d61c7cad.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/dot/reference/clang-10/coverage.file5.cpp.c953054e717675f6f8af56f7fee2fb14.html
+++ b/gcovr/tests/dot/reference/clang-10/coverage.file5.cpp.c953054e717675f6f8af56f7fee2fb14.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/dot/reference/clang-10/coverage.file6.cpp.c20fdcf8b426a70630979c0fc0ebd442.html
+++ b/gcovr/tests/dot/reference/clang-10/coverage.file6.cpp.c20fdcf8b426a70630979c0fc0ebd442.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/dot/reference/clang-10/coverage.html
+++ b/gcovr/tests/dot/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/dot/reference/clang-10/coverage.main.cpp.d0d5fc20837f40fa4765af5e07f5d1b9.html
+++ b/gcovr/tests/dot/reference/clang-10/coverage.main.cpp.d0d5fc20837f40fa4765af5e07f5d1b9.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/dot/reference/clang-13/coverage.file1.cpp.e4b34f3a937a38f4f36ad7d4400aa49c.html
+++ b/gcovr/tests/dot/reference/clang-13/coverage.file1.cpp.e4b34f3a937a38f4f36ad7d4400aa49c.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/dot/reference/clang-13/coverage.file2.cpp.d6f57cdf75749662672decd0e9380e9e.html
+++ b/gcovr/tests/dot/reference/clang-13/coverage.file2.cpp.d6f57cdf75749662672decd0e9380e9e.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/dot/reference/clang-13/coverage.file3.cpp.2f75129acf13033c6475b68d314e376c.html
+++ b/gcovr/tests/dot/reference/clang-13/coverage.file3.cpp.2f75129acf13033c6475b68d314e376c.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/dot/reference/clang-13/coverage.file4.cpp.a8cdb399bbaa0894976d9ad0d61c7cad.html
+++ b/gcovr/tests/dot/reference/clang-13/coverage.file4.cpp.a8cdb399bbaa0894976d9ad0d61c7cad.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/dot/reference/clang-13/coverage.file5.cpp.c953054e717675f6f8af56f7fee2fb14.html
+++ b/gcovr/tests/dot/reference/clang-13/coverage.file5.cpp.c953054e717675f6f8af56f7fee2fb14.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/dot/reference/clang-13/coverage.file6.cpp.c20fdcf8b426a70630979c0fc0ebd442.html
+++ b/gcovr/tests/dot/reference/clang-13/coverage.file6.cpp.c20fdcf8b426a70630979c0fc0ebd442.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/dot/reference/gcc-5/coverage.file1.cpp.e4b34f3a937a38f4f36ad7d4400aa49c.html
+++ b/gcovr/tests/dot/reference/gcc-5/coverage.file1.cpp.e4b34f3a937a38f4f36ad7d4400aa49c.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/dot/reference/gcc-5/coverage.file2.cpp.d6f57cdf75749662672decd0e9380e9e.html
+++ b/gcovr/tests/dot/reference/gcc-5/coverage.file2.cpp.d6f57cdf75749662672decd0e9380e9e.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/dot/reference/gcc-5/coverage.file3.cpp.2f75129acf13033c6475b68d314e376c.html
+++ b/gcovr/tests/dot/reference/gcc-5/coverage.file3.cpp.2f75129acf13033c6475b68d314e376c.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/dot/reference/gcc-5/coverage.file4.cpp.a8cdb399bbaa0894976d9ad0d61c7cad.html
+++ b/gcovr/tests/dot/reference/gcc-5/coverage.file4.cpp.a8cdb399bbaa0894976d9ad0d61c7cad.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/dot/reference/gcc-5/coverage.file5.cpp.c953054e717675f6f8af56f7fee2fb14.html
+++ b/gcovr/tests/dot/reference/gcc-5/coverage.file5.cpp.c953054e717675f6f8af56f7fee2fb14.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/dot/reference/gcc-5/coverage.file6.cpp.c20fdcf8b426a70630979c0fc0ebd442.html
+++ b/gcovr/tests/dot/reference/gcc-5/coverage.file6.cpp.c20fdcf8b426a70630979c0fc0ebd442.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/dot/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/dot/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/dot/reference/gcc-5/coverage.html
+++ b/gcovr/tests/dot/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/dot/reference/gcc-5/coverage.main.cpp.d0d5fc20837f40fa4765af5e07f5d1b9.html
+++ b/gcovr/tests/dot/reference/gcc-5/coverage.main.cpp.d0d5fc20837f40fa4765af5e07f5d1b9.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/dot/reference/gcc-8/coverage.functions.html
+++ b/gcovr/tests/dot/reference/gcc-8/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/dot/reference/gcc-8/coverage.html
+++ b/gcovr/tests/dot/reference/gcc-8/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/dot/reference/gcc-8/coverage.main.cpp.d0d5fc20837f40fa4765af5e07f5d1b9.html
+++ b/gcovr/tests/dot/reference/gcc-8/coverage.main.cpp.d0d5fc20837f40fa4765af5e07f5d1b9.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-branch/reference/clang-10/coverage.html
+++ b/gcovr/tests/excl-branch/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-branch/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/excl-branch/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-branch/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/excl-branch/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-branch/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/excl-branch/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-branch/reference/gcc-5/coverage.html
+++ b/gcovr/tests/excl-branch/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-branch/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/excl-branch/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-branch/reference/gcc-8/coverage.functions.html
+++ b/gcovr/tests/excl-branch/reference/gcc-8/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-branch/reference/gcc-8/coverage.html
+++ b/gcovr/tests/excl-branch/reference/gcc-8/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-branch/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/excl-branch/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-line-branch/reference/clang-10/coverage.html
+++ b/gcovr/tests/excl-line-branch/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-line-branch/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/excl-line-branch/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-line-branch/reference/clang-13/coverage.html
+++ b/gcovr/tests/excl-line-branch/reference/clang-13/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-line-branch/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/excl-line-branch/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-line-branch/reference/gcc-11/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/excl-line-branch/reference/gcc-11/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-line-branch/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/excl-line-branch/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-line-branch/reference/gcc-5/coverage.html
+++ b/gcovr/tests/excl-line-branch/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-line-branch/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/excl-line-branch/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-line-branch/reference/gcc-8/coverage.functions.html
+++ b/gcovr/tests/excl-line-branch/reference/gcc-8/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-line-branch/reference/gcc-8/coverage.html
+++ b/gcovr/tests/excl-line-branch/reference/gcc-8/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-line-branch/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/excl-line-branch/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-line-custom/reference/clang-10/coverage.functions.html
+++ b/gcovr/tests/excl-line-custom/reference/clang-10/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-line-custom/reference/clang-10/coverage.html
+++ b/gcovr/tests/excl-line-custom/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-line-custom/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/excl-line-custom/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-line-custom/reference/clang-13/coverage.functions.html
+++ b/gcovr/tests/excl-line-custom/reference/clang-13/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-line-custom/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/excl-line-custom/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-line-custom/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/excl-line-custom/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-line-custom/reference/gcc-5/coverage.html
+++ b/gcovr/tests/excl-line-custom/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-line-custom/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/excl-line-custom/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-line-custom/reference/gcc-8/coverage.functions.html
+++ b/gcovr/tests/excl-line-custom/reference/gcc-8/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-line-custom/reference/gcc-8/coverage.html
+++ b/gcovr/tests/excl-line-custom/reference/gcc-8/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-line-custom/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/excl-line-custom/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-line/reference/clang-10/coverage.html
+++ b/gcovr/tests/excl-line/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-line/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/excl-line/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-line/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/excl-line/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-line/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/excl-line/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-line/reference/gcc-5/coverage.html
+++ b/gcovr/tests/excl-line/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-line/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/excl-line/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-line/reference/gcc-8/coverage.functions.html
+++ b/gcovr/tests/excl-line/reference/gcc-8/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-line/reference/gcc-8/coverage.html
+++ b/gcovr/tests/excl-line/reference/gcc-8/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/excl-line/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/excl-line/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-directories-relative/reference/clang-10/coverage.html
+++ b/gcovr/tests/exclude-directories-relative/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-directories-relative/reference/clang-10/coverage.main.cpp.7d9c2f9355c8440401e02b7b21029098.html
+++ b/gcovr/tests/exclude-directories-relative/reference/clang-10/coverage.main.cpp.7d9c2f9355c8440401e02b7b21029098.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-directories-relative/reference/clang-13/coverage.main.cpp.7d9c2f9355c8440401e02b7b21029098.html
+++ b/gcovr/tests/exclude-directories-relative/reference/clang-13/coverage.main.cpp.7d9c2f9355c8440401e02b7b21029098.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-directories-relative/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/exclude-directories-relative/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-directories-relative/reference/gcc-5/coverage.html
+++ b/gcovr/tests/exclude-directories-relative/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-directories-relative/reference/gcc-5/coverage.main.cpp.7d9c2f9355c8440401e02b7b21029098.html
+++ b/gcovr/tests/exclude-directories-relative/reference/gcc-5/coverage.main.cpp.7d9c2f9355c8440401e02b7b21029098.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-directories-relative/reference/gcc-8/coverage.functions.html
+++ b/gcovr/tests/exclude-directories-relative/reference/gcc-8/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-directories-relative/reference/gcc-8/coverage.html
+++ b/gcovr/tests/exclude-directories-relative/reference/gcc-8/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-directories-relative/reference/gcc-8/coverage.main.cpp.7d9c2f9355c8440401e02b7b21029098.html
+++ b/gcovr/tests/exclude-directories-relative/reference/gcc-8/coverage.main.cpp.7d9c2f9355c8440401e02b7b21029098.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-lines-by-pattern/reference/clang-10/coverage.html
+++ b/gcovr/tests/exclude-lines-by-pattern/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-lines-by-pattern/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/exclude-lines-by-pattern/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-lines-by-pattern/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/exclude-lines-by-pattern/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-lines-by-pattern/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/exclude-lines-by-pattern/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-lines-by-pattern/reference/gcc-5/coverage.html
+++ b/gcovr/tests/exclude-lines-by-pattern/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-lines-by-pattern/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/exclude-lines-by-pattern/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-lines-by-pattern/reference/gcc-8/coverage.functions.html
+++ b/gcovr/tests/exclude-lines-by-pattern/reference/gcc-8/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-lines-by-pattern/reference/gcc-8/coverage.html
+++ b/gcovr/tests/exclude-lines-by-pattern/reference/gcc-8/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-lines-by-pattern/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/exclude-lines-by-pattern/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-relative-from-unfiltered-tracefile/reference/clang-10/coverage.html
+++ b/gcovr/tests/exclude-relative-from-unfiltered-tracefile/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-relative-from-unfiltered-tracefile/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/exclude-relative-from-unfiltered-tracefile/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-relative-from-unfiltered-tracefile/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/exclude-relative-from-unfiltered-tracefile/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-relative-from-unfiltered-tracefile/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/exclude-relative-from-unfiltered-tracefile/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-relative-from-unfiltered-tracefile/reference/gcc-5/coverage.html
+++ b/gcovr/tests/exclude-relative-from-unfiltered-tracefile/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-relative-from-unfiltered-tracefile/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/exclude-relative-from-unfiltered-tracefile/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-relative-from-unfiltered-tracefile/reference/gcc-8/coverage.functions.html
+++ b/gcovr/tests/exclude-relative-from-unfiltered-tracefile/reference/gcc-8/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-relative-from-unfiltered-tracefile/reference/gcc-8/coverage.html
+++ b/gcovr/tests/exclude-relative-from-unfiltered-tracefile/reference/gcc-8/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-relative-from-unfiltered-tracefile/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/exclude-relative-from-unfiltered-tracefile/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-relative/reference/clang-10/coverage.html
+++ b/gcovr/tests/exclude-relative/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-relative/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/exclude-relative/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-relative/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/exclude-relative/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-relative/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/exclude-relative/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-relative/reference/gcc-5/coverage.html
+++ b/gcovr/tests/exclude-relative/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-relative/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/exclude-relative/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-relative/reference/gcc-8/coverage.functions.html
+++ b/gcovr/tests/exclude-relative/reference/gcc-8/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-relative/reference/gcc-8/coverage.html
+++ b/gcovr/tests/exclude-relative/reference/gcc-8/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-relative/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/exclude-relative/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/clang-10/coverage-excl-throw.html
+++ b/gcovr/tests/exclude-throw-branches/reference/clang-10/coverage-excl-throw.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-excl-throw.css">
+    <link rel="stylesheet" href="coverage-excl-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/clang-10/coverage-excl-throw.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/exclude-throw-branches/reference/clang-10/coverage-excl-throw.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-excl-throw.css">
+    <link rel="stylesheet" href="coverage-excl-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/clang-10/coverage-throw.html
+++ b/gcovr/tests/exclude-throw-branches/reference/clang-10/coverage-throw.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-throw.css">
+    <link rel="stylesheet" href="coverage-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/clang-10/coverage-throw.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/exclude-throw-branches/reference/clang-10/coverage-throw.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-throw.css">
+    <link rel="stylesheet" href="coverage-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/clang-13/coverage-excl-throw.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/exclude-throw-branches/reference/clang-13/coverage-excl-throw.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-excl-throw.css">
+    <link rel="stylesheet" href="coverage-excl-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/clang-13/coverage-throw.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/exclude-throw-branches/reference/clang-13/coverage-throw.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-throw.css">
+    <link rel="stylesheet" href="coverage-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-10/coverage-excl-throw.functions.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-10/coverage-excl-throw.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-excl-throw.css">
+    <link rel="stylesheet" href="coverage-excl-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-10/coverage-excl-throw.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-10/coverage-excl-throw.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-excl-throw.css">
+    <link rel="stylesheet" href="coverage-excl-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-10/coverage-excl-throw.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-10/coverage-excl-throw.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-excl-throw.css">
+    <link rel="stylesheet" href="coverage-excl-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-10/coverage-throw.functions.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-10/coverage-throw.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-throw.css">
+    <link rel="stylesheet" href="coverage-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-10/coverage-throw.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-10/coverage-throw.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-throw.css">
+    <link rel="stylesheet" href="coverage-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-10/coverage-throw.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-10/coverage-throw.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-throw.css">
+    <link rel="stylesheet" href="coverage-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-11/coverage-excl-throw.functions.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-11/coverage-excl-throw.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-excl-throw.css">
+    <link rel="stylesheet" href="coverage-excl-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-11/coverage-excl-throw.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-11/coverage-excl-throw.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-excl-throw.css">
+    <link rel="stylesheet" href="coverage-excl-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-11/coverage-excl-throw.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-11/coverage-excl-throw.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-excl-throw.css">
+    <link rel="stylesheet" href="coverage-excl-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-11/coverage-throw.functions.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-11/coverage-throw.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-throw.css">
+    <link rel="stylesheet" href="coverage-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-11/coverage-throw.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-11/coverage-throw.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-throw.css">
+    <link rel="stylesheet" href="coverage-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-11/coverage-throw.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-11/coverage-throw.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-throw.css">
+    <link rel="stylesheet" href="coverage-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-5/coverage-excl-throw.functions.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-5/coverage-excl-throw.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-excl-throw.css">
+    <link rel="stylesheet" href="coverage-excl-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-5/coverage-excl-throw.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-5/coverage-excl-throw.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-excl-throw.css">
+    <link rel="stylesheet" href="coverage-excl-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-5/coverage-excl-throw.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-5/coverage-excl-throw.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-excl-throw.css">
+    <link rel="stylesheet" href="coverage-excl-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-5/coverage-throw.functions.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-5/coverage-throw.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-throw.css">
+    <link rel="stylesheet" href="coverage-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-5/coverage-throw.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-5/coverage-throw.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-throw.css">
+    <link rel="stylesheet" href="coverage-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-5/coverage-throw.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-5/coverage-throw.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-throw.css">
+    <link rel="stylesheet" href="coverage-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-6/coverage-excl-throw.functions.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-6/coverage-excl-throw.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-excl-throw.css">
+    <link rel="stylesheet" href="coverage-excl-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-6/coverage-excl-throw.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-6/coverage-excl-throw.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-excl-throw.css">
+    <link rel="stylesheet" href="coverage-excl-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-6/coverage-excl-throw.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-6/coverage-excl-throw.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-excl-throw.css">
+    <link rel="stylesheet" href="coverage-excl-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-6/coverage-throw.functions.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-6/coverage-throw.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-throw.css">
+    <link rel="stylesheet" href="coverage-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-6/coverage-throw.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-6/coverage-throw.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-throw.css">
+    <link rel="stylesheet" href="coverage-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-6/coverage-throw.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-6/coverage-throw.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-throw.css">
+    <link rel="stylesheet" href="coverage-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-8-Windows/coverage-excl-throw.functions.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-8-Windows/coverage-excl-throw.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-excl-throw.css">
+    <link rel="stylesheet" href="coverage-excl-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-8-Windows/coverage-excl-throw.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-8-Windows/coverage-excl-throw.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-excl-throw.css">
+    <link rel="stylesheet" href="coverage-excl-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-8-Windows/coverage-excl-throw.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-8-Windows/coverage-excl-throw.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-excl-throw.css">
+    <link rel="stylesheet" href="coverage-excl-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-8-Windows/coverage-throw.functions.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-8-Windows/coverage-throw.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-throw.css">
+    <link rel="stylesheet" href="coverage-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-8-Windows/coverage-throw.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-8-Windows/coverage-throw.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-throw.css">
+    <link rel="stylesheet" href="coverage-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-8-Windows/coverage-throw.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-8-Windows/coverage-throw.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-throw.css">
+    <link rel="stylesheet" href="coverage-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-8/coverage-excl-throw.functions.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-8/coverage-excl-throw.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-excl-throw.css">
+    <link rel="stylesheet" href="coverage-excl-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-8/coverage-excl-throw.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-8/coverage-excl-throw.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-excl-throw.css">
+    <link rel="stylesheet" href="coverage-excl-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-8/coverage-excl-throw.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-8/coverage-excl-throw.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-excl-throw.css">
+    <link rel="stylesheet" href="coverage-excl-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-8/coverage-throw.functions.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-8/coverage-throw.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-throw.css">
+    <link rel="stylesheet" href="coverage-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-8/coverage-throw.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-8/coverage-throw.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-throw.css">
+    <link rel="stylesheet" href="coverage-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/exclude-throw-branches/reference/gcc-8/coverage-throw.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/exclude-throw-branches/reference/gcc-8/coverage-throw.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-throw.css">
+    <link rel="stylesheet" href="coverage-throw.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-absolute-from-unfiltered-tracefile/reference/clang-10/coverage.html
+++ b/gcovr/tests/filter-absolute-from-unfiltered-tracefile/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-absolute-from-unfiltered-tracefile/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/filter-absolute-from-unfiltered-tracefile/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-absolute-from-unfiltered-tracefile/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/filter-absolute-from-unfiltered-tracefile/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-absolute-from-unfiltered-tracefile/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/filter-absolute-from-unfiltered-tracefile/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-absolute-from-unfiltered-tracefile/reference/gcc-5/coverage.html
+++ b/gcovr/tests/filter-absolute-from-unfiltered-tracefile/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-absolute-from-unfiltered-tracefile/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/filter-absolute-from-unfiltered-tracefile/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-absolute-from-unfiltered-tracefile/reference/gcc-8/coverage.functions.html
+++ b/gcovr/tests/filter-absolute-from-unfiltered-tracefile/reference/gcc-8/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-absolute-from-unfiltered-tracefile/reference/gcc-8/coverage.html
+++ b/gcovr/tests/filter-absolute-from-unfiltered-tracefile/reference/gcc-8/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-absolute-from-unfiltered-tracefile/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/filter-absolute-from-unfiltered-tracefile/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-absolute/reference/clang-10/coverage.html
+++ b/gcovr/tests/filter-absolute/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-absolute/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/filter-absolute/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-absolute/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/filter-absolute/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-absolute/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/filter-absolute/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-absolute/reference/gcc-5/coverage.html
+++ b/gcovr/tests/filter-absolute/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-absolute/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/filter-absolute/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-absolute/reference/gcc-8/coverage.functions.html
+++ b/gcovr/tests/filter-absolute/reference/gcc-8/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-absolute/reference/gcc-8/coverage.html
+++ b/gcovr/tests/filter-absolute/reference/gcc-8/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-absolute/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/filter-absolute/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-relative-from-unfiltered-tracefile/reference/clang-10/coverage.html
+++ b/gcovr/tests/filter-relative-from-unfiltered-tracefile/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-relative-from-unfiltered-tracefile/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/filter-relative-from-unfiltered-tracefile/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-relative-from-unfiltered-tracefile/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/filter-relative-from-unfiltered-tracefile/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-relative-from-unfiltered-tracefile/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/filter-relative-from-unfiltered-tracefile/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-relative-from-unfiltered-tracefile/reference/gcc-5/coverage.html
+++ b/gcovr/tests/filter-relative-from-unfiltered-tracefile/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-relative-from-unfiltered-tracefile/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/filter-relative-from-unfiltered-tracefile/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-relative-from-unfiltered-tracefile/reference/gcc-8/coverage.functions.html
+++ b/gcovr/tests/filter-relative-from-unfiltered-tracefile/reference/gcc-8/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-relative-from-unfiltered-tracefile/reference/gcc-8/coverage.html
+++ b/gcovr/tests/filter-relative-from-unfiltered-tracefile/reference/gcc-8/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-relative-from-unfiltered-tracefile/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/filter-relative-from-unfiltered-tracefile/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-relative-lib-from-unfiltered-tracefile/reference/clang-10/coverage.html
+++ b/gcovr/tests/filter-relative-lib-from-unfiltered-tracefile/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-relative-lib-from-unfiltered-tracefile/reference/clang-10/coverage.main.cpp.7ec3c68a81efff79b6ca22ac1f1eabba.html
+++ b/gcovr/tests/filter-relative-lib-from-unfiltered-tracefile/reference/clang-10/coverage.main.cpp.7ec3c68a81efff79b6ca22ac1f1eabba.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-relative-lib-from-unfiltered-tracefile/reference/clang-10/coverage.yes.cpp.37f9f505d6c6aaab5562071eb5f4d9da.html
+++ b/gcovr/tests/filter-relative-lib-from-unfiltered-tracefile/reference/clang-10/coverage.yes.cpp.37f9f505d6c6aaab5562071eb5f4d9da.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-relative-lib-from-unfiltered-tracefile/reference/clang-13/coverage.yes.cpp.37f9f505d6c6aaab5562071eb5f4d9da.html
+++ b/gcovr/tests/filter-relative-lib-from-unfiltered-tracefile/reference/clang-13/coverage.yes.cpp.37f9f505d6c6aaab5562071eb5f4d9da.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-relative-lib-from-unfiltered-tracefile/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/filter-relative-lib-from-unfiltered-tracefile/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-relative-lib-from-unfiltered-tracefile/reference/gcc-5/coverage.html
+++ b/gcovr/tests/filter-relative-lib-from-unfiltered-tracefile/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-relative-lib-from-unfiltered-tracefile/reference/gcc-5/coverage.main.cpp.7ec3c68a81efff79b6ca22ac1f1eabba.html
+++ b/gcovr/tests/filter-relative-lib-from-unfiltered-tracefile/reference/gcc-5/coverage.main.cpp.7ec3c68a81efff79b6ca22ac1f1eabba.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-relative-lib-from-unfiltered-tracefile/reference/gcc-5/coverage.yes.cpp.37f9f505d6c6aaab5562071eb5f4d9da.html
+++ b/gcovr/tests/filter-relative-lib-from-unfiltered-tracefile/reference/gcc-5/coverage.yes.cpp.37f9f505d6c6aaab5562071eb5f4d9da.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-relative-lib/reference/clang-10/coverage.html
+++ b/gcovr/tests/filter-relative-lib/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-relative-lib/reference/clang-10/coverage.main.cpp.7ec3c68a81efff79b6ca22ac1f1eabba.html
+++ b/gcovr/tests/filter-relative-lib/reference/clang-10/coverage.main.cpp.7ec3c68a81efff79b6ca22ac1f1eabba.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-relative-lib/reference/clang-10/coverage.yes.cpp.37f9f505d6c6aaab5562071eb5f4d9da.html
+++ b/gcovr/tests/filter-relative-lib/reference/clang-10/coverage.yes.cpp.37f9f505d6c6aaab5562071eb5f4d9da.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-relative-lib/reference/clang-13/coverage.yes.cpp.37f9f505d6c6aaab5562071eb5f4d9da.html
+++ b/gcovr/tests/filter-relative-lib/reference/clang-13/coverage.yes.cpp.37f9f505d6c6aaab5562071eb5f4d9da.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-relative-lib/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/filter-relative-lib/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-relative-lib/reference/gcc-5/coverage.html
+++ b/gcovr/tests/filter-relative-lib/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-relative-lib/reference/gcc-5/coverage.main.cpp.7ec3c68a81efff79b6ca22ac1f1eabba.html
+++ b/gcovr/tests/filter-relative-lib/reference/gcc-5/coverage.main.cpp.7ec3c68a81efff79b6ca22ac1f1eabba.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-relative-lib/reference/gcc-5/coverage.yes.cpp.37f9f505d6c6aaab5562071eb5f4d9da.html
+++ b/gcovr/tests/filter-relative-lib/reference/gcc-5/coverage.yes.cpp.37f9f505d6c6aaab5562071eb5f4d9da.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-relative/reference/clang-10/coverage.html
+++ b/gcovr/tests/filter-relative/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-relative/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/filter-relative/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-relative/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/filter-relative/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-relative/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/filter-relative/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-relative/reference/gcc-5/coverage.html
+++ b/gcovr/tests/filter-relative/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-relative/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/filter-relative/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-relative/reference/gcc-8/coverage.functions.html
+++ b/gcovr/tests/filter-relative/reference/gcc-8/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-relative/reference/gcc-8/coverage.html
+++ b/gcovr/tests/filter-relative/reference/gcc-8/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/filter-relative/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/filter-relative/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-default/reference/clang-10/coverage.html
+++ b/gcovr/tests/html-default/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-default/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-default/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-default/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/html-default/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-default/reference/gcc-5/coverage.html
+++ b/gcovr/tests/html-default/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-default/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-default/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-encoding-cp1252/reference/clang-10/coverage.html
+++ b/gcovr/tests/html-encoding-cp1252/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=cp1252"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-encoding-cp1252/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-encoding-cp1252/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -144,7 +144,7 @@
       <td class="linebranch">
       </td>
       <td class="linecount "></td>
-      <td class="src ">    <span class="c1">// ï¿½uvre, ï¿½typographic quotesï¿½, ï¿½, ï¿½, ï¿½, ï¿½</span></td>
+      <td class="src ">    <span class="c1">// œuvre, “typographic quotes”, ¦, ¼, €, ¤</span></td>
     </tr>
 
     <tr class="source-line">

--- a/gcovr/tests/html-encoding-cp1252/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-encoding-cp1252/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=cp1252"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>
@@ -144,7 +144,7 @@
       <td class="linebranch">
       </td>
       <td class="linecount "></td>
-      <td class="src ">    <span class="c1">// œuvre, “typographic quotes”, ¦, ¼, €, ¤</span></td>
+      <td class="src ">    <span class="c1">// ï¿½uvre, ï¿½typographic quotesï¿½, ï¿½, ï¿½, ï¿½, ï¿½</span></td>
     </tr>
 
     <tr class="source-line">

--- a/gcovr/tests/html-encoding-cp1252/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/html-encoding-cp1252/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=cp1252"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-encoding-cp1252/reference/gcc-5/coverage.html
+++ b/gcovr/tests/html-encoding-cp1252/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=cp1252"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-encoding-cp1252/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-encoding-cp1252/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -144,7 +144,7 @@
       <td class="linebranch">
       </td>
       <td class="linecount "></td>
-      <td class="src ">    <span class="c1">// ï¿½uvre, ï¿½typographic quotesï¿½, ï¿½, ï¿½, ï¿½, ï¿½</span></td>
+      <td class="src ">    <span class="c1">// œuvre, “typographic quotes”, ¦, ¼, €, ¤</span></td>
     </tr>
 
     <tr class="source-line">

--- a/gcovr/tests/html-encoding-cp1252/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-encoding-cp1252/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=cp1252"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>
@@ -144,7 +144,7 @@
       <td class="linebranch">
       </td>
       <td class="linecount "></td>
-      <td class="src ">    <span class="c1">// œuvre, “typographic quotes”, ¦, ¼, €, ¤</span></td>
+      <td class="src ">    <span class="c1">// ï¿½uvre, ï¿½typographic quotesï¿½, ï¿½, ï¿½, ï¿½, ï¿½</span></td>
     </tr>
 
     <tr class="source-line">

--- a/gcovr/tests/html-encoding-iso-8859-15/reference/clang-10/coverage.html
+++ b/gcovr/tests/html-encoding-iso-8859-15/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-15"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-encoding-iso-8859-15/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-encoding-iso-8859-15/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-15"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>
@@ -144,7 +144,7 @@
       <td class="linebranch">
       </td>
       <td class="linecount "></td>
-      <td class="src ">    <span class="c1">// œuvre, &#8220;typographic quotes&#8221;, &#166;, &#188;, €, &#164;</span></td>
+      <td class="src ">    <span class="c1">// ï¿œuvre, &#8220;typographic quotes&#8221;, &#166;, &#188;, ï¿œ, &#164;</span></td>
     </tr>
 
     <tr class="source-line">

--- a/gcovr/tests/html-encoding-iso-8859-15/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-encoding-iso-8859-15/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -144,7 +144,7 @@
       <td class="linebranch">
       </td>
       <td class="linecount "></td>
-      <td class="src ">    <span class="c1">// ï¿½uvre, &#8220;typographic quotes&#8221;, &#166;, &#188;, ï¿½, &#164;</span></td>
+      <td class="src ">    <span class="c1">// ½uvre, &#8220;typographic quotes&#8221;, &#166;, &#188;, ¤, &#164;</span></td>
     </tr>
 
     <tr class="source-line">

--- a/gcovr/tests/html-encoding-iso-8859-15/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/html-encoding-iso-8859-15/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-15"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-encoding-iso-8859-15/reference/gcc-5/coverage.html
+++ b/gcovr/tests/html-encoding-iso-8859-15/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-15"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-encoding-iso-8859-15/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-encoding-iso-8859-15/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-15"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>
@@ -144,7 +144,7 @@
       <td class="linebranch">
       </td>
       <td class="linecount "></td>
-      <td class="src ">    <span class="c1">// œuvre, &#8220;typographic quotes&#8221;, &#166;, &#188;, €, &#164;</span></td>
+      <td class="src ">    <span class="c1">// ï¿œuvre, &#8220;typographic quotes&#8221;, &#166;, &#188;, ï¿œ, &#164;</span></td>
     </tr>
 
     <tr class="source-line">

--- a/gcovr/tests/html-encoding-iso-8859-15/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-encoding-iso-8859-15/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -144,7 +144,7 @@
       <td class="linebranch">
       </td>
       <td class="linecount "></td>
-      <td class="src ">    <span class="c1">// ï¿½uvre, &#8220;typographic quotes&#8221;, &#166;, &#188;, ï¿½, &#164;</span></td>
+      <td class="src ">    <span class="c1">// ½uvre, &#8220;typographic quotes&#8221;, &#166;, &#188;, ¤, &#164;</span></td>
     </tr>
 
     <tr class="source-line">

--- a/gcovr/tests/html-file-not-found/reference/clang-10/coverage.does-not-exist.cpp.1630668f5825154f66e6eb6df88396a9.html
+++ b/gcovr/tests/html-file-not-found/reference/clang-10/coverage.does-not-exist.cpp.1630668f5825154f66e6eb6df88396a9.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-file-not-found/reference/clang-10/coverage.functions.html
+++ b/gcovr/tests/html-file-not-found/reference/clang-10/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-file-not-found/reference/clang-10/coverage.html
+++ b/gcovr/tests/html-file-not-found/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-file-not-found/reference/gcc-5/coverage.does-not-exist.cpp.1630668f5825154f66e6eb6df88396a9.html
+++ b/gcovr/tests/html-file-not-found/reference/gcc-5/coverage.does-not-exist.cpp.1630668f5825154f66e6eb6df88396a9.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-file-not-found/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/html-file-not-found/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-file-not-found/reference/gcc-5/coverage.html
+++ b/gcovr/tests/html-file-not-found/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-high-100/reference/clang-10/coverage.html
+++ b/gcovr/tests/html-high-100/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-high-100/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-high-100/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-high-100/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/html-high-100/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-high-100/reference/gcc-5/coverage.html
+++ b/gcovr/tests/html-high-100/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-high-100/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-high-100/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-high-75/reference/clang-10/coverage.html
+++ b/gcovr/tests/html-high-75/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-high-75/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-high-75/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-high-75/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/html-high-75/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-high-75/reference/gcc-5/coverage.html
+++ b/gcovr/tests/html-high-75/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-high-75/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-high-75/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-line-branch/reference/clang-10/coverage.html
+++ b/gcovr/tests/html-line-branch/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-line-branch/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-line-branch/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-line-branch/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/html-line-branch/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-line-branch/reference/gcc-5/coverage.html
+++ b/gcovr/tests/html-line-branch/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-line-branch/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-line-branch/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-medium-100-high-100/reference/clang-10/coverage.html
+++ b/gcovr/tests/html-medium-100-high-100/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-medium-100-high-100/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-medium-100-high-100/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-medium-100-high-100/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/html-medium-100-high-100/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-medium-100-high-100/reference/gcc-5/coverage.html
+++ b/gcovr/tests/html-medium-100-high-100/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-medium-100-high-100/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-medium-100-high-100/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-medium-50/reference/clang-10/coverage.html
+++ b/gcovr/tests/html-medium-50/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-medium-50/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-medium-50/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-medium-50/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/html-medium-50/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-medium-50/reference/gcc-5/coverage.html
+++ b/gcovr/tests/html-medium-50/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-medium-50/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-medium-50/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-nonsort/reference/clang-10/coverage_nested.A.7fc56270e7a70fa81a5935b72eacbe29.html
+++ b/gcovr/tests/html-nested-nonsort/reference/clang-10/coverage_nested.A.7fc56270e7a70fa81a5935b72eacbe29.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_nested.css">
+    <link rel="stylesheet" href="coverage_nested.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-nonsort/reference/clang-10/coverage_nested.C.65c6818f1beed0acac61ab4a271ddda2.html
+++ b/gcovr/tests/html-nested-nonsort/reference/clang-10/coverage_nested.C.65c6818f1beed0acac61ab4a271ddda2.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_nested.css">
+    <link rel="stylesheet" href="coverage_nested.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-nonsort/reference/clang-10/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/gcovr/tests/html-nested-nonsort/reference/clang-10/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_nested.css">
+    <link rel="stylesheet" href="coverage_nested.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-nonsort/reference/clang-10/coverage_nested.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
+++ b/gcovr/tests/html-nested-nonsort/reference/clang-10/coverage_nested.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_nested.css">
+    <link rel="stylesheet" href="coverage_nested.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-nonsort/reference/clang-10/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/gcovr/tests/html-nested-nonsort/reference/clang-10/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_nested.css">
+    <link rel="stylesheet" href="coverage_nested.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-nonsort/reference/clang-10/coverage_nested.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
+++ b/gcovr/tests/html-nested-nonsort/reference/clang-10/coverage_nested.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_nested.css">
+    <link rel="stylesheet" href="coverage_nested.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-nonsort/reference/clang-10/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/gcovr/tests/html-nested-nonsort/reference/clang-10/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_nested.css">
+    <link rel="stylesheet" href="coverage_nested.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-nonsort/reference/clang-10/coverage_nested.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
+++ b/gcovr/tests/html-nested-nonsort/reference/clang-10/coverage_nested.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_nested.css">
+    <link rel="stylesheet" href="coverage_nested.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-nonsort/reference/clang-10/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/gcovr/tests/html-nested-nonsort/reference/clang-10/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_nested.css">
+    <link rel="stylesheet" href="coverage_nested.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-nonsort/reference/clang-10/coverage_nested.functions.html
+++ b/gcovr/tests/html-nested-nonsort/reference/clang-10/coverage_nested.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_nested.css">
+    <link rel="stylesheet" href="coverage_nested.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-nonsort/reference/clang-10/coverage_nested.html
+++ b/gcovr/tests/html-nested-nonsort/reference/clang-10/coverage_nested.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_nested.css">
+    <link rel="stylesheet" href="coverage_nested.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-nonsort/reference/clang-10/coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/gcovr/tests/html-nested-nonsort/reference/clang-10/coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_nested.css">
+    <link rel="stylesheet" href="coverage_nested.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-nonsort/reference/clang-13/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/gcovr/tests/html-nested-nonsort/reference/clang-13/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_nested.css">
+    <link rel="stylesheet" href="coverage_nested.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-nonsort/reference/clang-13/coverage_nested.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
+++ b/gcovr/tests/html-nested-nonsort/reference/clang-13/coverage_nested.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_nested.css">
+    <link rel="stylesheet" href="coverage_nested.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-nonsort/reference/clang-13/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/gcovr/tests/html-nested-nonsort/reference/clang-13/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_nested.css">
+    <link rel="stylesheet" href="coverage_nested.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-nonsort/reference/clang-13/coverage_nested.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
+++ b/gcovr/tests/html-nested-nonsort/reference/clang-13/coverage_nested.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_nested.css">
+    <link rel="stylesheet" href="coverage_nested.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-nonsort/reference/clang-13/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/gcovr/tests/html-nested-nonsort/reference/clang-13/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_nested.css">
+    <link rel="stylesheet" href="coverage_nested.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-nonsort/reference/clang-13/coverage_nested.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
+++ b/gcovr/tests/html-nested-nonsort/reference/clang-13/coverage_nested.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_nested.css">
+    <link rel="stylesheet" href="coverage_nested.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-nonsort/reference/clang-13/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/gcovr/tests/html-nested-nonsort/reference/clang-13/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_nested.css">
+    <link rel="stylesheet" href="coverage_nested.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-nonsort/reference/clang-13/coverage_nested.functions.html
+++ b/gcovr/tests/html-nested-nonsort/reference/clang-13/coverage_nested.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_nested.css">
+    <link rel="stylesheet" href="coverage_nested.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-nonsort/reference/gcc-5/coverage_nested.A.7fc56270e7a70fa81a5935b72eacbe29.html
+++ b/gcovr/tests/html-nested-nonsort/reference/gcc-5/coverage_nested.A.7fc56270e7a70fa81a5935b72eacbe29.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_nested.css">
+    <link rel="stylesheet" href="coverage_nested.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-nonsort/reference/gcc-5/coverage_nested.C.65c6818f1beed0acac61ab4a271ddda2.html
+++ b/gcovr/tests/html-nested-nonsort/reference/gcc-5/coverage_nested.C.65c6818f1beed0acac61ab4a271ddda2.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_nested.css">
+    <link rel="stylesheet" href="coverage_nested.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-nonsort/reference/gcc-5/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/gcovr/tests/html-nested-nonsort/reference/gcc-5/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_nested.css">
+    <link rel="stylesheet" href="coverage_nested.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-nonsort/reference/gcc-5/coverage_nested.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
+++ b/gcovr/tests/html-nested-nonsort/reference/gcc-5/coverage_nested.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_nested.css">
+    <link rel="stylesheet" href="coverage_nested.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-nonsort/reference/gcc-5/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/gcovr/tests/html-nested-nonsort/reference/gcc-5/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_nested.css">
+    <link rel="stylesheet" href="coverage_nested.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-nonsort/reference/gcc-5/coverage_nested.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
+++ b/gcovr/tests/html-nested-nonsort/reference/gcc-5/coverage_nested.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_nested.css">
+    <link rel="stylesheet" href="coverage_nested.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-nonsort/reference/gcc-5/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/gcovr/tests/html-nested-nonsort/reference/gcc-5/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_nested.css">
+    <link rel="stylesheet" href="coverage_nested.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-nonsort/reference/gcc-5/coverage_nested.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
+++ b/gcovr/tests/html-nested-nonsort/reference/gcc-5/coverage_nested.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_nested.css">
+    <link rel="stylesheet" href="coverage_nested.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-nonsort/reference/gcc-5/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/gcovr/tests/html-nested-nonsort/reference/gcc-5/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_nested.css">
+    <link rel="stylesheet" href="coverage_nested.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-nonsort/reference/gcc-5/coverage_nested.functions.html
+++ b/gcovr/tests/html-nested-nonsort/reference/gcc-5/coverage_nested.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_nested.css">
+    <link rel="stylesheet" href="coverage_nested.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-nonsort/reference/gcc-5/coverage_nested.html
+++ b/gcovr/tests/html-nested-nonsort/reference/gcc-5/coverage_nested.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_nested.css">
+    <link rel="stylesheet" href="coverage_nested.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-nonsort/reference/gcc-5/coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/gcovr/tests/html-nested-nonsort/reference/gcc-5/coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_nested.css">
+    <link rel="stylesheet" href="coverage_nested.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-nonsort/reference/gcc-8/coverage_nested.A.7fc56270e7a70fa81a5935b72eacbe29.html
+++ b/gcovr/tests/html-nested-nonsort/reference/gcc-8/coverage_nested.A.7fc56270e7a70fa81a5935b72eacbe29.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_nested.css">
+    <link rel="stylesheet" href="coverage_nested.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-nonsort/reference/gcc-8/coverage_nested.C.65c6818f1beed0acac61ab4a271ddda2.html
+++ b/gcovr/tests/html-nested-nonsort/reference/gcc-8/coverage_nested.C.65c6818f1beed0acac61ab4a271ddda2.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_nested.css">
+    <link rel="stylesheet" href="coverage_nested.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-nonsort/reference/gcc-8/coverage_nested.functions.html
+++ b/gcovr/tests/html-nested-nonsort/reference/gcc-8/coverage_nested.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_nested.css">
+    <link rel="stylesheet" href="coverage_nested.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-nonsort/reference/gcc-8/coverage_nested.html
+++ b/gcovr/tests/html-nested-nonsort/reference/gcc-8/coverage_nested.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_nested.css">
+    <link rel="stylesheet" href="coverage_nested.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-nonsort/reference/gcc-8/coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/gcovr/tests/html-nested-nonsort/reference/gcc-8/coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_nested.css">
+    <link rel="stylesheet" href="coverage_nested.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-percentage/reference/clang-10/coverage.A.7fc56270e7a70fa81a5935b72eacbe29.html
+++ b/gcovr/tests/html-nested-sort-percentage/reference/clang-10/coverage.A.7fc56270e7a70fa81a5935b72eacbe29.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-percentage/reference/clang-10/coverage.C.65c6818f1beed0acac61ab4a271ddda2.html
+++ b/gcovr/tests/html-nested-sort-percentage/reference/clang-10/coverage.C.65c6818f1beed0acac61ab4a271ddda2.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-percentage/reference/clang-10/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/gcovr/tests/html-nested-sort-percentage/reference/clang-10/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-percentage/reference/clang-10/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
+++ b/gcovr/tests/html-nested-sort-percentage/reference/clang-10/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-percentage/reference/clang-10/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/gcovr/tests/html-nested-sort-percentage/reference/clang-10/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-percentage/reference/clang-10/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
+++ b/gcovr/tests/html-nested-sort-percentage/reference/clang-10/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-percentage/reference/clang-10/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/gcovr/tests/html-nested-sort-percentage/reference/clang-10/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-percentage/reference/clang-10/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
+++ b/gcovr/tests/html-nested-sort-percentage/reference/clang-10/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-percentage/reference/clang-10/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/gcovr/tests/html-nested-sort-percentage/reference/clang-10/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-percentage/reference/clang-10/coverage.functions.html
+++ b/gcovr/tests/html-nested-sort-percentage/reference/clang-10/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-percentage/reference/clang-10/coverage.html
+++ b/gcovr/tests/html-nested-sort-percentage/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-percentage/reference/clang-10/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/gcovr/tests/html-nested-sort-percentage/reference/clang-10/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-percentage/reference/clang-13/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/gcovr/tests/html-nested-sort-percentage/reference/clang-13/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-percentage/reference/clang-13/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
+++ b/gcovr/tests/html-nested-sort-percentage/reference/clang-13/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-percentage/reference/clang-13/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/gcovr/tests/html-nested-sort-percentage/reference/clang-13/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-percentage/reference/clang-13/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
+++ b/gcovr/tests/html-nested-sort-percentage/reference/clang-13/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-percentage/reference/clang-13/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/gcovr/tests/html-nested-sort-percentage/reference/clang-13/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-percentage/reference/clang-13/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
+++ b/gcovr/tests/html-nested-sort-percentage/reference/clang-13/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-percentage/reference/clang-13/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/gcovr/tests/html-nested-sort-percentage/reference/clang-13/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-percentage/reference/clang-13/coverage.functions.html
+++ b/gcovr/tests/html-nested-sort-percentage/reference/clang-13/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-percentage/reference/gcc-5/coverage.A.7fc56270e7a70fa81a5935b72eacbe29.html
+++ b/gcovr/tests/html-nested-sort-percentage/reference/gcc-5/coverage.A.7fc56270e7a70fa81a5935b72eacbe29.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-percentage/reference/gcc-5/coverage.C.65c6818f1beed0acac61ab4a271ddda2.html
+++ b/gcovr/tests/html-nested-sort-percentage/reference/gcc-5/coverage.C.65c6818f1beed0acac61ab4a271ddda2.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-percentage/reference/gcc-5/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/gcovr/tests/html-nested-sort-percentage/reference/gcc-5/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-percentage/reference/gcc-5/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
+++ b/gcovr/tests/html-nested-sort-percentage/reference/gcc-5/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-percentage/reference/gcc-5/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/gcovr/tests/html-nested-sort-percentage/reference/gcc-5/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-percentage/reference/gcc-5/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
+++ b/gcovr/tests/html-nested-sort-percentage/reference/gcc-5/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-percentage/reference/gcc-5/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/gcovr/tests/html-nested-sort-percentage/reference/gcc-5/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-percentage/reference/gcc-5/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
+++ b/gcovr/tests/html-nested-sort-percentage/reference/gcc-5/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-percentage/reference/gcc-5/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/gcovr/tests/html-nested-sort-percentage/reference/gcc-5/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-percentage/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/html-nested-sort-percentage/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-percentage/reference/gcc-5/coverage.html
+++ b/gcovr/tests/html-nested-sort-percentage/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-percentage/reference/gcc-5/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/gcovr/tests/html-nested-sort-percentage/reference/gcc-5/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-percentage/reference/gcc-8/coverage.A.7fc56270e7a70fa81a5935b72eacbe29.html
+++ b/gcovr/tests/html-nested-sort-percentage/reference/gcc-8/coverage.A.7fc56270e7a70fa81a5935b72eacbe29.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-percentage/reference/gcc-8/coverage.C.65c6818f1beed0acac61ab4a271ddda2.html
+++ b/gcovr/tests/html-nested-sort-percentage/reference/gcc-8/coverage.C.65c6818f1beed0acac61ab4a271ddda2.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-percentage/reference/gcc-8/coverage.functions.html
+++ b/gcovr/tests/html-nested-sort-percentage/reference/gcc-8/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-percentage/reference/gcc-8/coverage.html
+++ b/gcovr/tests/html-nested-sort-percentage/reference/gcc-8/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-percentage/reference/gcc-8/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/gcovr/tests/html-nested-sort-percentage/reference/gcc-8/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-uncovered/reference/clang-10/coverage.A.7fc56270e7a70fa81a5935b72eacbe29.html
+++ b/gcovr/tests/html-nested-sort-uncovered/reference/clang-10/coverage.A.7fc56270e7a70fa81a5935b72eacbe29.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-uncovered/reference/clang-10/coverage.C.65c6818f1beed0acac61ab4a271ddda2.html
+++ b/gcovr/tests/html-nested-sort-uncovered/reference/clang-10/coverage.C.65c6818f1beed0acac61ab4a271ddda2.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-uncovered/reference/clang-10/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/gcovr/tests/html-nested-sort-uncovered/reference/clang-10/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-uncovered/reference/clang-10/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
+++ b/gcovr/tests/html-nested-sort-uncovered/reference/clang-10/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-uncovered/reference/clang-10/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/gcovr/tests/html-nested-sort-uncovered/reference/clang-10/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-uncovered/reference/clang-10/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
+++ b/gcovr/tests/html-nested-sort-uncovered/reference/clang-10/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-uncovered/reference/clang-10/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/gcovr/tests/html-nested-sort-uncovered/reference/clang-10/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-uncovered/reference/clang-10/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
+++ b/gcovr/tests/html-nested-sort-uncovered/reference/clang-10/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-uncovered/reference/clang-10/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/gcovr/tests/html-nested-sort-uncovered/reference/clang-10/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-uncovered/reference/clang-10/coverage.functions.html
+++ b/gcovr/tests/html-nested-sort-uncovered/reference/clang-10/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-uncovered/reference/clang-10/coverage.html
+++ b/gcovr/tests/html-nested-sort-uncovered/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-uncovered/reference/clang-10/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/gcovr/tests/html-nested-sort-uncovered/reference/clang-10/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-uncovered/reference/clang-13/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/gcovr/tests/html-nested-sort-uncovered/reference/clang-13/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-uncovered/reference/clang-13/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
+++ b/gcovr/tests/html-nested-sort-uncovered/reference/clang-13/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-uncovered/reference/clang-13/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/gcovr/tests/html-nested-sort-uncovered/reference/clang-13/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-uncovered/reference/clang-13/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
+++ b/gcovr/tests/html-nested-sort-uncovered/reference/clang-13/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-uncovered/reference/clang-13/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/gcovr/tests/html-nested-sort-uncovered/reference/clang-13/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-uncovered/reference/clang-13/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
+++ b/gcovr/tests/html-nested-sort-uncovered/reference/clang-13/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-uncovered/reference/clang-13/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/gcovr/tests/html-nested-sort-uncovered/reference/clang-13/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-uncovered/reference/clang-13/coverage.functions.html
+++ b/gcovr/tests/html-nested-sort-uncovered/reference/clang-13/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-uncovered/reference/gcc-5/coverage.A.7fc56270e7a70fa81a5935b72eacbe29.html
+++ b/gcovr/tests/html-nested-sort-uncovered/reference/gcc-5/coverage.A.7fc56270e7a70fa81a5935b72eacbe29.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-uncovered/reference/gcc-5/coverage.C.65c6818f1beed0acac61ab4a271ddda2.html
+++ b/gcovr/tests/html-nested-sort-uncovered/reference/gcc-5/coverage.C.65c6818f1beed0acac61ab4a271ddda2.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-uncovered/reference/gcc-5/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/gcovr/tests/html-nested-sort-uncovered/reference/gcc-5/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-uncovered/reference/gcc-5/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
+++ b/gcovr/tests/html-nested-sort-uncovered/reference/gcc-5/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-uncovered/reference/gcc-5/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/gcovr/tests/html-nested-sort-uncovered/reference/gcc-5/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-uncovered/reference/gcc-5/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
+++ b/gcovr/tests/html-nested-sort-uncovered/reference/gcc-5/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-uncovered/reference/gcc-5/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/gcovr/tests/html-nested-sort-uncovered/reference/gcc-5/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-uncovered/reference/gcc-5/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
+++ b/gcovr/tests/html-nested-sort-uncovered/reference/gcc-5/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-uncovered/reference/gcc-5/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/gcovr/tests/html-nested-sort-uncovered/reference/gcc-5/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-uncovered/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/html-nested-sort-uncovered/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-uncovered/reference/gcc-5/coverage.html
+++ b/gcovr/tests/html-nested-sort-uncovered/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-uncovered/reference/gcc-5/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/gcovr/tests/html-nested-sort-uncovered/reference/gcc-5/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-uncovered/reference/gcc-8/coverage.A.7fc56270e7a70fa81a5935b72eacbe29.html
+++ b/gcovr/tests/html-nested-sort-uncovered/reference/gcc-8/coverage.A.7fc56270e7a70fa81a5935b72eacbe29.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-uncovered/reference/gcc-8/coverage.C.65c6818f1beed0acac61ab4a271ddda2.html
+++ b/gcovr/tests/html-nested-sort-uncovered/reference/gcc-8/coverage.C.65c6818f1beed0acac61ab4a271ddda2.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-uncovered/reference/gcc-8/coverage.functions.html
+++ b/gcovr/tests/html-nested-sort-uncovered/reference/gcc-8/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-uncovered/reference/gcc-8/coverage.html
+++ b/gcovr/tests/html-nested-sort-uncovered/reference/gcc-8/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-nested-sort-uncovered/reference/gcc-8/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/gcovr/tests/html-nested-sort-uncovered/reference/gcc-8/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-no-syntax-highlighting/reference/clang-10/coverage.html
+++ b/gcovr/tests/html-no-syntax-highlighting/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-no-syntax-highlighting/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-no-syntax-highlighting/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-no-syntax-highlighting/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/html-no-syntax-highlighting/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-no-syntax-highlighting/reference/gcc-5/coverage.html
+++ b/gcovr/tests/html-no-syntax-highlighting/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-no-syntax-highlighting/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-no-syntax-highlighting/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-source-encoding-cp1252/reference/clang-10/coverage.html
+++ b/gcovr/tests/html-source-encoding-cp1252/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-source-encoding-cp1252/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-source-encoding-cp1252/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-source-encoding-cp1252/reference/clang-13/coverage.html
+++ b/gcovr/tests/html-source-encoding-cp1252/reference/clang-13/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-source-encoding-cp1252/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-source-encoding-cp1252/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-source-encoding-cp1252/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/html-source-encoding-cp1252/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-source-encoding-cp1252/reference/gcc-5/coverage.html
+++ b/gcovr/tests/html-source-encoding-cp1252/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-source-encoding-cp1252/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-source-encoding-cp1252/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-source-encoding-utf8/reference/clang-10/coverage.html
+++ b/gcovr/tests/html-source-encoding-utf8/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-source-encoding-utf8/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-source-encoding-utf8/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-source-encoding-utf8/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/html-source-encoding-utf8/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-source-encoding-utf8/reference/gcc-5/coverage.html
+++ b/gcovr/tests/html-source-encoding-utf8/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-source-encoding-utf8/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-source-encoding-utf8/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-tab-size-2/reference/clang-10/coverage.html
+++ b/gcovr/tests/html-tab-size-2/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-tab-size-2/reference/gcc-5/coverage.html
+++ b/gcovr/tests/html-tab-size-2/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-themes/reference/clang-10/coverage.blue.html
+++ b/gcovr/tests/html-themes/reference/clang-10/coverage.blue.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.blue.css">
+    <link rel="stylesheet" href="coverage.blue.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-themes/reference/clang-10/coverage.blue.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-themes/reference/clang-10/coverage.blue.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.blue.css">
+    <link rel="stylesheet" href="coverage.blue.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-themes/reference/clang-10/coverage.green.html
+++ b/gcovr/tests/html-themes/reference/clang-10/coverage.green.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.green.css">
+    <link rel="stylesheet" href="coverage.green.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-themes/reference/clang-10/coverage.green.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-themes/reference/clang-10/coverage.green.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.green.css">
+    <link rel="stylesheet" href="coverage.green.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-themes/reference/clang-13/coverage.blue.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-themes/reference/clang-13/coverage.blue.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.blue.css">
+    <link rel="stylesheet" href="coverage.blue.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-themes/reference/clang-13/coverage.green.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-themes/reference/clang-13/coverage.green.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.green.css">
+    <link rel="stylesheet" href="coverage.green.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-themes/reference/gcc-10/coverage.blue.functions.html
+++ b/gcovr/tests/html-themes/reference/gcc-10/coverage.blue.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.blue.css">
+    <link rel="stylesheet" href="coverage.blue.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-themes/reference/gcc-10/coverage.blue.html
+++ b/gcovr/tests/html-themes/reference/gcc-10/coverage.blue.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.blue.css">
+    <link rel="stylesheet" href="coverage.blue.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-themes/reference/gcc-10/coverage.blue.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-themes/reference/gcc-10/coverage.blue.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.blue.css">
+    <link rel="stylesheet" href="coverage.blue.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-themes/reference/gcc-10/coverage.green.functions.html
+++ b/gcovr/tests/html-themes/reference/gcc-10/coverage.green.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.green.css">
+    <link rel="stylesheet" href="coverage.green.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-themes/reference/gcc-10/coverage.green.html
+++ b/gcovr/tests/html-themes/reference/gcc-10/coverage.green.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.green.css">
+    <link rel="stylesheet" href="coverage.green.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-themes/reference/gcc-10/coverage.green.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-themes/reference/gcc-10/coverage.green.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.green.css">
+    <link rel="stylesheet" href="coverage.green.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-themes/reference/gcc-11/coverage.blue.functions.html
+++ b/gcovr/tests/html-themes/reference/gcc-11/coverage.blue.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.blue.css">
+    <link rel="stylesheet" href="coverage.blue.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-themes/reference/gcc-11/coverage.blue.html
+++ b/gcovr/tests/html-themes/reference/gcc-11/coverage.blue.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.blue.css">
+    <link rel="stylesheet" href="coverage.blue.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-themes/reference/gcc-11/coverage.blue.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-themes/reference/gcc-11/coverage.blue.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.blue.css">
+    <link rel="stylesheet" href="coverage.blue.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-themes/reference/gcc-11/coverage.green.functions.html
+++ b/gcovr/tests/html-themes/reference/gcc-11/coverage.green.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.green.css">
+    <link rel="stylesheet" href="coverage.green.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-themes/reference/gcc-11/coverage.green.html
+++ b/gcovr/tests/html-themes/reference/gcc-11/coverage.green.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.green.css">
+    <link rel="stylesheet" href="coverage.green.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-themes/reference/gcc-11/coverage.green.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-themes/reference/gcc-11/coverage.green.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.green.css">
+    <link rel="stylesheet" href="coverage.green.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-themes/reference/gcc-5/coverage.blue.functions.html
+++ b/gcovr/tests/html-themes/reference/gcc-5/coverage.blue.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.blue.css">
+    <link rel="stylesheet" href="coverage.blue.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-themes/reference/gcc-5/coverage.blue.html
+++ b/gcovr/tests/html-themes/reference/gcc-5/coverage.blue.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.blue.css">
+    <link rel="stylesheet" href="coverage.blue.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-themes/reference/gcc-5/coverage.blue.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-themes/reference/gcc-5/coverage.blue.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.blue.css">
+    <link rel="stylesheet" href="coverage.blue.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-themes/reference/gcc-5/coverage.green.functions.html
+++ b/gcovr/tests/html-themes/reference/gcc-5/coverage.green.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.green.css">
+    <link rel="stylesheet" href="coverage.green.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-themes/reference/gcc-5/coverage.green.html
+++ b/gcovr/tests/html-themes/reference/gcc-5/coverage.green.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.green.css">
+    <link rel="stylesheet" href="coverage.green.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-themes/reference/gcc-5/coverage.green.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-themes/reference/gcc-5/coverage.green.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.green.css">
+    <link rel="stylesheet" href="coverage.green.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-themes/reference/gcc-6/coverage.blue.functions.html
+++ b/gcovr/tests/html-themes/reference/gcc-6/coverage.blue.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.blue.css">
+    <link rel="stylesheet" href="coverage.blue.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-themes/reference/gcc-6/coverage.blue.html
+++ b/gcovr/tests/html-themes/reference/gcc-6/coverage.blue.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.blue.css">
+    <link rel="stylesheet" href="coverage.blue.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-themes/reference/gcc-6/coverage.blue.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-themes/reference/gcc-6/coverage.blue.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.blue.css">
+    <link rel="stylesheet" href="coverage.blue.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-themes/reference/gcc-6/coverage.green.functions.html
+++ b/gcovr/tests/html-themes/reference/gcc-6/coverage.green.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.green.css">
+    <link rel="stylesheet" href="coverage.green.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-themes/reference/gcc-6/coverage.green.html
+++ b/gcovr/tests/html-themes/reference/gcc-6/coverage.green.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.green.css">
+    <link rel="stylesheet" href="coverage.green.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-themes/reference/gcc-6/coverage.green.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-themes/reference/gcc-6/coverage.green.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.green.css">
+    <link rel="stylesheet" href="coverage.green.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-themes/reference/gcc-8/coverage.blue.functions.html
+++ b/gcovr/tests/html-themes/reference/gcc-8/coverage.blue.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.blue.css">
+    <link rel="stylesheet" href="coverage.blue.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-themes/reference/gcc-8/coverage.blue.html
+++ b/gcovr/tests/html-themes/reference/gcc-8/coverage.blue.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.blue.css">
+    <link rel="stylesheet" href="coverage.blue.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-themes/reference/gcc-8/coverage.blue.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-themes/reference/gcc-8/coverage.blue.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.blue.css">
+    <link rel="stylesheet" href="coverage.blue.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-themes/reference/gcc-8/coverage.green.functions.html
+++ b/gcovr/tests/html-themes/reference/gcc-8/coverage.green.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.green.css">
+    <link rel="stylesheet" href="coverage.green.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-themes/reference/gcc-8/coverage.green.html
+++ b/gcovr/tests/html-themes/reference/gcc-8/coverage.green.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.green.css">
+    <link rel="stylesheet" href="coverage.green.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-themes/reference/gcc-8/coverage.green.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-themes/reference/gcc-8/coverage.green.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.green.css">
+    <link rel="stylesheet" href="coverage.green.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-title/reference/clang-10/coverage.html
+++ b/gcovr/tests/html-title/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>Title of report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-title/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-title/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>Title of report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-title/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/html-title/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>Title of report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-title/reference/gcc-5/coverage.html
+++ b/gcovr/tests/html-title/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>Title of report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/html-title/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/html-title/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>Title of report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/linked/reference/clang-10/coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
+++ b/gcovr/tests/linked/reference/clang-10/coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/linked/reference/clang-10/coverage.file2.cpp.eaea841cc07a0c33cf11763308ec1d22.html
+++ b/gcovr/tests/linked/reference/clang-10/coverage.file2.cpp.eaea841cc07a0c33cf11763308ec1d22.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/linked/reference/clang-10/coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
+++ b/gcovr/tests/linked/reference/clang-10/coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/linked/reference/clang-10/coverage.file4.cpp.2b76827d4721ef11f88982191f3ee8c1.html
+++ b/gcovr/tests/linked/reference/clang-10/coverage.file4.cpp.2b76827d4721ef11f88982191f3ee8c1.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/linked/reference/clang-10/coverage.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
+++ b/gcovr/tests/linked/reference/clang-10/coverage.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/linked/reference/clang-10/coverage.file6.cpp.37f4b31e3e12086d7b0f11d140944edf.html
+++ b/gcovr/tests/linked/reference/clang-10/coverage.file6.cpp.37f4b31e3e12086d7b0f11d140944edf.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/linked/reference/clang-10/coverage.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
+++ b/gcovr/tests/linked/reference/clang-10/coverage.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/linked/reference/clang-10/coverage.html
+++ b/gcovr/tests/linked/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/linked/reference/clang-10/coverage.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/gcovr/tests/linked/reference/clang-10/coverage.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/linked/reference/clang-13/coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
+++ b/gcovr/tests/linked/reference/clang-13/coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/linked/reference/clang-13/coverage.file2.cpp.eaea841cc07a0c33cf11763308ec1d22.html
+++ b/gcovr/tests/linked/reference/clang-13/coverage.file2.cpp.eaea841cc07a0c33cf11763308ec1d22.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/linked/reference/clang-13/coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
+++ b/gcovr/tests/linked/reference/clang-13/coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/linked/reference/clang-13/coverage.file4.cpp.2b76827d4721ef11f88982191f3ee8c1.html
+++ b/gcovr/tests/linked/reference/clang-13/coverage.file4.cpp.2b76827d4721ef11f88982191f3ee8c1.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/linked/reference/clang-13/coverage.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
+++ b/gcovr/tests/linked/reference/clang-13/coverage.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/linked/reference/clang-13/coverage.file6.cpp.37f4b31e3e12086d7b0f11d140944edf.html
+++ b/gcovr/tests/linked/reference/clang-13/coverage.file6.cpp.37f4b31e3e12086d7b0f11d140944edf.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/linked/reference/clang-13/coverage.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
+++ b/gcovr/tests/linked/reference/clang-13/coverage.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/linked/reference/gcc-5/coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
+++ b/gcovr/tests/linked/reference/gcc-5/coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/linked/reference/gcc-5/coverage.file2.cpp.eaea841cc07a0c33cf11763308ec1d22.html
+++ b/gcovr/tests/linked/reference/gcc-5/coverage.file2.cpp.eaea841cc07a0c33cf11763308ec1d22.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/linked/reference/gcc-5/coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
+++ b/gcovr/tests/linked/reference/gcc-5/coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/linked/reference/gcc-5/coverage.file4.cpp.2b76827d4721ef11f88982191f3ee8c1.html
+++ b/gcovr/tests/linked/reference/gcc-5/coverage.file4.cpp.2b76827d4721ef11f88982191f3ee8c1.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/linked/reference/gcc-5/coverage.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
+++ b/gcovr/tests/linked/reference/gcc-5/coverage.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/linked/reference/gcc-5/coverage.file6.cpp.37f4b31e3e12086d7b0f11d140944edf.html
+++ b/gcovr/tests/linked/reference/gcc-5/coverage.file6.cpp.37f4b31e3e12086d7b0f11d140944edf.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/linked/reference/gcc-5/coverage.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
+++ b/gcovr/tests/linked/reference/gcc-5/coverage.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/linked/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/linked/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/linked/reference/gcc-5/coverage.html
+++ b/gcovr/tests/linked/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/linked/reference/gcc-5/coverage.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/gcovr/tests/linked/reference/gcc-5/coverage.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/linked/reference/gcc-8/coverage.functions.html
+++ b/gcovr/tests/linked/reference/gcc-8/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/linked/reference/gcc-8/coverage.html
+++ b/gcovr/tests/linked/reference/gcc-8/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/linked/reference/gcc-8/coverage.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/gcovr/tests/linked/reference/gcc-8/coverage.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested/reference/clang-10/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/gcovr/tests/nested/reference/clang-10/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested/reference/clang-10/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
+++ b/gcovr/tests/nested/reference/clang-10/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested/reference/clang-10/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/gcovr/tests/nested/reference/clang-10/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested/reference/clang-10/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
+++ b/gcovr/tests/nested/reference/clang-10/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested/reference/clang-10/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/gcovr/tests/nested/reference/clang-10/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested/reference/clang-10/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
+++ b/gcovr/tests/nested/reference/clang-10/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested/reference/clang-10/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/gcovr/tests/nested/reference/clang-10/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested/reference/clang-10/coverage.html
+++ b/gcovr/tests/nested/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested/reference/clang-10/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/gcovr/tests/nested/reference/clang-10/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested/reference/clang-13/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/gcovr/tests/nested/reference/clang-13/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested/reference/clang-13/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
+++ b/gcovr/tests/nested/reference/clang-13/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested/reference/clang-13/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/gcovr/tests/nested/reference/clang-13/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested/reference/clang-13/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
+++ b/gcovr/tests/nested/reference/clang-13/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested/reference/clang-13/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/gcovr/tests/nested/reference/clang-13/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested/reference/clang-13/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
+++ b/gcovr/tests/nested/reference/clang-13/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested/reference/clang-13/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/gcovr/tests/nested/reference/clang-13/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested/reference/gcc-5/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/gcovr/tests/nested/reference/gcc-5/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested/reference/gcc-5/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
+++ b/gcovr/tests/nested/reference/gcc-5/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested/reference/gcc-5/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/gcovr/tests/nested/reference/gcc-5/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested/reference/gcc-5/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
+++ b/gcovr/tests/nested/reference/gcc-5/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested/reference/gcc-5/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/gcovr/tests/nested/reference/gcc-5/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested/reference/gcc-5/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
+++ b/gcovr/tests/nested/reference/gcc-5/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested/reference/gcc-5/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/gcovr/tests/nested/reference/gcc-5/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/nested/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested/reference/gcc-5/coverage.html
+++ b/gcovr/tests/nested/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested/reference/gcc-5/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/gcovr/tests/nested/reference/gcc-5/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested/reference/gcc-8/coverage.functions.html
+++ b/gcovr/tests/nested/reference/gcc-8/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested/reference/gcc-8/coverage.html
+++ b/gcovr/tests/nested/reference/gcc-8/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested/reference/gcc-8/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/gcovr/tests/nested/reference/gcc-8/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2-use-existing/reference/clang-10/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/gcovr/tests/nested2-use-existing/reference/clang-10/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2-use-existing/reference/clang-10/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
+++ b/gcovr/tests/nested2-use-existing/reference/clang-10/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2-use-existing/reference/clang-10/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/gcovr/tests/nested2-use-existing/reference/clang-10/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2-use-existing/reference/clang-10/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
+++ b/gcovr/tests/nested2-use-existing/reference/clang-10/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2-use-existing/reference/clang-10/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/gcovr/tests/nested2-use-existing/reference/clang-10/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2-use-existing/reference/clang-10/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
+++ b/gcovr/tests/nested2-use-existing/reference/clang-10/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2-use-existing/reference/clang-10/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/gcovr/tests/nested2-use-existing/reference/clang-10/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2-use-existing/reference/clang-10/coverage.html
+++ b/gcovr/tests/nested2-use-existing/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2-use-existing/reference/clang-10/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/gcovr/tests/nested2-use-existing/reference/clang-10/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2-use-existing/reference/gcc-5/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/gcovr/tests/nested2-use-existing/reference/gcc-5/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2-use-existing/reference/gcc-5/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
+++ b/gcovr/tests/nested2-use-existing/reference/gcc-5/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2-use-existing/reference/gcc-5/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/gcovr/tests/nested2-use-existing/reference/gcc-5/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2-use-existing/reference/gcc-5/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
+++ b/gcovr/tests/nested2-use-existing/reference/gcc-5/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2-use-existing/reference/gcc-5/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/gcovr/tests/nested2-use-existing/reference/gcc-5/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2-use-existing/reference/gcc-5/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
+++ b/gcovr/tests/nested2-use-existing/reference/gcc-5/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2-use-existing/reference/gcc-5/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/gcovr/tests/nested2-use-existing/reference/gcc-5/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2-use-existing/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/nested2-use-existing/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2-use-existing/reference/gcc-5/coverage.html
+++ b/gcovr/tests/nested2-use-existing/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2-use-existing/reference/gcc-5/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/gcovr/tests/nested2-use-existing/reference/gcc-5/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2-use-existing/reference/gcc-8/coverage.functions.html
+++ b/gcovr/tests/nested2-use-existing/reference/gcc-8/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2-use-existing/reference/gcc-8/coverage.html
+++ b/gcovr/tests/nested2-use-existing/reference/gcc-8/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2-use-existing/reference/gcc-8/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/gcovr/tests/nested2-use-existing/reference/gcc-8/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2/reference/clang-10/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/gcovr/tests/nested2/reference/clang-10/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2/reference/clang-10/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
+++ b/gcovr/tests/nested2/reference/clang-10/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2/reference/clang-10/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/gcovr/tests/nested2/reference/clang-10/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2/reference/clang-10/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
+++ b/gcovr/tests/nested2/reference/clang-10/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2/reference/clang-10/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/gcovr/tests/nested2/reference/clang-10/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2/reference/clang-10/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
+++ b/gcovr/tests/nested2/reference/clang-10/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2/reference/clang-10/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/gcovr/tests/nested2/reference/clang-10/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2/reference/clang-10/coverage.html
+++ b/gcovr/tests/nested2/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2/reference/clang-10/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/gcovr/tests/nested2/reference/clang-10/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2/reference/clang-13/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/gcovr/tests/nested2/reference/clang-13/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2/reference/clang-13/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
+++ b/gcovr/tests/nested2/reference/clang-13/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2/reference/clang-13/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/gcovr/tests/nested2/reference/clang-13/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2/reference/clang-13/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
+++ b/gcovr/tests/nested2/reference/clang-13/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2/reference/clang-13/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/gcovr/tests/nested2/reference/clang-13/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2/reference/clang-13/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
+++ b/gcovr/tests/nested2/reference/clang-13/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2/reference/clang-13/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/gcovr/tests/nested2/reference/clang-13/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2/reference/gcc-5/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/gcovr/tests/nested2/reference/gcc-5/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2/reference/gcc-5/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
+++ b/gcovr/tests/nested2/reference/gcc-5/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2/reference/gcc-5/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/gcovr/tests/nested2/reference/gcc-5/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2/reference/gcc-5/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
+++ b/gcovr/tests/nested2/reference/gcc-5/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2/reference/gcc-5/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/gcovr/tests/nested2/reference/gcc-5/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2/reference/gcc-5/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
+++ b/gcovr/tests/nested2/reference/gcc-5/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2/reference/gcc-5/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/gcovr/tests/nested2/reference/gcc-5/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/nested2/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2/reference/gcc-5/coverage.html
+++ b/gcovr/tests/nested2/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2/reference/gcc-5/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/gcovr/tests/nested2/reference/gcc-5/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2/reference/gcc-8/coverage.functions.html
+++ b/gcovr/tests/nested2/reference/gcc-8/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2/reference/gcc-8/coverage.html
+++ b/gcovr/tests/nested2/reference/gcc-8/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested2/reference/gcc-8/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/gcovr/tests/nested2/reference/gcc-8/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested3/reference/clang-10/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/gcovr/tests/nested3/reference/clang-10/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested3/reference/clang-10/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
+++ b/gcovr/tests/nested3/reference/clang-10/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested3/reference/clang-10/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/gcovr/tests/nested3/reference/clang-10/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested3/reference/clang-10/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
+++ b/gcovr/tests/nested3/reference/clang-10/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested3/reference/clang-10/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/gcovr/tests/nested3/reference/clang-10/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested3/reference/clang-10/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
+++ b/gcovr/tests/nested3/reference/clang-10/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested3/reference/clang-10/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/gcovr/tests/nested3/reference/clang-10/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested3/reference/clang-10/coverage.html
+++ b/gcovr/tests/nested3/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested3/reference/clang-10/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/gcovr/tests/nested3/reference/clang-10/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested3/reference/clang-13/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/gcovr/tests/nested3/reference/clang-13/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested3/reference/clang-13/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
+++ b/gcovr/tests/nested3/reference/clang-13/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested3/reference/clang-13/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/gcovr/tests/nested3/reference/clang-13/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested3/reference/clang-13/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
+++ b/gcovr/tests/nested3/reference/clang-13/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested3/reference/clang-13/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/gcovr/tests/nested3/reference/clang-13/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested3/reference/clang-13/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
+++ b/gcovr/tests/nested3/reference/clang-13/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested3/reference/clang-13/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/gcovr/tests/nested3/reference/clang-13/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested3/reference/gcc-5/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/gcovr/tests/nested3/reference/gcc-5/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested3/reference/gcc-5/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
+++ b/gcovr/tests/nested3/reference/gcc-5/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested3/reference/gcc-5/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/gcovr/tests/nested3/reference/gcc-5/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested3/reference/gcc-5/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
+++ b/gcovr/tests/nested3/reference/gcc-5/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested3/reference/gcc-5/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/gcovr/tests/nested3/reference/gcc-5/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested3/reference/gcc-5/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
+++ b/gcovr/tests/nested3/reference/gcc-5/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested3/reference/gcc-5/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/gcovr/tests/nested3/reference/gcc-5/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested3/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/nested3/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested3/reference/gcc-5/coverage.html
+++ b/gcovr/tests/nested3/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nested3/reference/gcc-5/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/gcovr/tests/nested3/reference/gcc-5/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/no-markers/reference/clang-10/coverage.html
+++ b/gcovr/tests/no-markers/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/no-markers/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/no-markers/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/no-markers/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/no-markers/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/no-markers/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/no-markers/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/no-markers/reference/gcc-5/coverage.html
+++ b/gcovr/tests/no-markers/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/no-markers/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/no-markers/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/no-markers/reference/gcc-8/coverage.functions.html
+++ b/gcovr/tests/no-markers/reference/gcc-8/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/no-markers/reference/gcc-8/coverage.html
+++ b/gcovr/tests/no-markers/reference/gcc-8/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/no-markers/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/no-markers/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nobranch/reference/clang-10/coverage.html
+++ b/gcovr/tests/nobranch/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nobranch/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/nobranch/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nobranch/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/nobranch/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nobranch/reference/gcc-5/coverage.html
+++ b/gcovr/tests/nobranch/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/nobranch/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/nobranch/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/noncode/reference/clang-10/coverage.functions.html
+++ b/gcovr/tests/noncode/reference/clang-10/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/noncode/reference/clang-10/coverage.html
+++ b/gcovr/tests/noncode/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/noncode/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/noncode/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/noncode/reference/gcc-10/coverage.functions.html
+++ b/gcovr/tests/noncode/reference/gcc-10/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/noncode/reference/gcc-10/coverage.html
+++ b/gcovr/tests/noncode/reference/gcc-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/noncode/reference/gcc-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/noncode/reference/gcc-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/noncode/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/noncode/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/noncode/reference/gcc-5/coverage.html
+++ b/gcovr/tests/noncode/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/noncode/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/noncode/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/noncode/reference/gcc-8/coverage.functions.html
+++ b/gcovr/tests/noncode/reference/gcc-8/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/noncode/reference/gcc-8/coverage.html
+++ b/gcovr/tests/noncode/reference/gcc-8/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/noncode/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/noncode/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/oos/reference/clang-10/coverage.file1.cpp.79c9168e71af7c6ad188756fb55e9092.html
+++ b/gcovr/tests/oos/reference/clang-10/coverage.file1.cpp.79c9168e71af7c6ad188756fb55e9092.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/oos/reference/clang-10/coverage.html
+++ b/gcovr/tests/oos/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/oos/reference/clang-10/coverage.main.cpp.7ec3c68a81efff79b6ca22ac1f1eabba.html
+++ b/gcovr/tests/oos/reference/clang-10/coverage.main.cpp.7ec3c68a81efff79b6ca22ac1f1eabba.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/oos/reference/clang-13/coverage.file1.cpp.79c9168e71af7c6ad188756fb55e9092.html
+++ b/gcovr/tests/oos/reference/clang-13/coverage.file1.cpp.79c9168e71af7c6ad188756fb55e9092.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/oos/reference/clang-13/coverage.main.cpp.7ec3c68a81efff79b6ca22ac1f1eabba.html
+++ b/gcovr/tests/oos/reference/clang-13/coverage.main.cpp.7ec3c68a81efff79b6ca22ac1f1eabba.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/oos/reference/gcc-5/coverage.file1.cpp.79c9168e71af7c6ad188756fb55e9092.html
+++ b/gcovr/tests/oos/reference/gcc-5/coverage.file1.cpp.79c9168e71af7c6ad188756fb55e9092.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/oos/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/oos/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/oos/reference/gcc-5/coverage.html
+++ b/gcovr/tests/oos/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/oos/reference/gcc-5/coverage.main.cpp.7ec3c68a81efff79b6ca22ac1f1eabba.html
+++ b/gcovr/tests/oos/reference/gcc-5/coverage.main.cpp.7ec3c68a81efff79b6ca22ac1f1eabba.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/oos/reference/gcc-8/coverage.functions.html
+++ b/gcovr/tests/oos/reference/gcc-8/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/oos/reference/gcc-8/coverage.html
+++ b/gcovr/tests/oos/reference/gcc-8/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/oos/reference/gcc-8/coverage.main.cpp.7ec3c68a81efff79b6ca22ac1f1eabba.html
+++ b/gcovr/tests/oos/reference/gcc-8/coverage.main.cpp.7ec3c68a81efff79b6ca22ac1f1eabba.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/oos2/reference/clang-10/coverage.file1.cpp.37fe642e5aafc503ffc5506444f44c6f.html
+++ b/gcovr/tests/oos2/reference/clang-10/coverage.file1.cpp.37fe642e5aafc503ffc5506444f44c6f.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/oos2/reference/clang-10/coverage.html
+++ b/gcovr/tests/oos2/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/oos2/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/oos2/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/oos2/reference/clang-13/coverage.file1.cpp.37fe642e5aafc503ffc5506444f44c6f.html
+++ b/gcovr/tests/oos2/reference/clang-13/coverage.file1.cpp.37fe642e5aafc503ffc5506444f44c6f.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/oos2/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/oos2/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/oos2/reference/gcc-5/coverage.file1.cpp.37fe642e5aafc503ffc5506444f44c6f.html
+++ b/gcovr/tests/oos2/reference/gcc-5/coverage.file1.cpp.37fe642e5aafc503ffc5506444f44c6f.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/oos2/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/oos2/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/oos2/reference/gcc-5/coverage.html
+++ b/gcovr/tests/oos2/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/oos2/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/oos2/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/oos2/reference/gcc-8/coverage.functions.html
+++ b/gcovr/tests/oos2/reference/gcc-8/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/oos2/reference/gcc-8/coverage.html
+++ b/gcovr/tests/oos2/reference/gcc-8/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/oos2/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/oos2/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/rounding/reference/clang-10/coverage.html
+++ b/gcovr/tests/rounding/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/rounding/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/rounding/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/rounding/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/rounding/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/rounding/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/rounding/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/rounding/reference/gcc-5/coverage.html
+++ b/gcovr/tests/rounding/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/rounding/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/rounding/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/shadow/reference/clang-10/coverage.html
+++ b/gcovr/tests/shadow/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/shadow/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/shadow/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/shadow/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/shadow/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/shadow/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/shadow/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/shadow/reference/gcc-5/coverage.html
+++ b/gcovr/tests/shadow/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/shadow/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/shadow/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/shadow/reference/gcc-8/coverage.functions.html
+++ b/gcovr/tests/shadow/reference/gcc-8/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/shadow/reference/gcc-8/coverage.html
+++ b/gcovr/tests/shadow/reference/gcc-8/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/shadow/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/shadow/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/shared_lib/reference/clang-10/coverage.html
+++ b/gcovr/tests/shared_lib/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/shared_lib/reference/clang-10/coverage.lib.cpp.fe0bf7776d5f70ffd16bbbe1585c3b26.html
+++ b/gcovr/tests/shared_lib/reference/clang-10/coverage.lib.cpp.fe0bf7776d5f70ffd16bbbe1585c3b26.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/shared_lib/reference/clang-10/coverage.tmp.cpp.5862a73542fa66ffe4756306b76b28bb.html
+++ b/gcovr/tests/shared_lib/reference/clang-10/coverage.tmp.cpp.5862a73542fa66ffe4756306b76b28bb.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/shared_lib/reference/clang-13/coverage.lib.cpp.fe0bf7776d5f70ffd16bbbe1585c3b26.html
+++ b/gcovr/tests/shared_lib/reference/clang-13/coverage.lib.cpp.fe0bf7776d5f70ffd16bbbe1585c3b26.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/shared_lib/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/shared_lib/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/shared_lib/reference/gcc-5/coverage.html
+++ b/gcovr/tests/shared_lib/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/shared_lib/reference/gcc-5/coverage.lib.cpp.fe0bf7776d5f70ffd16bbbe1585c3b26.html
+++ b/gcovr/tests/shared_lib/reference/gcc-5/coverage.lib.cpp.fe0bf7776d5f70ffd16bbbe1585c3b26.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/shared_lib/reference/gcc-5/coverage.tmp.cpp.5862a73542fa66ffe4756306b76b28bb.html
+++ b/gcovr/tests/shared_lib/reference/gcc-5/coverage.tmp.cpp.5862a73542fa66ffe4756306b76b28bb.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/shared_lib/reference/gcc-8/coverage.functions.html
+++ b/gcovr/tests/shared_lib/reference/gcc-8/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/shared_lib/reference/gcc-8/coverage.html
+++ b/gcovr/tests/shared_lib/reference/gcc-8/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/shared_lib/reference/gcc-8/coverage.lib.cpp.fe0bf7776d5f70ffd16bbbe1585c3b26.html
+++ b/gcovr/tests/shared_lib/reference/gcc-8/coverage.lib.cpp.fe0bf7776d5f70ffd16bbbe1585c3b26.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/simple1-dir/reference/clang-10/coverage_details.html
+++ b/gcovr/tests/simple1-dir/reference/clang-10/coverage_details.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_details.css">
+    <link rel="stylesheet" href="coverage_details.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/simple1-dir/reference/clang-10/coverage_details.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/simple1-dir/reference/clang-10/coverage_details.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_details.css">
+    <link rel="stylesheet" href="coverage_details.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/simple1-dir/reference/clang-13/coverage_details.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/simple1-dir/reference/clang-13/coverage_details.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_details.css">
+    <link rel="stylesheet" href="coverage_details.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/simple1-dir/reference/gcc-5/coverage_details.functions.html
+++ b/gcovr/tests/simple1-dir/reference/gcc-5/coverage_details.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_details.css">
+    <link rel="stylesheet" href="coverage_details.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/simple1-dir/reference/gcc-5/coverage_details.html
+++ b/gcovr/tests/simple1-dir/reference/gcc-5/coverage_details.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_details.css">
+    <link rel="stylesheet" href="coverage_details.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/simple1-dir/reference/gcc-5/coverage_details.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/simple1-dir/reference/gcc-5/coverage_details.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_details.css">
+    <link rel="stylesheet" href="coverage_details.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/simple1-dir/reference/gcc-8/coverage_details.functions.html
+++ b/gcovr/tests/simple1-dir/reference/gcc-8/coverage_details.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_details.css">
+    <link rel="stylesheet" href="coverage_details.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/simple1-dir/reference/gcc-8/coverage_details.html
+++ b/gcovr/tests/simple1-dir/reference/gcc-8/coverage_details.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_details.css">
+    <link rel="stylesheet" href="coverage_details.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/simple1-dir/reference/gcc-8/coverage_details.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/simple1-dir/reference/gcc-8/coverage_details.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage_details.css">
+    <link rel="stylesheet" href="coverage_details.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/simple1-drive-subst/reference/gcc-8-Windows/coverage-details-linkcss.html
+++ b/gcovr/tests/simple1-drive-subst/reference/gcc-8-Windows/coverage-details-linkcss.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-details-linkcss.css">
+    <link rel="stylesheet" href="coverage-details-linkcss.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/simple1-drive-subst/reference/gcc-8-Windows/coverage-details-linkcss.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/simple1-drive-subst/reference/gcc-8-Windows/coverage-details-linkcss.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-details-linkcss.css">
+    <link rel="stylesheet" href="coverage-details-linkcss.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/simple1/reference/clang-10/coverage-details-linkcss.functions.html
+++ b/gcovr/tests/simple1/reference/clang-10/coverage-details-linkcss.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-details-linkcss.css">
+    <link rel="stylesheet" href="coverage-details-linkcss.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/simple1/reference/clang-10/coverage-details-linkcss.html
+++ b/gcovr/tests/simple1/reference/clang-10/coverage-details-linkcss.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-details-linkcss.css">
+    <link rel="stylesheet" href="coverage-details-linkcss.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/simple1/reference/clang-10/coverage-details-linkcss.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/simple1/reference/clang-10/coverage-details-linkcss.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-details-linkcss.css">
+    <link rel="stylesheet" href="coverage-details-linkcss.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/simple1/reference/clang-10/coverage-summary-linkcss.html
+++ b/gcovr/tests/simple1/reference/clang-10/coverage-summary-linkcss.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-summary-linkcss.css">
+    <link rel="stylesheet" href="coverage-summary-linkcss.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/simple1/reference/clang-13/coverage-details-linkcss.functions.html
+++ b/gcovr/tests/simple1/reference/clang-13/coverage-details-linkcss.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-details-linkcss.css">
+    <link rel="stylesheet" href="coverage-details-linkcss.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/simple1/reference/clang-13/coverage-details-linkcss.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/simple1/reference/clang-13/coverage-details-linkcss.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-details-linkcss.css">
+    <link rel="stylesheet" href="coverage-details-linkcss.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/simple1/reference/gcc-5/coverage-details-linkcss.functions.html
+++ b/gcovr/tests/simple1/reference/gcc-5/coverage-details-linkcss.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-details-linkcss.css">
+    <link rel="stylesheet" href="coverage-details-linkcss.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/simple1/reference/gcc-5/coverage-details-linkcss.html
+++ b/gcovr/tests/simple1/reference/gcc-5/coverage-details-linkcss.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-details-linkcss.css">
+    <link rel="stylesheet" href="coverage-details-linkcss.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/simple1/reference/gcc-5/coverage-details-linkcss.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/simple1/reference/gcc-5/coverage-details-linkcss.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-details-linkcss.css">
+    <link rel="stylesheet" href="coverage-details-linkcss.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/simple1/reference/gcc-5/coverage-summary-linkcss.html
+++ b/gcovr/tests/simple1/reference/gcc-5/coverage-summary-linkcss.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-summary-linkcss.css">
+    <link rel="stylesheet" href="coverage-summary-linkcss.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/simple1/reference/gcc-8/coverage-details-linkcss.functions.html
+++ b/gcovr/tests/simple1/reference/gcc-8/coverage-details-linkcss.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-details-linkcss.css">
+    <link rel="stylesheet" href="coverage-details-linkcss.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/simple1/reference/gcc-8/coverage-details-linkcss.html
+++ b/gcovr/tests/simple1/reference/gcc-8/coverage-details-linkcss.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-details-linkcss.css">
+    <link rel="stylesheet" href="coverage-details-linkcss.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/simple1/reference/gcc-8/coverage-details-linkcss.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/simple1/reference/gcc-8/coverage-details-linkcss.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-details-linkcss.css">
+    <link rel="stylesheet" href="coverage-details-linkcss.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/simple1/reference/gcc-8/coverage-summary-linkcss.html
+++ b/gcovr/tests/simple1/reference/gcc-8/coverage-summary-linkcss.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage-summary-linkcss.css">
+    <link rel="stylesheet" href="coverage-summary-linkcss.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-percentage/reference/clang-10/coverage.file1.cpp.37fe642e5aafc503ffc5506444f44c6f.html
+++ b/gcovr/tests/sort-percentage/reference/clang-10/coverage.file1.cpp.37fe642e5aafc503ffc5506444f44c6f.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-percentage/reference/clang-10/coverage.file2.cpp.6037836e0caa27aaeac26df61b128c1b.html
+++ b/gcovr/tests/sort-percentage/reference/clang-10/coverage.file2.cpp.6037836e0caa27aaeac26df61b128c1b.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-percentage/reference/clang-10/coverage.file3.cpp.a89d5d218ee87cc237c08dfe8c96105c.html
+++ b/gcovr/tests/sort-percentage/reference/clang-10/coverage.file3.cpp.a89d5d218ee87cc237c08dfe8c96105c.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-percentage/reference/clang-10/coverage.file4.cpp.02ece764f9b8791575a938834ca3ac75.html
+++ b/gcovr/tests/sort-percentage/reference/clang-10/coverage.file4.cpp.02ece764f9b8791575a938834ca3ac75.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-percentage/reference/clang-10/coverage.html
+++ b/gcovr/tests/sort-percentage/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-percentage/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/sort-percentage/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-percentage/reference/clang-13/coverage.file1.cpp.37fe642e5aafc503ffc5506444f44c6f.html
+++ b/gcovr/tests/sort-percentage/reference/clang-13/coverage.file1.cpp.37fe642e5aafc503ffc5506444f44c6f.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-percentage/reference/clang-13/coverage.file2.cpp.6037836e0caa27aaeac26df61b128c1b.html
+++ b/gcovr/tests/sort-percentage/reference/clang-13/coverage.file2.cpp.6037836e0caa27aaeac26df61b128c1b.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-percentage/reference/clang-13/coverage.file3.cpp.a89d5d218ee87cc237c08dfe8c96105c.html
+++ b/gcovr/tests/sort-percentage/reference/clang-13/coverage.file3.cpp.a89d5d218ee87cc237c08dfe8c96105c.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-percentage/reference/clang-13/coverage.file4.cpp.02ece764f9b8791575a938834ca3ac75.html
+++ b/gcovr/tests/sort-percentage/reference/clang-13/coverage.file4.cpp.02ece764f9b8791575a938834ca3ac75.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-percentage/reference/gcc-5/coverage.file1.cpp.37fe642e5aafc503ffc5506444f44c6f.html
+++ b/gcovr/tests/sort-percentage/reference/gcc-5/coverage.file1.cpp.37fe642e5aafc503ffc5506444f44c6f.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-percentage/reference/gcc-5/coverage.file2.cpp.6037836e0caa27aaeac26df61b128c1b.html
+++ b/gcovr/tests/sort-percentage/reference/gcc-5/coverage.file2.cpp.6037836e0caa27aaeac26df61b128c1b.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-percentage/reference/gcc-5/coverage.file3.cpp.a89d5d218ee87cc237c08dfe8c96105c.html
+++ b/gcovr/tests/sort-percentage/reference/gcc-5/coverage.file3.cpp.a89d5d218ee87cc237c08dfe8c96105c.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-percentage/reference/gcc-5/coverage.file4.cpp.02ece764f9b8791575a938834ca3ac75.html
+++ b/gcovr/tests/sort-percentage/reference/gcc-5/coverage.file4.cpp.02ece764f9b8791575a938834ca3ac75.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-percentage/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/sort-percentage/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-percentage/reference/gcc-5/coverage.html
+++ b/gcovr/tests/sort-percentage/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-percentage/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/sort-percentage/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-percentage/reference/gcc-8/coverage.functions.html
+++ b/gcovr/tests/sort-percentage/reference/gcc-8/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-percentage/reference/gcc-8/coverage.html
+++ b/gcovr/tests/sort-percentage/reference/gcc-8/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-percentage/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/sort-percentage/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-uncovered/reference/clang-10/coverage.file1.cpp.37fe642e5aafc503ffc5506444f44c6f.html
+++ b/gcovr/tests/sort-uncovered/reference/clang-10/coverage.file1.cpp.37fe642e5aafc503ffc5506444f44c6f.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-uncovered/reference/clang-10/coverage.file2.cpp.6037836e0caa27aaeac26df61b128c1b.html
+++ b/gcovr/tests/sort-uncovered/reference/clang-10/coverage.file2.cpp.6037836e0caa27aaeac26df61b128c1b.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-uncovered/reference/clang-10/coverage.file3.cpp.a89d5d218ee87cc237c08dfe8c96105c.html
+++ b/gcovr/tests/sort-uncovered/reference/clang-10/coverage.file3.cpp.a89d5d218ee87cc237c08dfe8c96105c.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-uncovered/reference/clang-10/coverage.file4.cpp.02ece764f9b8791575a938834ca3ac75.html
+++ b/gcovr/tests/sort-uncovered/reference/clang-10/coverage.file4.cpp.02ece764f9b8791575a938834ca3ac75.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-uncovered/reference/clang-10/coverage.html
+++ b/gcovr/tests/sort-uncovered/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-uncovered/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/sort-uncovered/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-uncovered/reference/clang-13/coverage.file1.cpp.37fe642e5aafc503ffc5506444f44c6f.html
+++ b/gcovr/tests/sort-uncovered/reference/clang-13/coverage.file1.cpp.37fe642e5aafc503ffc5506444f44c6f.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-uncovered/reference/clang-13/coverage.file2.cpp.6037836e0caa27aaeac26df61b128c1b.html
+++ b/gcovr/tests/sort-uncovered/reference/clang-13/coverage.file2.cpp.6037836e0caa27aaeac26df61b128c1b.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-uncovered/reference/clang-13/coverage.file3.cpp.a89d5d218ee87cc237c08dfe8c96105c.html
+++ b/gcovr/tests/sort-uncovered/reference/clang-13/coverage.file3.cpp.a89d5d218ee87cc237c08dfe8c96105c.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-uncovered/reference/clang-13/coverage.file4.cpp.02ece764f9b8791575a938834ca3ac75.html
+++ b/gcovr/tests/sort-uncovered/reference/clang-13/coverage.file4.cpp.02ece764f9b8791575a938834ca3ac75.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-uncovered/reference/gcc-5/coverage.file1.cpp.37fe642e5aafc503ffc5506444f44c6f.html
+++ b/gcovr/tests/sort-uncovered/reference/gcc-5/coverage.file1.cpp.37fe642e5aafc503ffc5506444f44c6f.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-uncovered/reference/gcc-5/coverage.file2.cpp.6037836e0caa27aaeac26df61b128c1b.html
+++ b/gcovr/tests/sort-uncovered/reference/gcc-5/coverage.file2.cpp.6037836e0caa27aaeac26df61b128c1b.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-uncovered/reference/gcc-5/coverage.file3.cpp.a89d5d218ee87cc237c08dfe8c96105c.html
+++ b/gcovr/tests/sort-uncovered/reference/gcc-5/coverage.file3.cpp.a89d5d218ee87cc237c08dfe8c96105c.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-uncovered/reference/gcc-5/coverage.file4.cpp.02ece764f9b8791575a938834ca3ac75.html
+++ b/gcovr/tests/sort-uncovered/reference/gcc-5/coverage.file4.cpp.02ece764f9b8791575a938834ca3ac75.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-uncovered/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/sort-uncovered/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-uncovered/reference/gcc-5/coverage.html
+++ b/gcovr/tests/sort-uncovered/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-uncovered/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/sort-uncovered/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-uncovered/reference/gcc-8/coverage.functions.html
+++ b/gcovr/tests/sort-uncovered/reference/gcc-8/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-uncovered/reference/gcc-8/coverage.html
+++ b/gcovr/tests/sort-uncovered/reference/gcc-8/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/sort-uncovered/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/sort-uncovered/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/source_from_pipe/reference/clang-10/coverage.code.cpp.f70555cd100043535e6272991bc73f72.html
+++ b/gcovr/tests/source_from_pipe/reference/clang-10/coverage.code.cpp.f70555cd100043535e6272991bc73f72.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/source_from_pipe/reference/clang-10/coverage.functions.html
+++ b/gcovr/tests/source_from_pipe/reference/clang-10/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/source_from_pipe/reference/clang-10/coverage.html
+++ b/gcovr/tests/source_from_pipe/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/source_from_pipe/reference/clang-13/coverage.code.cpp.f70555cd100043535e6272991bc73f72.html
+++ b/gcovr/tests/source_from_pipe/reference/clang-13/coverage.code.cpp.f70555cd100043535e6272991bc73f72.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/source_from_pipe/reference/clang-13/coverage.functions.html
+++ b/gcovr/tests/source_from_pipe/reference/clang-13/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/source_from_pipe/reference/gcc-5/coverage.code.cpp.f70555cd100043535e6272991bc73f72.html
+++ b/gcovr/tests/source_from_pipe/reference/gcc-5/coverage.code.cpp.f70555cd100043535e6272991bc73f72.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/source_from_pipe/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/source_from_pipe/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/source_from_pipe/reference/gcc-5/coverage.html
+++ b/gcovr/tests/source_from_pipe/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/subfolder-includes/reference/clang-10/coverage.functions.html
+++ b/gcovr/tests/subfolder-includes/reference/clang-10/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/subfolder-includes/reference/clang-10/coverage.html
+++ b/gcovr/tests/subfolder-includes/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/subfolder-includes/reference/clang-10/coverage.lib.cpp.da76a1556dcc5fe5f8ec3352e7d825b2.html
+++ b/gcovr/tests/subfolder-includes/reference/clang-10/coverage.lib.cpp.da76a1556dcc5fe5f8ec3352e7d825b2.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/subfolder-includes/reference/clang-10/coverage.lib.h.c5e03e0214ccc981f577d5e15b7f85c2.html
+++ b/gcovr/tests/subfolder-includes/reference/clang-10/coverage.lib.h.c5e03e0214ccc981f577d5e15b7f85c2.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/subfolder-includes/reference/clang-10/coverage.main.cpp.16fd1b6ab93c2a3c530d0ec6b50173dc.html
+++ b/gcovr/tests/subfolder-includes/reference/clang-10/coverage.main.cpp.16fd1b6ab93c2a3c530d0ec6b50173dc.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/subfolder-includes/reference/clang-13/coverage.functions.html
+++ b/gcovr/tests/subfolder-includes/reference/clang-13/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/subfolder-includes/reference/clang-13/coverage.lib.cpp.da76a1556dcc5fe5f8ec3352e7d825b2.html
+++ b/gcovr/tests/subfolder-includes/reference/clang-13/coverage.lib.cpp.da76a1556dcc5fe5f8ec3352e7d825b2.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/subfolder-includes/reference/clang-13/coverage.lib.h.c5e03e0214ccc981f577d5e15b7f85c2.html
+++ b/gcovr/tests/subfolder-includes/reference/clang-13/coverage.lib.h.c5e03e0214ccc981f577d5e15b7f85c2.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/subfolder-includes/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/subfolder-includes/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/subfolder-includes/reference/gcc-5/coverage.html
+++ b/gcovr/tests/subfolder-includes/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/subfolder-includes/reference/gcc-5/coverage.lib.cpp.da76a1556dcc5fe5f8ec3352e7d825b2.html
+++ b/gcovr/tests/subfolder-includes/reference/gcc-5/coverage.lib.cpp.da76a1556dcc5fe5f8ec3352e7d825b2.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/subfolder-includes/reference/gcc-5/coverage.lib.h.c5e03e0214ccc981f577d5e15b7f85c2.html
+++ b/gcovr/tests/subfolder-includes/reference/gcc-5/coverage.lib.h.c5e03e0214ccc981f577d5e15b7f85c2.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/subfolder-includes/reference/gcc-5/coverage.main.cpp.16fd1b6ab93c2a3c530d0ec6b50173dc.html
+++ b/gcovr/tests/subfolder-includes/reference/gcc-5/coverage.main.cpp.16fd1b6ab93c2a3c530d0ec6b50173dc.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/subfolder-includes/reference/gcc-8/coverage.functions.html
+++ b/gcovr/tests/subfolder-includes/reference/gcc-8/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/subfolder-includes/reference/gcc-8/coverage.html
+++ b/gcovr/tests/subfolder-includes/reference/gcc-8/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/subfolder-includes/reference/gcc-8/coverage.main.cpp.16fd1b6ab93c2a3c530d0ec6b50173dc.html
+++ b/gcovr/tests/subfolder-includes/reference/gcc-8/coverage.main.cpp.16fd1b6ab93c2a3c530d0ec6b50173dc.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/test_gcovr.py
+++ b/gcovr/tests/test_gcovr.py
@@ -150,9 +150,7 @@ def findtests(basedir):
     for f in sorted(os.listdir(basedir)):
         if not os.path.isdir(os.path.join(basedir, f)):
             continue
-        if f.startswith("."):
-            continue
-        if "pycache" in f:
+        if not os.path.isfile(os.path.join(basedir, f, "Makefile")):  # pragma: no cover
             continue
         yield f
 
@@ -173,7 +171,9 @@ def assert_equals(reference_file, reference, test_file, test, encoding):
         if diff_out is None:
             return
 
-        diff_out = f"-- {reference_file}\n++ {test_file}\n{diff_out}"
+        diff_out = (
+            f"-- {reference_file}\n++ {test_file}\n{diff_out}"  # pragma: no cover
+        )
     else:
         diff_out = list(
             difflib.unified_diff(
@@ -187,9 +187,9 @@ def assert_equals(reference_file, reference, test_file, test, encoding):
         diff_is_empty = len(diff_out) == 0
         if diff_is_empty:
             return
-        diff_out = "".join(diff_out)
+        diff_out = "".join(diff_out)  # pragma: no cover
 
-    raise AssertionError(diff_out)
+    raise AssertionError(diff_out)  # pragma: no cover
 
 
 def run(cmd, cwd=None):

--- a/gcovr/tests/test_gcovr.py
+++ b/gcovr/tests/test_gcovr.py
@@ -18,6 +18,7 @@
 # ****************************************************************************
 
 import glob
+from io import StringIO
 import logging
 import os
 import platform
@@ -30,6 +31,7 @@ import difflib
 import zipfile
 
 from yaxmldiff import compare_xml
+from lxml import etree
 
 from gcovr.utils import force_unix_separator
 
@@ -156,12 +158,37 @@ def findtests(basedir):
         yield f
 
 
-def assert_xml_equals(reference, coverage):
-    diff = compare_xml(reference, coverage)
-    if diff is None:
-        return
+def assert_equals(reference_file, reference, test_file, test):
+    _, extension = os.path.splitext(reference_file)
+    if extension in [".html", ".xml"]:
+        if extension == ".html":
+            reference = etree.fromstring(reference.encode(), etree.HTMLParser())
+            test = etree.fromstring(test.encode(), etree.HTMLParser())
+        else:
+            reference = etree.fromstring(reference.encode())
+            test = etree.fromstring(test.encode())
 
-    raise AssertionError(f"XML documents differed (-reference, +actual):\n{diff}")
+        diff_out = compare_xml(reference, test)
+        if diff_out is None:
+            return
+
+        diff_out = f"-- {reference_file}\n++ {test_file}\n{diff_out}"
+    else:
+        diff_out = list(
+            difflib.unified_diff(
+                reference.splitlines(keepends=True),
+                test.splitlines(keepends=True),
+                fromfile=reference_file,
+                tofile=test_file,
+            )
+        )
+
+        diff_is_empty = len(diff_out) == 0
+        if diff_is_empty:
+            return
+        diff_out = "".join(diff_out)
+
+    raise AssertionError(diff_out)
 
 
 def run(cmd, cwd=None):
@@ -176,11 +203,11 @@ def find_reference_files(output_pattern):
     for reference_dir in REFERENCE_DIRS:
         for pattern in output_pattern:
             if os.path.isdir(reference_dir):
-                for file in glob.glob(os.path.join(reference_dir, pattern)):
-                    if os.path.basename(file) not in seen_files:
-                        coverage = os.path.basename(file)
-                        seen_files.add(coverage)
-                        yield coverage, file
+                for reference_file in glob.glob(os.path.join(reference_dir, pattern)):
+                    if os.path.basename(reference_file) not in seen_files:
+                        test_file = os.path.basename(reference_file)
+                        seen_files.add(test_file)
+                        yield test_file, reference_file
 
 
 @pytest.fixture(scope="module")
@@ -445,9 +472,6 @@ OUTPUT_PATTERN = dict(
     sonarqube=["sonarqube*.xml"],
 )
 
-ASSERT_EQUALS = dict(cobertura=assert_xml_equals, sonarqube=assert_xml_equals)
-
-
 def test_build(
     compiled,
     format,
@@ -459,7 +483,6 @@ def test_build(
     name = compiled
     scrub = SCRUBBERS[format]
     output_pattern = OUTPUT_PATTERN[format]
-    assert_equals = ASSERT_EQUALS.get(format, None)
 
     encoding = "utf8"
     if format == "html" and name.startswith("html-encoding-"):
@@ -486,21 +509,14 @@ def test_build(
                 reference_scrubbed = scrub(f.read())
 
         try:
-            if assert_equals is not None:
-                assert_equals(reference_scrubbed, test_scrubbed)
-            else:
-                diff_out = list(
-                    difflib.unified_diff(
-                        reference_scrubbed.splitlines(keepends=True),
-                        test_scrubbed.splitlines(keepends=True),
-                        fromfile=reference_file,
-                        tofile=test_file,
-                    )
-                )
-                diff_is_empty = len(diff_out) == 0
-                assert diff_is_empty, "".join(diff_out)
-        except Exception as e:  # pragma: no cover
-            whole_diff_output += "  " + str(e) + "\n"
+            assert_equals(
+                reference_file,
+                reference_scrubbed,
+                test_file,
+                test_scrubbed,
+            )
+        except AssertionError as e:  # pragma: no cover
+            whole_diff_output += str(e) + "\n"
             if update_reference:
                 reference_file = update_reference_data(
                     reference_file, test_scrubbed, encoding

--- a/gcovr/tests/test_gcovr.py
+++ b/gcovr/tests/test_gcovr.py
@@ -18,7 +18,6 @@
 # ****************************************************************************
 
 import glob
-from io import StringIO
 import logging
 import os
 import platform
@@ -158,12 +157,14 @@ def findtests(basedir):
         yield f
 
 
-def assert_equals(reference_file, reference, test_file, test):
+def assert_equals(reference_file, reference, test_file, test, encoding):
     _, extension = os.path.splitext(reference_file)
     if extension in [".html", ".xml"]:
         if extension == ".html":
-            reference = etree.fromstring(reference.encode(), etree.HTMLParser())
-            test = etree.fromstring(test.encode(), etree.HTMLParser())
+            reference = etree.fromstring(
+                reference.encode(), etree.HTMLParser(encoding=encoding)
+            )
+            test = etree.fromstring(test.encode(), etree.HTMLParser(encoding=encoding))
         else:
             reference = etree.fromstring(reference.encode())
             test = etree.fromstring(test.encode())
@@ -472,6 +473,7 @@ OUTPUT_PATTERN = dict(
     sonarqube=["sonarqube*.xml"],
 )
 
+
 def test_build(
     compiled,
     format,
@@ -514,6 +516,7 @@ def test_build(
                 reference_scrubbed,
                 test_file,
                 test_scrubbed,
+                encoding,
             )
         except AssertionError as e:  # pragma: no cover
             whole_diff_output += str(e) + "\n"

--- a/gcovr/tests/threaded/reference/clang-10/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/gcovr/tests/threaded/reference/clang-10/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/threaded/reference/clang-10/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
+++ b/gcovr/tests/threaded/reference/clang-10/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/threaded/reference/clang-10/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/gcovr/tests/threaded/reference/clang-10/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/threaded/reference/clang-10/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
+++ b/gcovr/tests/threaded/reference/clang-10/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/threaded/reference/clang-10/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/gcovr/tests/threaded/reference/clang-10/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/threaded/reference/clang-10/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
+++ b/gcovr/tests/threaded/reference/clang-10/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/threaded/reference/clang-10/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/gcovr/tests/threaded/reference/clang-10/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/threaded/reference/clang-10/coverage.html
+++ b/gcovr/tests/threaded/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/threaded/reference/clang-10/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/gcovr/tests/threaded/reference/clang-10/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/threaded/reference/clang-13/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/gcovr/tests/threaded/reference/clang-13/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/threaded/reference/clang-13/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
+++ b/gcovr/tests/threaded/reference/clang-13/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/threaded/reference/clang-13/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/gcovr/tests/threaded/reference/clang-13/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/threaded/reference/clang-13/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
+++ b/gcovr/tests/threaded/reference/clang-13/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/threaded/reference/clang-13/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/gcovr/tests/threaded/reference/clang-13/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/threaded/reference/clang-13/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
+++ b/gcovr/tests/threaded/reference/clang-13/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/threaded/reference/clang-13/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/gcovr/tests/threaded/reference/clang-13/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/threaded/reference/gcc-5/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/gcovr/tests/threaded/reference/gcc-5/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/threaded/reference/gcc-5/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
+++ b/gcovr/tests/threaded/reference/gcc-5/coverage.file2.cpp.3545800e72707f891cf27b6eed96d85a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/threaded/reference/gcc-5/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/gcovr/tests/threaded/reference/gcc-5/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/threaded/reference/gcc-5/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
+++ b/gcovr/tests/threaded/reference/gcc-5/coverage.file4.cpp.9414ee61cc57b8771eb308d9925280d1.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/threaded/reference/gcc-5/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/gcovr/tests/threaded/reference/gcc-5/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/threaded/reference/gcc-5/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
+++ b/gcovr/tests/threaded/reference/gcc-5/coverage.file6.cpp.521da11c6869ce8705f0ee8a4667568d.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/threaded/reference/gcc-5/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/gcovr/tests/threaded/reference/gcc-5/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/threaded/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/threaded/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/threaded/reference/gcc-5/coverage.html
+++ b/gcovr/tests/threaded/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/threaded/reference/gcc-5/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/gcovr/tests/threaded/reference/gcc-5/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/threaded/reference/gcc-8/coverage.functions.html
+++ b/gcovr/tests/threaded/reference/gcc-8/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/threaded/reference/gcc-8/coverage.html
+++ b/gcovr/tests/threaded/reference/gcc-8/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/threaded/reference/gcc-8/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/gcovr/tests/threaded/reference/gcc-8/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/update-data/reference/clang-10/coverage.html
+++ b/gcovr/tests/update-data/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/update-data/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/update-data/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/update-data/reference/clang-10/coverage.update-data.c.d336a0298bf4843f0a6fde2a6a938e7f.html
+++ b/gcovr/tests/update-data/reference/clang-10/coverage.update-data.c.d336a0298bf4843f0a6fde2a6a938e7f.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/update-data/reference/clang-10/coverage.update-data.h.522c29cd66298f97fb9ff5a561c844e0.html
+++ b/gcovr/tests/update-data/reference/clang-10/coverage.update-data.h.522c29cd66298f97fb9ff5a561c844e0.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/update-data/reference/clang-13/coverage.update-data.h.522c29cd66298f97fb9ff5a561c844e0.html
+++ b/gcovr/tests/update-data/reference/clang-13/coverage.update-data.h.522c29cd66298f97fb9ff5a561c844e0.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/update-data/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/update-data/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/update-data/reference/gcc-5/coverage.html
+++ b/gcovr/tests/update-data/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/update-data/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/update-data/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/update-data/reference/gcc-5/coverage.update-data.c.d336a0298bf4843f0a6fde2a6a938e7f.html
+++ b/gcovr/tests/update-data/reference/gcc-5/coverage.update-data.c.d336a0298bf4843f0a6fde2a6a938e7f.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/update-data/reference/gcc-5/coverage.update-data.h.522c29cd66298f97fb9ff5a561c844e0.html
+++ b/gcovr/tests/update-data/reference/gcc-5/coverage.update-data.h.522c29cd66298f97fb9ff5a561c844e0.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/use-existing/reference/clang-10/coverage.html
+++ b/gcovr/tests/use-existing/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/use-existing/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/use-existing/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/use-existing/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/use-existing/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/use-existing/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/use-existing/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/use-existing/reference/gcc-5/coverage.html
+++ b/gcovr/tests/use-existing/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/use-existing/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/use-existing/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/use-existing/reference/gcc-8/coverage.functions.html
+++ b/gcovr/tests/use-existing/reference/gcc-8/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/use-existing/reference/gcc-8/coverage.html
+++ b/gcovr/tests/use-existing/reference/gcc-8/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/use-existing/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/use-existing/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/wspace/reference/clang-10/coverage.html
+++ b/gcovr/tests/wspace/reference/clang-10/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/wspace/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/wspace/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/wspace/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/wspace/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/wspace/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/wspace/reference/gcc-5/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/wspace/reference/gcc-5/coverage.html
+++ b/gcovr/tests/wspace/reference/gcc-5/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/wspace/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/wspace/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/wspace/reference/gcc-8/coverage.functions.html
+++ b/gcovr/tests/wspace/reference/gcc-8/coverage.functions.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/wspace/reference/gcc-8/coverage.html
+++ b/gcovr/tests/wspace/reference/gcc-8/coverage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/tests/wspace/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/wspace/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="coverage.css">
+    <link rel="stylesheet" href="coverage.css"/>
   </head>
 
   <body>

--- a/gcovr/writer/html/templates/base.html
+++ b/gcovr/writer/html/templates/base.html
@@ -7,7 +7,7 @@
     <title>{{info.head}}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     {% if css_link is defined %}
-    <link rel="stylesheet" href="{{css_link}}">
+    <link rel="stylesheet" href="{{css_link}}"/>
     {% else %}
     <style type="text/css">
       {{css | safe}}


### PR DESCRIPTION
Change the test suite to compare the files depending on the extension. Use also `lxml` to compare HTML files.
While implementing this a not closed link tag in HTML report was found and fixed.

Related to #714 