### PR TITLE
Update exclusion-markers.rst

### DIFF
--- a/doc/source/guide/exclusion-markers.rst
+++ b/doc/source/guide/exclusion-markers.rst
@@ -10,6 +10,9 @@ You can exclude parts of your code from coverage metrics.
 -   If ``GCOVR_EXCL_START`` appears within a line,
     all following lines (including the current line) are ignored
     until a ``GCOVR_EXCL_STOP`` marker is encountered.
+-   If ``GCOVR_EXCL_BR_*`` markers are used the same exclusion rules
+    apply as above, with the difference beeing that they are only taken
+    into account for branch coverage.
 
 Instead of ``GCOVR_*``,
 the markers may also start with ``GCOV_*`` or ``LCOV_*``.


### PR DESCRIPTION
I just added a short sentence about the `GCOVR_EXCL_BR_*` markers which are a very nice feature.

[no changelog]