### PR TITLE
Fix problem in decision parser if case is not on a single line with the break statement.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -49,6 +49,7 @@ Bug fixes and small improvements:
 - Add Python 3.11 to test matrix. (:issue:`717`)
 - Fix casing of files if filesystem is case insensitive. (:issue:`694`)
 - Fix deadlock if :option:`-j` is used and there are errors from ``gcov`` execution. (:issue:`719`)
+- Fix problem in decision parser if case is not on a single line with the break statement. (:issue:`738`)
 
 Documentation:
 

--- a/gcovr/decision_analysis.py
+++ b/gcovr/decision_analysis.py
@@ -217,7 +217,9 @@ class DecisionParser:
         # check if it's a case statement (measured at every line of a case, so a branch definition isn't given)
         elif _is_a_switch(code):
             # Get the coverage of the next line before a break
-            for next_lineno in range(lineno, max(lineno + 1, *self.coverage.lines.keys())):
+            for next_lineno in range(
+                lineno, max(lineno + 1, *self.coverage.lines.keys())
+            ):
                 line_coverage = self.coverage.lines.get(next_lineno)
                 if line_coverage is not None:
                     line_coverage.decision = DecisionCoverageSwitch(line_coverage.count)

--- a/gcovr/decision_analysis.py
+++ b/gcovr/decision_analysis.py
@@ -49,12 +49,14 @@ def _prep_decision_string(code: str) -> str:
     ' case x :'
     >>> _prep_decision_string('    default     : // check for something ')
     ' default :'
+    >>> _prep_decision_string('    def/* Comment */ault: /* xxx */ ')
+    ' def ault :'
     """
 
     # Add whitespaces around ":"
     code = code.replace(":", " : ")
-    code = _CPP_STYLE_COMMENT_PATTERN.sub("", code)
-    code = _C_STYLE_COMMENT_PATTERN.sub("", code)
+    code = _CPP_STYLE_COMMENT_PATTERN.sub(" ", code)
+    code = _C_STYLE_COMMENT_PATTERN.sub(" ", code)
     code = _WHITESPACE_PATTERN.sub(" ", code)
 
     return " " + code.lstrip().strip()

--- a/gcovr/tests/decisions/main.cpp
+++ b/gcovr/tests/decisions/main.cpp
@@ -186,12 +186,19 @@ bool checkSwitch1(int a)
    switch (a)
    {
    case 5: return true; break;
+   /* Comment */
    case 10:
+      /* Comment */
       return true;
+      /* Comment */
       break;
+      /* Comment */
    default:
+      /* Comment */
       return false;
+      /* Comment */
       break;
+      /* Comment */
    }
 }
 

--- a/gcovr/tests/decisions/reference/clang-10/coverage.functions.html
+++ b/gcovr/tests/decisions/reference/clang-10/coverage.functions.html
@@ -122,16 +122,16 @@
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l270">_Z12checkForLoopi</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l277">_Z12checkForLoopi</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l270">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l277">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l270">270</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l277">277</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l270"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l277"> called 1 time</a>
     </td>
   </tr>
   <tr>
@@ -150,30 +150,30 @@
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l198">_Z12checkSwitch2i</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l205">_Z12checkSwitch2i</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l198">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l205">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l198">198</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l205">205</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l198"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l205"> called 1 time</a>
     </td>
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l214">_Z12checkSwitch3i</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l221">_Z12checkSwitch3i</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l214">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l221">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l214">214</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l221">221</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l214"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l221"> called 1 time</a>
     </td>
   </tr>
   <tr>
@@ -192,16 +192,16 @@
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l290">_Z14checkWhileLoopi</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l297">_Z14checkWhileLoopi</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l290">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l297">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l290">290</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l297">297</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l290"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l297"> called 1 time</a>
     </td>
   </tr>
   <tr>
@@ -276,30 +276,30 @@
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l304">_Z16checkDoWhileLoopi</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l311">_Z16checkDoWhileLoopi</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l304">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l311">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l304">304</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l311">311</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l304"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l311"> called 1 time</a>
     </td>
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l318">_Z16checkInterpreteri</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l325">_Z16checkInterpreteri</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l318">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l325">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l318">318</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l325">325</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l318"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l325"> called 1 time</a>
     </td>
   </tr>
   <tr>
@@ -318,16 +318,16 @@
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l342">_Z16verify_issue_679b</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l349">_Z16verify_issue_679b</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l342">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l349">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l342">342</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l349">349</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l342"> called 2 times</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l349"> called 2 times</a>
     </td>
   </tr>
   <tr>
@@ -374,30 +374,30 @@
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l250">_Z17checkTernary1Truei</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l257">_Z17checkTernary1Truei</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l250">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l257">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l250">250</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l257">257</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l250"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l257"> called 1 time</a>
     </td>
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l260">_Z17checkTernary2Truei</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l267">_Z17checkTernary2Truei</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l260">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l267">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l260">260</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l267">267</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l260"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l267"> called 1 time</a>
     </td>
   </tr>
   <tr>
@@ -416,114 +416,114 @@
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l255">_Z18checkTernary1Falsei</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l262">_Z18checkTernary1Falsei</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l255">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l262">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l255">255</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l262">262</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l255"> called 1 time</a>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l265">_Z18checkTernary2Falsei</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l265">main.cpp</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l265">265</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l265"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l262"> called 1 time</a>
     </td>
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l280">_Z19checkComplexForLoopi</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l272">_Z18checkTernary2Falsei</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l280">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l272">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l280">280</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l272">272</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l280"> called 1 time</a>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l230">_Z23checkCompactBranch1Truei</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l230">main.cpp</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l230">230</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l230"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l272"> called 1 time</a>
     </td>
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l240">_Z23checkCompactBranch2Truei</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l287">_Z19checkComplexForLoopi</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l240">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l287">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l240">240</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l287">287</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l240"> called 1 time</a>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l235">_Z24checkCompactBranch1Falsei</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l235">main.cpp</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l235">235</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l235"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l287"> called 1 time</a>
     </td>
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l245">_Z24checkCompactBranch2Falsei</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l237">_Z23checkCompactBranch1Truei</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l245">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l237">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l245">245</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l237">237</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l245"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l237"> called 1 time</a>
     </td>
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l349">main</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l247">_Z23checkCompactBranch2Truei</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l349">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l247">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l349">349</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l247">247</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l349"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l247"> called 1 time</a>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l242">_Z24checkCompactBranch1Falsei</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l242">main.cpp</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l242">242</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l242"> called 1 time</a>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l252">_Z24checkCompactBranch2Falsei</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l252">main.cpp</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l252">252</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l252"> called 1 time</a>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l356">main</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l356">main.cpp</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l356">356</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l356"> called 1 time</a>
     </td>
   </tr>
 </table>

--- a/gcovr/tests/decisions/reference/clang-10/coverage.functions.html
+++ b/gcovr/tests/decisions/reference/clang-10/coverage.functions.html
@@ -56,9 +56,9 @@
     </tr>
     <tr>
       <th scope="row">Decisions:</th>
-      <td>31</td>
-      <td>57</td>
-      <td class="coverage-low">54.4%</td>
+      <td>33</td>
+      <td>65</td>
+      <td class="coverage-low">50.8%</td>
     </tr>
   </table>
 </div>

--- a/gcovr/tests/decisions/reference/clang-10/coverage.html
+++ b/gcovr/tests/decisions/reference/clang-10/coverage.html
@@ -64,9 +64,9 @@
     </tr>
     <tr>
       <th scope="row">Decisions:</th>
-      <td>31</td>
-      <td>57</td>
-      <td class="coverage-low">54.4%</td>
+      <td>33</td>
+      <td>65</td>
+      <td class="coverage-low">50.8%</td>
     </tr>
   </table>
 </div>
@@ -109,8 +109,8 @@
     <td class="CoverValue function-coverage coverage-high">32 / 32</td>
     <td class="CoverValue branch-coverage coverage-low">54.2%</td>
     <td class="CoverValue branch-coverage coverage-low">45 / 83</td>
-    <td class="CoverValue decision-coverage coverage-low">54.4%</td>
-    <td class="CoverValue decision-coverage coverage-low">31 / 57</td>
+    <td class="CoverValue decision-coverage coverage-low">50.8%</td>
+    <td class="CoverValue decision-coverage coverage-low">33 / 65</td>
   </tr>
 
 </table>

--- a/gcovr/tests/decisions/reference/clang-10/coverage.json
+++ b/gcovr/tests/decisions/reference/clang-10/coverage.json
@@ -895,11 +895,19 @@
                 {
                     "branches": [],
                     "count": 0,
+                    "gcovr/decision": {
+                        "count": 0,
+                        "type": "switch"
+                    },
                     "line_number": 192
                 },
                 {
                     "branches": [],
                     "count": 0,
+                    "gcovr/decision": {
+                        "count": 0,
+                        "type": "switch"
+                    },
                     "line_number": 198
                 },
                 {
@@ -936,16 +944,28 @@
                 {
                     "branches": [],
                     "count": 0,
+                    "gcovr/decision": {
+                        "count": 0,
+                        "type": "switch"
+                    },
                     "line_number": 210
                 },
                 {
                     "branches": [],
                     "count": 1,
+                    "gcovr/decision": {
+                        "count": 1,
+                        "type": "switch"
+                    },
                     "line_number": 213
                 },
                 {
                     "branches": [],
                     "count": 0,
+                    "gcovr/decision": {
+                        "count": 0,
+                        "type": "switch"
+                    },
                     "line_number": 216
                 },
                 {
@@ -982,16 +1002,28 @@
                 {
                     "branches": [],
                     "count": 0,
+                    "gcovr/decision": {
+                        "count": 0,
+                        "type": "switch"
+                    },
                     "line_number": 226
                 },
                 {
                     "branches": [],
                     "count": 0,
+                    "gcovr/decision": {
+                        "count": 0,
+                        "type": "switch"
+                    },
                     "line_number": 229
                 },
                 {
                     "branches": [],
                     "count": 1,
+                    "gcovr/decision": {
+                        "count": 1,
+                        "type": "switch"
+                    },
                     "line_number": 232
                 },
                 {

--- a/gcovr/tests/decisions/reference/clang-10/coverage.json
+++ b/gcovr/tests/decisions/reference/clang-10/coverage.json
@@ -20,7 +20,7 @@
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 270,
+                    "lineno": 277,
                     "name": "_Z12checkForLoopi"
                 },
                 {
@@ -30,12 +30,12 @@
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 198,
+                    "lineno": 205,
                     "name": "_Z12checkSwitch2i"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 214,
+                    "lineno": 221,
                     "name": "_Z12checkSwitch3i"
                 },
                 {
@@ -45,7 +45,7 @@
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 290,
+                    "lineno": 297,
                     "name": "_Z14checkWhileLoopi"
                 },
                 {
@@ -75,12 +75,12 @@
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 304,
+                    "lineno": 311,
                     "name": "_Z16checkDoWhileLoopi"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 318,
+                    "lineno": 325,
                     "name": "_Z16checkInterpreteri"
                 },
                 {
@@ -90,7 +90,7 @@
                 },
                 {
                     "execution_count": 2,
-                    "lineno": 342,
+                    "lineno": 349,
                     "name": "_Z16verify_issue_679b"
                 },
                 {
@@ -110,12 +110,12 @@
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 250,
+                    "lineno": 257,
                     "name": "_Z17checkTernary1Truei"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 260,
+                    "lineno": 267,
                     "name": "_Z17checkTernary2Truei"
                 },
                 {
@@ -125,42 +125,42 @@
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 255,
+                    "lineno": 262,
                     "name": "_Z18checkTernary1Falsei"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 265,
+                    "lineno": 272,
                     "name": "_Z18checkTernary2Falsei"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 280,
+                    "lineno": 287,
                     "name": "_Z19checkComplexForLoopi"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 230,
+                    "lineno": 237,
                     "name": "_Z23checkCompactBranch1Truei"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 240,
+                    "lineno": 247,
                     "name": "_Z23checkCompactBranch2Truei"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 235,
+                    "lineno": 242,
                     "name": "_Z24checkCompactBranch1Falsei"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 245,
+                    "lineno": 252,
                     "name": "_Z24checkCompactBranch2Falsei"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 349,
+                    "lineno": 356,
                     "name": "main"
                 }
             ],
@@ -895,68 +895,68 @@
                 {
                     "branches": [],
                     "count": 0,
-                    "line_number": 190
+                    "line_number": 192
                 },
                 {
                     "branches": [],
                     "count": 0,
-                    "line_number": 193
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 196
-                },
-                {
-                    "branches": [],
-                    "count": 1,
                     "line_number": 198
                 },
                 {
-                    "branches": [
-                        {
-                            "count": 0,
-                            "fallthrough": false,
-                            "throw": false
-                        },
-                        {
-                            "count": 1,
-                            "fallthrough": false,
-                            "throw": false
-                        },
-                        {
-                            "count": 0,
-                            "fallthrough": false,
-                            "throw": false
-                        }
-                    ],
-                    "count": 1,
-                    "line_number": 200
-                },
-                {
                     "branches": [],
-                    "count": 0,
+                    "count": 1,
                     "line_number": 203
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 206
+                    "line_number": 205
+                },
+                {
+                    "branches": [
+                        {
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "count": 1,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
+                    "count": 1,
+                    "line_number": 207
                 },
                 {
                     "branches": [],
                     "count": 0,
-                    "line_number": 209
+                    "line_number": 210
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 212
+                    "line_number": 213
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "line_number": 216
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 214
+                    "line_number": 219
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 221
                 },
                 {
                     "branches": [
@@ -977,32 +977,32 @@
                         }
                     ],
                     "count": 1,
-                    "line_number": 216
+                    "line_number": 223
                 },
                 {
                     "branches": [],
                     "count": 0,
-                    "line_number": 219
+                    "line_number": 226
                 },
                 {
                     "branches": [],
                     "count": 0,
-                    "line_number": 222
+                    "line_number": 229
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 225
+                    "line_number": 232
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 228
+                    "line_number": 235
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 230
+                    "line_number": 237
                 },
                 {
                     "branches": [
@@ -1023,17 +1023,17 @@
                         "count_true": 1,
                         "type": "conditional"
                     },
-                    "line_number": 232
+                    "line_number": 239
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 233
+                    "line_number": 240
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 235
+                    "line_number": 242
                 },
                 {
                     "branches": [
@@ -1054,51 +1054,7 @@
                         "count_true": 0,
                         "type": "conditional"
                     },
-                    "line_number": 237
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 238
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 240
-                },
-                {
-                    "branches": [
-                        {
-                            "count": 1,
-                            "fallthrough": false,
-                            "throw": false
-                        },
-                        {
-                            "count": 0,
-                            "fallthrough": false,
-                            "throw": false
-                        },
-                        {
-                            "count": 1,
-                            "fallthrough": false,
-                            "throw": false
-                        },
-                        {
-                            "count": 0,
-                            "fallthrough": false,
-                            "throw": false
-                        }
-                    ],
-                    "count": 1,
-                    "gcovr/decision": {
-                        "type": "uncheckable"
-                    },
-                    "line_number": 242
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 243
+                    "line_number": 244
                 },
                 {
                     "branches": [],
@@ -1106,7 +1062,17 @@
                     "line_number": 245
                 },
                 {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 247
+                },
+                {
                     "branches": [
+                        {
+                            "count": 1,
+                            "fallthrough": false,
+                            "throw": false
+                        },
                         {
                             "count": 0,
                             "fallthrough": false,
@@ -1121,23 +1087,13 @@
                             "count": 0,
                             "fallthrough": false,
                             "throw": false
-                        },
-                        {
-                            "count": 0,
-                            "fallthrough": false,
-                            "throw": false
                         }
                     ],
                     "count": 1,
                     "gcovr/decision": {
                         "type": "uncheckable"
                     },
-                    "line_number": 247
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 248
+                    "line_number": 249
                 },
                 {
                     "branches": [],
@@ -1148,6 +1104,35 @@
                     "branches": [],
                     "count": 1,
                     "line_number": 252
+                },
+                {
+                    "branches": [
+                        {
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "count": 1,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
+                    "count": 1,
+                    "gcovr/decision": {
+                        "type": "uncheckable"
+                    },
+                    "line_number": 254
                 },
                 {
                     "branches": [],
@@ -1162,28 +1147,43 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 260
+                    "line_number": 259
                 },
                 {
-                    "branches": [
-                        {
-                            "count": 1,
-                            "fallthrough": false,
-                            "throw": false
-                        },
-                        {
-                            "count": 0,
-                            "fallthrough": false,
-                            "throw": false
-                        }
-                    ],
+                    "branches": [],
                     "count": 1,
                     "line_number": 262
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 265
+                    "line_number": 264
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 267
+                },
+                {
+                    "branches": [
+                        {
+                            "count": 1,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
+                    "count": 1,
+                    "line_number": 269
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 272
                 },
                 {
                     "branches": [
@@ -1199,17 +1199,17 @@
                         }
                     ],
                     "count": 1,
-                    "line_number": 267
+                    "line_number": 274
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 270
+                    "line_number": 277
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 272
+                    "line_number": 279
                 },
                 {
                     "branches": [
@@ -1230,32 +1230,32 @@
                         "count_true": 5,
                         "type": "conditional"
                     },
-                    "line_number": 273
-                },
-                {
-                    "branches": [],
-                    "count": 5,
-                    "line_number": 275
-                },
-                {
-                    "branches": [],
-                    "count": 5,
-                    "line_number": 276
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 277
-                },
-                {
-                    "branches": [],
-                    "count": 1,
                     "line_number": 280
                 },
                 {
                     "branches": [],
-                    "count": 1,
+                    "count": 5,
                     "line_number": 282
+                },
+                {
+                    "branches": [],
+                    "count": 5,
+                    "line_number": 283
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 284
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 287
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 289
                 },
                 {
                     "branches": [
@@ -1284,37 +1284,37 @@
                     "gcovr/decision": {
                         "type": "uncheckable"
                     },
-                    "line_number": 283
-                },
-                {
-                    "branches": [],
-                    "count": 5,
-                    "line_number": 285
-                },
-                {
-                    "branches": [],
-                    "count": 5,
-                    "line_number": 286
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 287
-                },
-                {
-                    "branches": [],
-                    "count": 1,
                     "line_number": 290
                 },
                 {
                     "branches": [],
-                    "count": 1,
+                    "count": 5,
                     "line_number": 292
                 },
                 {
                     "branches": [],
-                    "count": 1,
+                    "count": 5,
                     "line_number": 293
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 294
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 297
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 299
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 300
                 },
                 {
                     "branches": [
@@ -1335,52 +1335,52 @@
                         "count_true": 5,
                         "type": "conditional"
                     },
-                    "line_number": 295
+                    "line_number": 302
                 },
                 {
                     "branches": [],
                     "count": 5,
-                    "line_number": 297
-                },
-                {
-                    "branches": [],
-                    "count": 5,
-                    "line_number": 298
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 301
-                },
-                {
-                    "branches": [],
-                    "count": 1,
                     "line_number": 304
                 },
                 {
                     "branches": [],
-                    "count": 1,
-                    "line_number": 306
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 307
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 309
-                },
-                {
-                    "branches": [],
                     "count": 5,
+                    "line_number": 305
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 308
+                },
+                {
+                    "branches": [],
+                    "count": 1,
                     "line_number": 311
                 },
                 {
                     "branches": [],
+                    "count": 1,
+                    "line_number": 313
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 314
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 316
+                },
+                {
+                    "branches": [],
                     "count": 5,
-                    "line_number": 312
+                    "line_number": 318
+                },
+                {
+                    "branches": [],
+                    "count": 5,
+                    "line_number": 319
                 },
                 {
                     "branches": [
@@ -1401,32 +1401,12 @@
                         "count_true": 4,
                         "type": "conditional"
                     },
-                    "line_number": 313
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 315
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 318
-                },
-                {
-                    "branches": [],
-                    "count": 1,
                     "line_number": 320
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 321
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 323
+                    "line_number": 322
                 },
                 {
                     "branches": [],
@@ -1436,22 +1416,42 @@
                 {
                     "branches": [],
                     "count": 1,
+                    "line_number": 327
+                },
+                {
+                    "branches": [],
+                    "count": 1,
                     "line_number": 328
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 329
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 331
+                    "line_number": 330
                 },
                 {
                     "branches": [],
                     "count": 1,
                     "line_number": 332
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 335
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 336
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 338
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 339
                 },
                 {
                     "branches": [
@@ -1472,27 +1472,27 @@
                         "count_true": 1,
                         "type": "conditional"
                     },
-                    "line_number": 334
+                    "line_number": 341
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 336
+                    "line_number": 343
                 },
                 {
                     "branches": [],
                     "count": 0,
-                    "line_number": 339
+                    "line_number": 346
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 340
+                    "line_number": 347
                 },
                 {
                     "branches": [],
                     "count": 2,
-                    "line_number": 342
+                    "line_number": 349
                 },
                 {
                     "branches": [
@@ -1513,7 +1513,7 @@
                         "count_true": 1,
                         "type": "conditional"
                     },
-                    "line_number": 343
+                    "line_number": 350
                 },
                 {
                     "branches": [
@@ -1534,36 +1534,11 @@
                         "count_true": 10,
                         "type": "conditional"
                     },
-                    "line_number": 344
-                },
-                {
-                    "branches": [],
-                    "count": 10,
-                    "line_number": 345
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 346
-                },
-                {
-                    "branches": [],
-                    "count": 2,
-                    "line_number": 347
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 349
-                },
-                {
-                    "branches": [],
-                    "count": 1,
                     "line_number": 351
                 },
                 {
                     "branches": [],
-                    "count": 1,
+                    "count": 10,
                     "line_number": 352
                 },
                 {
@@ -1573,7 +1548,7 @@
                 },
                 {
                     "branches": [],
-                    "count": 1,
+                    "count": 2,
                     "line_number": 354
                 },
                 {
@@ -1584,7 +1559,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 357
+                    "line_number": 358
                 },
                 {
                     "branches": [],
@@ -1599,7 +1574,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 362
+                    "line_number": 361
                 },
                 {
                     "branches": [],
@@ -1609,7 +1584,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 365
+                    "line_number": 364
                 },
                 {
                     "branches": [],
@@ -1619,7 +1594,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 368
+                    "line_number": 367
                 },
                 {
                     "branches": [],
@@ -1644,7 +1619,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 374
+                    "line_number": 375
                 },
                 {
                     "branches": [],
@@ -1669,7 +1644,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 382
+                    "line_number": 381
                 },
                 {
                     "branches": [],
@@ -1679,7 +1654,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 385
+                    "line_number": 384
                 },
                 {
                     "branches": [],
@@ -1689,7 +1664,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 388
+                    "line_number": 387
                 },
                 {
                     "branches": [],
@@ -1704,7 +1679,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 391
+                    "line_number": 392
                 },
                 {
                     "branches": [],
@@ -1724,7 +1699,32 @@
                 {
                     "branches": [],
                     "count": 1,
+                    "line_number": 397
+                },
+                {
+                    "branches": [],
+                    "count": 1,
                     "line_number": 398
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 400
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 402
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 403
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 405
                 }
             ]
         }

--- a/gcovr/tests/decisions/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/decisions/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -63,9 +63,9 @@
     </tr>
     <tr>
       <th scope="row">Decisions:</th>
-      <td>31</td>
-      <td>57</td>
-      <td class="coverage-low">54.4%</td>
+      <td>33</td>
+      <td>65</td>
+      <td class="coverage-low">50.8%</td>
     </tr>
   </table>
 </div>
@@ -2619,6 +2619,12 @@
       <td class="linebranch">
       </td>
       <td class="linedecision">
+        <details class="linedecisionDetails">
+          <summary class="linedecisionSummary">0/1</summary>
+          <div class="linedecisionContents">
+            <div class="notTakenDecision">&cross; Decision 'true' not taken.</div>
+          </div>
+        </details>
       </td>
       <td class="linecount uncoveredLine">&cross;</td>
       <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">true</span><span class="p">;</span></td>
@@ -2679,6 +2685,12 @@
       <td class="linebranch">
       </td>
       <td class="linedecision">
+        <details class="linedecisionDetails">
+          <summary class="linedecisionSummary">0/1</summary>
+          <div class="linedecisionContents">
+            <div class="notTakenDecision">&cross; Decision 'true' not taken.</div>
+          </div>
+        </details>
       </td>
       <td class="linecount uncoveredLine">&cross;</td>
       <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">false</span><span class="p">;</span></td>
@@ -2807,6 +2819,12 @@
       <td class="linebranch">
       </td>
       <td class="linedecision">
+        <details class="linedecisionDetails">
+          <summary class="linedecisionSummary">0/1</summary>
+          <div class="linedecisionContents">
+            <div class="notTakenDecision">&cross; Decision 'true' not taken.</div>
+          </div>
+        </details>
       </td>
       <td class="linecount uncoveredLine">&cross;</td>
       <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">true</span><span class="p">;</span></td>
@@ -2837,6 +2855,12 @@
       <td class="linebranch">
       </td>
       <td class="linedecision">
+        <details class="linedecisionDetails">
+          <summary class="linedecisionSummary">1/1</summary>
+          <div class="linedecisionContents">
+            <div class="takenDecision">&check; Decision 'true' taken 1 times.</div>
+          </div>
+        </details>
       </td>
       <td class="linecount coveredLine">1</td>
       <td class="src coveredLine">      <span class="k">return</span> <span class="nb">true</span><span class="p">;</span></td>
@@ -2867,6 +2891,12 @@
       <td class="linebranch">
       </td>
       <td class="linedecision">
+        <details class="linedecisionDetails">
+          <summary class="linedecisionSummary">0/1</summary>
+          <div class="linedecisionContents">
+            <div class="notTakenDecision">&cross; Decision 'true' not taken.</div>
+          </div>
+        </details>
       </td>
       <td class="linecount uncoveredLine">&cross;</td>
       <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">false</span><span class="p">;</span></td>
@@ -2975,6 +3005,12 @@
       <td class="linebranch">
       </td>
       <td class="linedecision">
+        <details class="linedecisionDetails">
+          <summary class="linedecisionSummary">0/1</summary>
+          <div class="linedecisionContents">
+            <div class="notTakenDecision">&cross; Decision 'true' not taken.</div>
+          </div>
+        </details>
       </td>
       <td class="linecount uncoveredLine">&cross;</td>
       <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">true</span><span class="p">;</span></td>
@@ -3005,6 +3041,12 @@
       <td class="linebranch">
       </td>
       <td class="linedecision">
+        <details class="linedecisionDetails">
+          <summary class="linedecisionSummary">0/1</summary>
+          <div class="linedecisionContents">
+            <div class="notTakenDecision">&cross; Decision 'true' not taken.</div>
+          </div>
+        </details>
       </td>
       <td class="linecount uncoveredLine">&cross;</td>
       <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">true</span><span class="p">;</span></td>
@@ -3035,6 +3077,12 @@
       <td class="linebranch">
       </td>
       <td class="linedecision">
+        <details class="linedecisionDetails">
+          <summary class="linedecisionSummary">1/1</summary>
+          <div class="linedecisionContents">
+            <div class="takenDecision">&check; Decision 'true' taken 1 times.</div>
+          </div>
+        </details>
       </td>
       <td class="linecount coveredLine">1</td>
       <td class="src coveredLine">      <span class="k">return</span> <span class="nb">false</span><span class="p">;</span></td>

--- a/gcovr/tests/decisions/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/decisions/reference/clang-10/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -118,13 +118,13 @@
     </tr>
     <tr>
       <td>
-        <a href="#l270">_Z12checkForLoopi</a>
+        <a href="#l277">_Z12checkForLoopi</a>
       </td>
       <td>
-        <a href="#l270">270</a>
+        <a href="#l277">277</a>
       </td>
       <td>
-        <a href="#l270"> called 1 time</a>
+        <a href="#l277"> called 1 time</a>
       </td>
     </tr>
     <tr>
@@ -140,24 +140,24 @@
     </tr>
     <tr>
       <td>
-        <a href="#l198">_Z12checkSwitch2i</a>
+        <a href="#l205">_Z12checkSwitch2i</a>
       </td>
       <td>
-        <a href="#l198">198</a>
+        <a href="#l205">205</a>
       </td>
       <td>
-        <a href="#l198"> called 1 time</a>
+        <a href="#l205"> called 1 time</a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="#l214">_Z12checkSwitch3i</a>
+        <a href="#l221">_Z12checkSwitch3i</a>
       </td>
       <td>
-        <a href="#l214">214</a>
+        <a href="#l221">221</a>
       </td>
       <td>
-        <a href="#l214"> called 1 time</a>
+        <a href="#l221"> called 1 time</a>
       </td>
     </tr>
     <tr>
@@ -173,13 +173,13 @@
     </tr>
     <tr>
       <td>
-        <a href="#l290">_Z14checkWhileLoopi</a>
+        <a href="#l297">_Z14checkWhileLoopi</a>
       </td>
       <td>
-        <a href="#l290">290</a>
+        <a href="#l297">297</a>
       </td>
       <td>
-        <a href="#l290"> called 1 time</a>
+        <a href="#l297"> called 1 time</a>
       </td>
     </tr>
     <tr>
@@ -239,24 +239,24 @@
     </tr>
     <tr>
       <td>
-        <a href="#l304">_Z16checkDoWhileLoopi</a>
+        <a href="#l311">_Z16checkDoWhileLoopi</a>
       </td>
       <td>
-        <a href="#l304">304</a>
+        <a href="#l311">311</a>
       </td>
       <td>
-        <a href="#l304"> called 1 time</a>
+        <a href="#l311"> called 1 time</a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="#l318">_Z16checkInterpreteri</a>
+        <a href="#l325">_Z16checkInterpreteri</a>
       </td>
       <td>
-        <a href="#l318">318</a>
+        <a href="#l325">325</a>
       </td>
       <td>
-        <a href="#l318"> called 1 time</a>
+        <a href="#l325"> called 1 time</a>
       </td>
     </tr>
     <tr>
@@ -272,13 +272,13 @@
     </tr>
     <tr>
       <td>
-        <a href="#l342">_Z16verify_issue_679b</a>
+        <a href="#l349">_Z16verify_issue_679b</a>
       </td>
       <td>
-        <a href="#l342">342</a>
+        <a href="#l349">349</a>
       </td>
       <td>
-        <a href="#l342"> called 2 times</a>
+        <a href="#l349"> called 2 times</a>
       </td>
     </tr>
     <tr>
@@ -316,24 +316,24 @@
     </tr>
     <tr>
       <td>
-        <a href="#l250">_Z17checkTernary1Truei</a>
+        <a href="#l257">_Z17checkTernary1Truei</a>
       </td>
       <td>
-        <a href="#l250">250</a>
+        <a href="#l257">257</a>
       </td>
       <td>
-        <a href="#l250"> called 1 time</a>
+        <a href="#l257"> called 1 time</a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="#l260">_Z17checkTernary2Truei</a>
+        <a href="#l267">_Z17checkTernary2Truei</a>
       </td>
       <td>
-        <a href="#l260">260</a>
+        <a href="#l267">267</a>
       </td>
       <td>
-        <a href="#l260"> called 1 time</a>
+        <a href="#l267"> called 1 time</a>
       </td>
     </tr>
     <tr>
@@ -349,90 +349,90 @@
     </tr>
     <tr>
       <td>
-        <a href="#l255">_Z18checkTernary1Falsei</a>
+        <a href="#l262">_Z18checkTernary1Falsei</a>
       </td>
       <td>
-        <a href="#l255">255</a>
+        <a href="#l262">262</a>
       </td>
       <td>
-        <a href="#l255"> called 1 time</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <a href="#l265">_Z18checkTernary2Falsei</a>
-      </td>
-      <td>
-        <a href="#l265">265</a>
-      </td>
-      <td>
-        <a href="#l265"> called 1 time</a>
+        <a href="#l262"> called 1 time</a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="#l280">_Z19checkComplexForLoopi</a>
+        <a href="#l272">_Z18checkTernary2Falsei</a>
       </td>
       <td>
-        <a href="#l280">280</a>
+        <a href="#l272">272</a>
       </td>
       <td>
-        <a href="#l280"> called 1 time</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <a href="#l230">_Z23checkCompactBranch1Truei</a>
-      </td>
-      <td>
-        <a href="#l230">230</a>
-      </td>
-      <td>
-        <a href="#l230"> called 1 time</a>
+        <a href="#l272"> called 1 time</a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="#l240">_Z23checkCompactBranch2Truei</a>
+        <a href="#l287">_Z19checkComplexForLoopi</a>
       </td>
       <td>
-        <a href="#l240">240</a>
+        <a href="#l287">287</a>
       </td>
       <td>
-        <a href="#l240"> called 1 time</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <a href="#l235">_Z24checkCompactBranch1Falsei</a>
-      </td>
-      <td>
-        <a href="#l235">235</a>
-      </td>
-      <td>
-        <a href="#l235"> called 1 time</a>
+        <a href="#l287"> called 1 time</a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="#l245">_Z24checkCompactBranch2Falsei</a>
+        <a href="#l237">_Z23checkCompactBranch1Truei</a>
       </td>
       <td>
-        <a href="#l245">245</a>
+        <a href="#l237">237</a>
       </td>
       <td>
-        <a href="#l245"> called 1 time</a>
+        <a href="#l237"> called 1 time</a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="#l349">main</a>
+        <a href="#l247">_Z23checkCompactBranch2Truei</a>
       </td>
       <td>
-        <a href="#l349">349</a>
+        <a href="#l247">247</a>
       </td>
       <td>
-        <a href="#l349"> called 1 time</a>
+        <a href="#l247"> called 1 time</a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="#l242">_Z24checkCompactBranch1Falsei</a>
+      </td>
+      <td>
+        <a href="#l242">242</a>
+      </td>
+      <td>
+        <a href="#l242"> called 1 time</a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="#l252">_Z24checkCompactBranch2Falsei</a>
+      </td>
+      <td>
+        <a href="#l252">252</a>
+      </td>
+      <td>
+        <a href="#l252"> called 1 time</a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="#l356">main</a>
+      </td>
+      <td>
+        <a href="#l356">356</a>
+      </td>
+      <td>
+        <a href="#l356"> called 1 time</a>
       </td>
     </tr>
   </table>
@@ -2591,7 +2591,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src ">   <span class="k">case</span> <span class="mi">10</span><span class="o">:</span></td>
+      <td class="src ">   <span class="cm">/* Comment */</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2600,8 +2600,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount uncoveredLine">&cross;</td>
-      <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">true</span><span class="p">;</span></td>
+      <td class="linecount "></td>
+      <td class="src ">   <span class="k">case</span> <span class="mi">10</span><span class="o">:</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2611,7 +2611,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
+      <td class="src ">      <span class="cm">/* Comment */</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2620,8 +2620,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src ">   <span class="k">default</span><span class="o">:</span></td>
+      <td class="linecount uncoveredLine">&cross;</td>
+      <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">true</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2630,8 +2630,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount uncoveredLine">&cross;</td>
-      <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">false</span><span class="p">;</span></td>
+      <td class="linecount "></td>
+      <td class="src ">      <span class="cm">/* Comment */</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2651,7 +2651,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src ">   <span class="p">}</span></td>
+      <td class="src ">      <span class="cm">/* Comment */</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2660,8 +2660,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="p">}</span></td>
+      <td class="linecount "></td>
+      <td class="src ">   <span class="k">default</span><span class="o">:</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2671,7 +2671,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="src ">      <span class="cm">/* Comment */</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2680,8 +2680,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkSwitch2</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+      <td class="linecount uncoveredLine">&cross;</td>
+      <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">false</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2691,11 +2691,81 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
+      <td class="src ">      <span class="cm">/* Comment */</span></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l200" href="#l200">200</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l201" href="#l201">201</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src ">      <span class="cm">/* Comment */</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l202" href="#l202">202</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src ">   <span class="p">}</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l203" href="#l203">203</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine"><span class="p">}</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l204" href="#l204">204</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l205" href="#l205">205</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkSwitch2</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l206" href="#l206">206</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">{</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l207" href="#l207">207</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">1/3</summary>
@@ -2713,7 +2783,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l201" href="#l201">201</a></td>
+      <td class="lineno"><a id="l208" href="#l208">208</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2723,7 +2793,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l202" href="#l202">202</a></td>
+      <td class="lineno"><a id="l209" href="#l209">209</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2733,7 +2803,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l203" href="#l203">203</a></td>
+      <td class="lineno"><a id="l210" href="#l210">210</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2743,7 +2813,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l204" href="#l204">204</a></td>
+      <td class="lineno"><a id="l211" href="#l211">211</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2753,7 +2823,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l205" href="#l205">205</a></td>
+      <td class="lineno"><a id="l212" href="#l212">212</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2763,7 +2833,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l206" href="#l206">206</a></td>
+      <td class="lineno"><a id="l213" href="#l213">213</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2773,83 +2843,13 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l207" href="#l207">207</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l208" href="#l208">208</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src ">   <span class="k">default</span><span class="o">:</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l209" href="#l209">209</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount uncoveredLine">&cross;</td>
-      <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">false</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l210" href="#l210">210</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l211" href="#l211">211</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src ">   <span class="p">}</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l212" href="#l212">212</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="p">}</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l213" href="#l213">213</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
-    </tr>
-
-    <tr class="source-line">
       <td class="lineno"><a id="l214" href="#l214">214</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkSwitch3</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+      <td class="linecount "></td>
+      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2859,11 +2859,81 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
+      <td class="src ">   <span class="k">default</span><span class="o">:</span></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l216" href="#l216">216</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount uncoveredLine">&cross;</td>
+      <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">false</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l217" href="#l217">217</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l218" href="#l218">218</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src ">   <span class="p">}</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l219" href="#l219">219</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine"><span class="p">}</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l220" href="#l220">220</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l221" href="#l221">221</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkSwitch3</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l222" href="#l222">222</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">{</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l223" href="#l223">223</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">1/3</summary>
@@ -2881,7 +2951,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l217" href="#l217">217</a></td>
+      <td class="lineno"><a id="l224" href="#l224">224</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2891,7 +2961,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l218" href="#l218">218</a></td>
+      <td class="lineno"><a id="l225" href="#l225">225</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2901,83 +2971,13 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l219" href="#l219">219</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount uncoveredLine">&cross;</td>
-      <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">true</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l220" href="#l220">220</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l221" href="#l221">221</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src ">   <span class="k">case</span> <span class="mi">10</span><span class="o">:</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l222" href="#l222">222</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount uncoveredLine">&cross;</td>
-      <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">true</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l223" href="#l223">223</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l224" href="#l224">224</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src ">   <span class="k">default</span><span class="o">:</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l225" href="#l225">225</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">      <span class="k">return</span> <span class="nb">false</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
       <td class="lineno"><a id="l226" href="#l226">226</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
+      <td class="linecount uncoveredLine">&cross;</td>
+      <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">true</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2987,7 +2987,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src ">   <span class="p">}</span></td>
+      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2996,8 +2996,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="p">}</span></td>
+      <td class="linecount "></td>
+      <td class="src ">   <span class="k">case</span> <span class="mi">10</span><span class="o">:</span></td>
     </tr>
 
     <tr class="source-line">
@@ -3006,8 +3006,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount uncoveredLine">&cross;</td>
+      <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">true</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -3016,8 +3016,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkCompactBranch1True</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+      <td class="linecount "></td>
+      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -3027,11 +3027,81 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
+      <td class="src ">   <span class="k">default</span><span class="o">:</span></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l232" href="#l232">232</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">      <span class="k">return</span> <span class="nb">false</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l233" href="#l233">233</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l234" href="#l234">234</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src ">   <span class="p">}</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l235" href="#l235">235</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine"><span class="p">}</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l236" href="#l236">236</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l237" href="#l237">237</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkCompactBranch1True</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l238" href="#l238">238</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">{</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l239" href="#l239">239</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">1/2</summary>
@@ -3055,7 +3125,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l233" href="#l233">233</a></td>
+      <td class="lineno"><a id="l240" href="#l240">240</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3065,7 +3135,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l234" href="#l234">234</a></td>
+      <td class="lineno"><a id="l241" href="#l241">241</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3075,7 +3145,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l235" href="#l235">235</a></td>
+      <td class="lineno"><a id="l242" href="#l242">242</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3085,7 +3155,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l236" href="#l236">236</a></td>
+      <td class="lineno"><a id="l243" href="#l243">243</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3095,7 +3165,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l237" href="#l237">237</a></td>
+      <td class="lineno"><a id="l244" href="#l244">244</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">1/2</summary>
@@ -3119,7 +3189,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l238" href="#l238">238</a></td>
+      <td class="lineno"><a id="l245" href="#l245">245</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3129,7 +3199,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l239" href="#l239">239</a></td>
+      <td class="lineno"><a id="l246" href="#l246">246</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3139,7 +3209,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l240" href="#l240">240</a></td>
+      <td class="lineno"><a id="l247" href="#l247">247</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3149,7 +3219,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l241" href="#l241">241</a></td>
+      <td class="lineno"><a id="l248" href="#l248">248</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3159,7 +3229,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l242" href="#l242">242</a></td>
+      <td class="lineno"><a id="l249" href="#l249">249</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">2/4</summary>
@@ -3184,7 +3254,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l243" href="#l243">243</a></td>
+      <td class="lineno"><a id="l250" href="#l250">250</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3194,7 +3264,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l244" href="#l244">244</a></td>
+      <td class="lineno"><a id="l251" href="#l251">251</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3204,7 +3274,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l245" href="#l245">245</a></td>
+      <td class="lineno"><a id="l252" href="#l252">252</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3214,7 +3284,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l246" href="#l246">246</a></td>
+      <td class="lineno"><a id="l253" href="#l253">253</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3224,7 +3294,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l247" href="#l247">247</a></td>
+      <td class="lineno"><a id="l254" href="#l254">254</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">1/4</summary>
@@ -3249,7 +3319,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l248" href="#l248">248</a></td>
+      <td class="lineno"><a id="l255" href="#l255">255</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3259,83 +3329,13 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l249" href="#l249">249</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l250" href="#l250">250</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkTernary1True</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l251" href="#l251">251</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l252" href="#l252">252</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="k">return</span> <span class="p">(</span><span class="n">a</span> <span class="o">==</span> <span class="mi">5</span><span class="p">)</span> <span class="o">?</span> <span class="nb">true</span> <span class="o">:</span> <span class="nb">false</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l253" href="#l253">253</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "><span class="p">}</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l254" href="#l254">254</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l255" href="#l255">255</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkTernary1False</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
-    </tr>
-
-    <tr class="source-line">
       <td class="lineno"><a id="l256" href="#l256">256</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
@@ -3345,7 +3345,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="k">return</span> <span class="p">(</span><span class="n">a</span> <span class="o">==</span> <span class="mi">5</span><span class="p">)</span> <span class="o">?</span> <span class="nb">true</span> <span class="o">:</span> <span class="nb">false</span><span class="p">;</span></td>
+      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkTernary1True</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
     </tr>
 
     <tr class="source-line">
@@ -3355,7 +3355,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "><span class="p">}</span></td>
+      <td class="src "><span class="p">{</span></td>
     </tr>
 
     <tr class="source-line">
@@ -3364,8 +3364,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="k">return</span> <span class="p">(</span><span class="n">a</span> <span class="o">==</span> <span class="mi">5</span><span class="p">)</span> <span class="o">?</span> <span class="nb">true</span> <span class="o">:</span> <span class="nb">false</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -3374,8 +3374,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkTernary2True</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">}</span></td>
     </tr>
 
     <tr class="source-line">
@@ -3385,11 +3385,81 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l262" href="#l262">262</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkTernary1False</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l263" href="#l263">263</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">{</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l264" href="#l264">264</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="k">return</span> <span class="p">(</span><span class="n">a</span> <span class="o">==</span> <span class="mi">5</span><span class="p">)</span> <span class="o">?</span> <span class="nb">true</span> <span class="o">:</span> <span class="nb">false</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l265" href="#l265">265</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">}</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l266" href="#l266">266</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l267" href="#l267">267</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkTernary2True</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l268" href="#l268">268</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">{</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l269" href="#l269">269</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">1/2</summary>
@@ -3406,7 +3476,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l263" href="#l263">263</a></td>
+      <td class="lineno"><a id="l270" href="#l270">270</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3416,7 +3486,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l264" href="#l264">264</a></td>
+      <td class="lineno"><a id="l271" href="#l271">271</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3426,7 +3496,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l265" href="#l265">265</a></td>
+      <td class="lineno"><a id="l272" href="#l272">272</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3436,7 +3506,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l266" href="#l266">266</a></td>
+      <td class="lineno"><a id="l273" href="#l273">273</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3446,7 +3516,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l267" href="#l267">267</a></td>
+      <td class="lineno"><a id="l274" href="#l274">274</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">1/2</summary>
@@ -3463,7 +3533,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l268" href="#l268">268</a></td>
+      <td class="lineno"><a id="l275" href="#l275">275</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3473,7 +3543,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l269" href="#l269">269</a></td>
+      <td class="lineno"><a id="l276" href="#l276">276</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3483,7 +3553,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l270" href="#l270">270</a></td>
+      <td class="lineno"><a id="l277" href="#l277">277</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3493,7 +3563,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l271" href="#l271">271</a></td>
+      <td class="lineno"><a id="l278" href="#l278">278</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3503,7 +3573,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l272" href="#l272">272</a></td>
+      <td class="lineno"><a id="l279" href="#l279">279</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3513,7 +3583,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l273" href="#l273">273</a></td>
+      <td class="lineno"><a id="l280" href="#l280">280</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">2/2</summary>
@@ -3537,7 +3607,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l274" href="#l274">274</a></td>
+      <td class="lineno"><a id="l281" href="#l281">281</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3547,7 +3617,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l275" href="#l275">275</a></td>
+      <td class="lineno"><a id="l282" href="#l282">282</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3557,7 +3627,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l276" href="#l276">276</a></td>
+      <td class="lineno"><a id="l283" href="#l283">283</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3567,7 +3637,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l277" href="#l277">277</a></td>
+      <td class="lineno"><a id="l284" href="#l284">284</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3577,7 +3647,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l278" href="#l278">278</a></td>
+      <td class="lineno"><a id="l285" href="#l285">285</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3587,7 +3657,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l279" href="#l279">279</a></td>
+      <td class="lineno"><a id="l286" href="#l286">286</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3597,7 +3667,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l280" href="#l280">280</a></td>
+      <td class="lineno"><a id="l287" href="#l287">287</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3607,7 +3677,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l281" href="#l281">281</a></td>
+      <td class="lineno"><a id="l288" href="#l288">288</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3617,7 +3687,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l282" href="#l282">282</a></td>
+      <td class="lineno"><a id="l289" href="#l289">289</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3627,7 +3697,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l283" href="#l283">283</a></td>
+      <td class="lineno"><a id="l290" href="#l290">290</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">4/4</summary>
@@ -3652,7 +3722,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l284" href="#l284">284</a></td>
+      <td class="lineno"><a id="l291" href="#l291">291</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3662,7 +3732,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l285" href="#l285">285</a></td>
+      <td class="lineno"><a id="l292" href="#l292">292</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3672,7 +3742,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l286" href="#l286">286</a></td>
+      <td class="lineno"><a id="l293" href="#l293">293</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3682,7 +3752,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l287" href="#l287">287</a></td>
+      <td class="lineno"><a id="l294" href="#l294">294</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3692,7 +3762,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l288" href="#l288">288</a></td>
+      <td class="lineno"><a id="l295" href="#l295">295</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3702,7 +3772,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l289" href="#l289">289</a></td>
+      <td class="lineno"><a id="l296" href="#l296">296</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3712,7 +3782,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l290" href="#l290">290</a></td>
+      <td class="lineno"><a id="l297" href="#l297">297</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3722,7 +3792,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l291" href="#l291">291</a></td>
+      <td class="lineno"><a id="l298" href="#l298">298</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3732,7 +3802,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l292" href="#l292">292</a></td>
+      <td class="lineno"><a id="l299" href="#l299">299</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3742,7 +3812,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l293" href="#l293">293</a></td>
+      <td class="lineno"><a id="l300" href="#l300">300</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3752,7 +3822,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l294" href="#l294">294</a></td>
+      <td class="lineno"><a id="l301" href="#l301">301</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3762,7 +3832,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l295" href="#l295">295</a></td>
+      <td class="lineno"><a id="l302" href="#l302">302</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">2/2</summary>
@@ -3786,7 +3856,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l296" href="#l296">296</a></td>
+      <td class="lineno"><a id="l303" href="#l303">303</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3796,7 +3866,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l297" href="#l297">297</a></td>
+      <td class="lineno"><a id="l304" href="#l304">304</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3806,7 +3876,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l298" href="#l298">298</a></td>
+      <td class="lineno"><a id="l305" href="#l305">305</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3816,7 +3886,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l299" href="#l299">299</a></td>
+      <td class="lineno"><a id="l306" href="#l306">306</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3826,7 +3896,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l300" href="#l300">300</a></td>
+      <td class="lineno"><a id="l307" href="#l307">307</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3836,7 +3906,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l301" href="#l301">301</a></td>
+      <td class="lineno"><a id="l308" href="#l308">308</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3846,7 +3916,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l302" href="#l302">302</a></td>
+      <td class="lineno"><a id="l309" href="#l309">309</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3856,7 +3926,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l303" href="#l303">303</a></td>
+      <td class="lineno"><a id="l310" href="#l310">310</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3866,7 +3936,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l304" href="#l304">304</a></td>
+      <td class="lineno"><a id="l311" href="#l311">311</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3876,7 +3946,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l305" href="#l305">305</a></td>
+      <td class="lineno"><a id="l312" href="#l312">312</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3886,7 +3956,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l306" href="#l306">306</a></td>
+      <td class="lineno"><a id="l313" href="#l313">313</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3896,7 +3966,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l307" href="#l307">307</a></td>
+      <td class="lineno"><a id="l314" href="#l314">314</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3906,7 +3976,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l308" href="#l308">308</a></td>
+      <td class="lineno"><a id="l315" href="#l315">315</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3916,7 +3986,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l309" href="#l309">309</a></td>
+      <td class="lineno"><a id="l316" href="#l316">316</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3926,7 +3996,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l310" href="#l310">310</a></td>
+      <td class="lineno"><a id="l317" href="#l317">317</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3936,7 +4006,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l311" href="#l311">311</a></td>
+      <td class="lineno"><a id="l318" href="#l318">318</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3946,7 +4016,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l312" href="#l312">312</a></td>
+      <td class="lineno"><a id="l319" href="#l319">319</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3956,7 +4026,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l313" href="#l313">313</a></td>
+      <td class="lineno"><a id="l320" href="#l320">320</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">2/2</summary>
@@ -3980,7 +4050,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l314" href="#l314">314</a></td>
+      <td class="lineno"><a id="l321" href="#l321">321</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3990,7 +4060,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l315" href="#l315">315</a></td>
+      <td class="lineno"><a id="l322" href="#l322">322</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4000,7 +4070,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l316" href="#l316">316</a></td>
+      <td class="lineno"><a id="l323" href="#l323">323</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4010,83 +4080,13 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l317" href="#l317">317</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l318" href="#l318">318</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkInterpreter</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l319" href="#l319">319</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l320" href="#l320">320</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test1</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; while &quot;</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l321" href="#l321">321</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">a</span><span class="o">++</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l322" href="#l322">322</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l323" href="#l323">323</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test2</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; for &quot;</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
       <td class="lineno"><a id="l324" href="#l324">324</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src ">   <span class="p">{</span></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
@@ -4096,7 +4096,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">      <span class="n">a</span><span class="o">++</span><span class="p">;</span></td>
+      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkInterpreter</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4106,7 +4106,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src ">   <span class="p">}</span></td>
+      <td class="src "><span class="p">{</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4115,8 +4115,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test1</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; while &quot;</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4126,21 +4126,11 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test3</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; if(&quot;</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l329" href="#l329">329</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
       <td class="src coveredLine">   <span class="n">a</span><span class="o">++</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l330" href="#l330">330</a></td>
+      <td class="lineno"><a id="l329" href="#l329">329</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4150,13 +4140,23 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l331" href="#l331">331</a></td>
+      <td class="lineno"><a id="l330" href="#l330">330</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test4</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; do &quot;</span><span class="p">;</span></td>
+      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test2</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; for &quot;</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l331" href="#l331">331</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src ">   <span class="p">{</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4166,7 +4166,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">a</span><span class="o">++</span><span class="p">;</span></td>
+      <td class="src coveredLine">      <span class="n">a</span><span class="o">++</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4176,11 +4176,81 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="src ">   <span class="p">}</span></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l334" href="#l334">334</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l335" href="#l335">335</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test3</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; if(&quot;</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l336" href="#l336">336</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">a</span><span class="o">++</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l337" href="#l337">337</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l338" href="#l338">338</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test4</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; do &quot;</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l339" href="#l339">339</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">a</span><span class="o">++</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l340" href="#l340">340</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l341" href="#l341">341</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">1/2</summary>
@@ -4204,7 +4274,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l335" href="#l335">335</a></td>
+      <td class="lineno"><a id="l342" href="#l342">342</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4214,7 +4284,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l336" href="#l336">336</a></td>
+      <td class="lineno"><a id="l343" href="#l343">343</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4224,7 +4294,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l337" href="#l337">337</a></td>
+      <td class="lineno"><a id="l344" href="#l344">344</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4234,7 +4304,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l338" href="#l338">338</a></td>
+      <td class="lineno"><a id="l345" href="#l345">345</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4244,7 +4314,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l339" href="#l339">339</a></td>
+      <td class="lineno"><a id="l346" href="#l346">346</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4254,7 +4324,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l340" href="#l340">340</a></td>
+      <td class="lineno"><a id="l347" href="#l347">347</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4264,7 +4334,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l341" href="#l341">341</a></td>
+      <td class="lineno"><a id="l348" href="#l348">348</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4274,7 +4344,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l342" href="#l342">342</a></td>
+      <td class="lineno"><a id="l349" href="#l349">349</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4284,7 +4354,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l343" href="#l343">343</a></td>
+      <td class="lineno"><a id="l350" href="#l350">350</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">2/2</summary>
@@ -4308,7 +4378,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l344" href="#l344">344</a></td>
+      <td class="lineno"><a id="l351" href="#l351">351</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">2/2</summary>
@@ -4332,7 +4402,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l345" href="#l345">345</a></td>
+      <td class="lineno"><a id="l352" href="#l352">352</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4342,7 +4412,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l346" href="#l346">346</a></td>
+      <td class="lineno"><a id="l353" href="#l353">353</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4352,83 +4422,13 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l347" href="#l347">347</a></td>
+      <td class="lineno"><a id="l354" href="#l354">354</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">2</td>
       <td class="src coveredLine"><span class="p">}</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l348" href="#l348">348</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l349" href="#l349">349</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">int</span> <span class="nf">main</span><span class="p">(</span><span class="kt">int</span> <span class="n">argc</span><span class="p">,</span> <span class="kt">char</span> <span class="o">*</span><span class="n">argv</span><span class="p">[])</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l350" href="#l350">350</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l351" href="#l351">351</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkBiggerTrue</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l352" href="#l352">352</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkBiggerFalse</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l353" href="#l353">353</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkBiggerBoth</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l354" href="#l354">354</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkBiggerBoth</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4448,7 +4448,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkSmallerTrue</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
+      <td class="src coveredLine"><span class="kt">int</span> <span class="nf">main</span><span class="p">(</span><span class="kt">int</span> <span class="n">argc</span><span class="p">,</span> <span class="kt">char</span> <span class="o">*</span><span class="n">argv</span><span class="p">[])</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4457,8 +4457,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkSmallerFalse</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">{</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4467,8 +4467,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkBiggerTrue</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4478,7 +4478,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkEqualTrue</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkBiggerFalse</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4488,7 +4488,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkEqualFalse</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkBiggerBoth</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4497,8 +4497,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkBiggerBoth</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4507,8 +4507,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkNotEqualTrue</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
+      <td class="linecount "></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
@@ -4518,7 +4518,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkNotEqualFalse</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkSmallerTrue</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4527,8 +4527,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkSmallerFalse</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4537,8 +4537,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkComplexTrue</span><span class="p">(</span><span class="mi">8</span><span class="p">);</span></td>
+      <td class="linecount "></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
@@ -4548,11 +4548,21 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkComplexFalse</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkEqualTrue</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l367" href="#l367">367</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkEqualFalse</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l368" href="#l368">368</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4562,23 +4572,13 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l368" href="#l368">368</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkElseIf1</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
-    </tr>
-
-    <tr class="source-line">
       <td class="lineno"><a id="l369" href="#l369">369</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkElseIf2</span><span class="p">(</span><span class="mi">10</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkNotEqualTrue</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4588,7 +4588,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkElseIf3</span><span class="p">(</span><span class="mi">0</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkNotEqualFalse</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4608,7 +4608,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkSwitch1</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkComplexTrue</span><span class="p">(</span><span class="mi">8</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4618,21 +4618,11 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkSwitch2</span><span class="p">(</span><span class="mi">10</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkComplexFalse</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l374" href="#l374">374</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkSwitch3</span><span class="p">(</span><span class="mi">0</span><span class="p">);</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l375" href="#l375">375</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4642,13 +4632,23 @@
     </tr>
 
     <tr class="source-line">
+      <td class="lineno"><a id="l375" href="#l375">375</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkElseIf1</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
+    </tr>
+
+    <tr class="source-line">
       <td class="lineno"><a id="l376" href="#l376">376</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkCompactBranch1True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkElseIf2</span><span class="p">(</span><span class="mi">10</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4658,7 +4658,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkCompactBranch1False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkElseIf3</span><span class="p">(</span><span class="mi">0</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4678,7 +4678,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkCompactBranch2True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkSwitch1</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4688,7 +4688,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkCompactBranch2False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkSwitch2</span><span class="p">(</span><span class="mi">10</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4697,8 +4697,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkSwitch3</span><span class="p">(</span><span class="mi">0</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4707,8 +4707,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkTernary1True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
+      <td class="linecount "></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
@@ -4718,7 +4718,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkTernary1False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkCompactBranch1True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4727,8 +4727,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkCompactBranch1False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4737,8 +4737,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkTernary2True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
+      <td class="linecount "></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
@@ -4748,7 +4748,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkTernary2False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkCompactBranch2True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4757,8 +4757,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkCompactBranch2False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4767,8 +4767,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkForLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
+      <td class="linecount "></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
@@ -4778,7 +4778,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkComplexForLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkTernary1True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4788,21 +4788,11 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkWhileLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkTernary1False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l391" href="#l391">391</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkDoWhileLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l392" href="#l392">392</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4812,13 +4802,23 @@
     </tr>
 
     <tr class="source-line">
+      <td class="lineno"><a id="l392" href="#l392">392</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkTernary2True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
+    </tr>
+
+    <tr class="source-line">
       <td class="lineno"><a id="l393" href="#l393">393</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkInterpreter</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkTernary2False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4838,7 +4838,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">verify_issue_679</span><span class="p">(</span><span class="nb">false</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkForLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4848,7 +4848,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">verify_issue_679</span><span class="p">(</span><span class="nb">true</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkComplexForLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4857,8 +4857,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkWhileLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4868,7 +4868,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="k">return</span> <span class="mi">0</span><span class="p">;</span></td>
+      <td class="src coveredLine">   <span class="n">checkDoWhileLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4878,11 +4878,81 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "><span class="p">}</span></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l400" href="#l400">400</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkInterpreter</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l401" href="#l401">401</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l402" href="#l402">402</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">verify_issue_679</span><span class="p">(</span><span class="nb">false</span><span class="p">);</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l403" href="#l403">403</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">verify_issue_679</span><span class="p">(</span><span class="nb">true</span><span class="p">);</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l404" href="#l404">404</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l405" href="#l405">405</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="k">return</span> <span class="mi">0</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l406" href="#l406">406</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">}</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l407" href="#l407">407</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">

--- a/gcovr/tests/decisions/reference/clang-13/coverage.functions.html
+++ b/gcovr/tests/decisions/reference/clang-13/coverage.functions.html
@@ -56,9 +56,9 @@
     </tr>
     <tr>
       <th scope="row">Decisions:</th>
-      <td>31</td>
-      <td>57</td>
-      <td class="coverage-low">54.4%</td>
+      <td>33</td>
+      <td>65</td>
+      <td class="coverage-low">50.8%</td>
     </tr>
   </table>
 </div>

--- a/gcovr/tests/decisions/reference/clang-13/coverage.functions.html
+++ b/gcovr/tests/decisions/reference/clang-13/coverage.functions.html
@@ -122,58 +122,58 @@
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l235">checkCompactBranch1False(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l242">checkCompactBranch1False(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l235">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l242">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l235">235</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l242">242</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l235"> called 1 time</a>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l230">checkCompactBranch1True(int)</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l230">main.cpp</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l230">230</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l230"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l242"> called 1 time</a>
     </td>
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l245">checkCompactBranch2False(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l237">checkCompactBranch1True(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l245">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l237">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l245">245</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l237">237</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l245"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l237"> called 1 time</a>
     </td>
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l240">checkCompactBranch2True(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l252">checkCompactBranch2False(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l240">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l252">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l240">240</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l252">252</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l240"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l252"> called 1 time</a>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l247">checkCompactBranch2True(int)</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l247">main.cpp</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l247">247</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l247"> called 1 time</a>
     </td>
   </tr>
   <tr>
@@ -192,16 +192,16 @@
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l280">checkComplexForLoop(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l287">checkComplexForLoop(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l280">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l287">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l280">280</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l287">287</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l280"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l287"> called 1 time</a>
     </td>
   </tr>
   <tr>
@@ -220,16 +220,16 @@
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l304">checkDoWhileLoop(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l311">checkDoWhileLoop(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l304">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l311">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l304">304</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l311">311</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l304"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l311"> called 1 time</a>
     </td>
   </tr>
   <tr>
@@ -304,30 +304,30 @@
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l270">checkForLoop(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l277">checkForLoop(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l270">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l277">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l270">270</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l277">277</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l270"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l277"> called 1 time</a>
     </td>
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l318">checkInterpreter(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l325">checkInterpreter(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l318">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l325">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l318">318</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l325">325</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l318"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l325"> called 1 time</a>
     </td>
   </tr>
   <tr>
@@ -402,105 +402,119 @@
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l198">checkSwitch2(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l205">checkSwitch2(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l198">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l205">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l198">198</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l205">205</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l198"> called 1 time</a>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l214">checkSwitch3(int)</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l214">main.cpp</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l214">214</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l214"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l205"> called 1 time</a>
     </td>
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l255">checkTernary1False(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l221">checkSwitch3(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l255">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l221">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l255">255</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l221">221</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l255"> called 1 time</a>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l250">checkTernary1True(int)</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l250">main.cpp</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l250">250</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l250"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l221"> called 1 time</a>
     </td>
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l265">checkTernary2False(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l262">checkTernary1False(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l265">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l262">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l265">265</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l262">262</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l265"> called 1 time</a>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l260">checkTernary2True(int)</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l260">main.cpp</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l260">260</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l260"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l262"> called 1 time</a>
     </td>
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l290">checkWhileLoop(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l257">checkTernary1True(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l290">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l257">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l290">290</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l257">257</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l290"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l257"> called 1 time</a>
     </td>
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l349">main</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l272">checkTernary2False(int)</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l272">main.cpp</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l272">272</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l272"> called 1 time</a>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l267">checkTernary2True(int)</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l267">main.cpp</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l267">267</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l267"> called 1 time</a>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l297">checkWhileLoop(int)</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l297">main.cpp</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l297">297</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l297"> called 1 time</a>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l356">main</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l356">main.cpp</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l356">356</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l356"> called 1 time</a>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l349">verify_issue_679(bool)</a>
     </td>
     <td>
       <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l349">main.cpp</a>
@@ -509,21 +523,7 @@
       <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l349">349</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l349"> called 1 time</a>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l342">verify_issue_679(bool)</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l342">main.cpp</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l342">342</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l342"> called 2 times</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l349"> called 2 times</a>
     </td>
   </tr>
 </table>

--- a/gcovr/tests/decisions/reference/clang-13/coverage.json
+++ b/gcovr/tests/decisions/reference/clang-13/coverage.json
@@ -895,11 +895,19 @@
                 {
                     "branches": [],
                     "count": 0,
+                    "gcovr/decision": {
+                        "count": 0,
+                        "type": "switch"
+                    },
                     "line_number": 192
                 },
                 {
                     "branches": [],
                     "count": 0,
+                    "gcovr/decision": {
+                        "count": 0,
+                        "type": "switch"
+                    },
                     "line_number": 198
                 },
                 {
@@ -936,16 +944,28 @@
                 {
                     "branches": [],
                     "count": 0,
+                    "gcovr/decision": {
+                        "count": 0,
+                        "type": "switch"
+                    },
                     "line_number": 210
                 },
                 {
                     "branches": [],
                     "count": 1,
+                    "gcovr/decision": {
+                        "count": 1,
+                        "type": "switch"
+                    },
                     "line_number": 213
                 },
                 {
                     "branches": [],
                     "count": 0,
+                    "gcovr/decision": {
+                        "count": 0,
+                        "type": "switch"
+                    },
                     "line_number": 216
                 },
                 {
@@ -982,16 +1002,28 @@
                 {
                     "branches": [],
                     "count": 0,
+                    "gcovr/decision": {
+                        "count": 0,
+                        "type": "switch"
+                    },
                     "line_number": 226
                 },
                 {
                     "branches": [],
                     "count": 0,
+                    "gcovr/decision": {
+                        "count": 0,
+                        "type": "switch"
+                    },
                     "line_number": 229
                 },
                 {
                     "branches": [],
                     "count": 1,
+                    "gcovr/decision": {
+                        "count": 1,
+                        "type": "switch"
+                    },
                     "line_number": 232
                 },
                 {

--- a/gcovr/tests/decisions/reference/clang-13/coverage.json
+++ b/gcovr/tests/decisions/reference/clang-13/coverage.json
@@ -20,22 +20,22 @@
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 235,
+                    "lineno": 242,
                     "name": "checkCompactBranch1False(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 230,
+                    "lineno": 237,
                     "name": "checkCompactBranch1True(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 245,
+                    "lineno": 252,
                     "name": "checkCompactBranch2False(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 240,
+                    "lineno": 247,
                     "name": "checkCompactBranch2True(int)"
                 },
                 {
@@ -45,7 +45,7 @@
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 280,
+                    "lineno": 287,
                     "name": "checkComplexForLoop(int)"
                 },
                 {
@@ -55,7 +55,7 @@
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 304,
+                    "lineno": 311,
                     "name": "checkDoWhileLoop(int)"
                 },
                 {
@@ -85,12 +85,12 @@
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 270,
+                    "lineno": 277,
                     "name": "checkForLoop(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 318,
+                    "lineno": 325,
                     "name": "checkInterpreter(int)"
                 },
                 {
@@ -120,47 +120,47 @@
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 198,
+                    "lineno": 205,
                     "name": "checkSwitch2(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 214,
+                    "lineno": 221,
                     "name": "checkSwitch3(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 255,
+                    "lineno": 262,
                     "name": "checkTernary1False(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 250,
+                    "lineno": 257,
                     "name": "checkTernary1True(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 265,
+                    "lineno": 272,
                     "name": "checkTernary2False(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 260,
+                    "lineno": 267,
                     "name": "checkTernary2True(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 290,
+                    "lineno": 297,
                     "name": "checkWhileLoop(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 349,
+                    "lineno": 356,
                     "name": "main"
                 },
                 {
                     "execution_count": 2,
-                    "lineno": 342,
+                    "lineno": 349,
                     "name": "verify_issue_679(bool)"
                 }
             ],
@@ -895,68 +895,68 @@
                 {
                     "branches": [],
                     "count": 0,
-                    "line_number": 190
+                    "line_number": 192
                 },
                 {
                     "branches": [],
                     "count": 0,
-                    "line_number": 193
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 196
-                },
-                {
-                    "branches": [],
-                    "count": 1,
                     "line_number": 198
                 },
                 {
-                    "branches": [
-                        {
-                            "count": 1,
-                            "fallthrough": false,
-                            "throw": false
-                        },
-                        {
-                            "count": 0,
-                            "fallthrough": false,
-                            "throw": false
-                        },
-                        {
-                            "count": 0,
-                            "fallthrough": false,
-                            "throw": false
-                        }
-                    ],
-                    "count": 1,
-                    "line_number": 200
-                },
-                {
                     "branches": [],
-                    "count": 0,
+                    "count": 1,
                     "line_number": 203
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 206
+                    "line_number": 205
+                },
+                {
+                    "branches": [
+                        {
+                            "count": 1,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
+                    "count": 1,
+                    "line_number": 207
                 },
                 {
                     "branches": [],
                     "count": 0,
-                    "line_number": 209
+                    "line_number": 210
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 212
+                    "line_number": 213
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "line_number": 216
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 214
+                    "line_number": 219
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 221
                 },
                 {
                     "branches": [
@@ -977,32 +977,32 @@
                         }
                     ],
                     "count": 1,
-                    "line_number": 216
+                    "line_number": 223
                 },
                 {
                     "branches": [],
                     "count": 0,
-                    "line_number": 219
+                    "line_number": 226
                 },
                 {
                     "branches": [],
                     "count": 0,
-                    "line_number": 222
+                    "line_number": 229
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 225
+                    "line_number": 232
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 228
+                    "line_number": 235
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 230
+                    "line_number": 237
                 },
                 {
                     "branches": [
@@ -1023,17 +1023,17 @@
                         "count_true": 1,
                         "type": "conditional"
                     },
-                    "line_number": 232
+                    "line_number": 239
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 233
+                    "line_number": 240
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 235
+                    "line_number": 242
                 },
                 {
                     "branches": [
@@ -1054,51 +1054,7 @@
                         "count_true": 0,
                         "type": "conditional"
                     },
-                    "line_number": 237
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 238
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 240
-                },
-                {
-                    "branches": [
-                        {
-                            "count": 1,
-                            "fallthrough": false,
-                            "throw": false
-                        },
-                        {
-                            "count": 0,
-                            "fallthrough": false,
-                            "throw": false
-                        },
-                        {
-                            "count": 1,
-                            "fallthrough": false,
-                            "throw": false
-                        },
-                        {
-                            "count": 0,
-                            "fallthrough": false,
-                            "throw": false
-                        }
-                    ],
-                    "count": 1,
-                    "gcovr/decision": {
-                        "type": "uncheckable"
-                    },
-                    "line_number": 242
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 243
+                    "line_number": 244
                 },
                 {
                     "branches": [],
@@ -1106,7 +1062,17 @@
                     "line_number": 245
                 },
                 {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 247
+                },
+                {
                     "branches": [
+                        {
+                            "count": 1,
+                            "fallthrough": false,
+                            "throw": false
+                        },
                         {
                             "count": 0,
                             "fallthrough": false,
@@ -1121,23 +1087,13 @@
                             "count": 0,
                             "fallthrough": false,
                             "throw": false
-                        },
-                        {
-                            "count": 0,
-                            "fallthrough": false,
-                            "throw": false
                         }
                     ],
                     "count": 1,
                     "gcovr/decision": {
                         "type": "uncheckable"
                     },
-                    "line_number": 247
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 248
+                    "line_number": 249
                 },
                 {
                     "branches": [],
@@ -1148,6 +1104,35 @@
                     "branches": [],
                     "count": 1,
                     "line_number": 252
+                },
+                {
+                    "branches": [
+                        {
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "count": 1,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
+                    "count": 1,
+                    "gcovr/decision": {
+                        "type": "uncheckable"
+                    },
+                    "line_number": 254
                 },
                 {
                     "branches": [],
@@ -1162,28 +1147,43 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 260
+                    "line_number": 259
                 },
                 {
-                    "branches": [
-                        {
-                            "count": 0,
-                            "fallthrough": false,
-                            "throw": false
-                        },
-                        {
-                            "count": 1,
-                            "fallthrough": false,
-                            "throw": false
-                        }
-                    ],
+                    "branches": [],
                     "count": 1,
                     "line_number": 262
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 265
+                    "line_number": 264
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 267
+                },
+                {
+                    "branches": [
+                        {
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "count": 1,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
+                    "count": 1,
+                    "line_number": 269
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 272
                 },
                 {
                     "branches": [
@@ -1199,17 +1199,17 @@
                         }
                     ],
                     "count": 1,
-                    "line_number": 267
+                    "line_number": 274
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 270
+                    "line_number": 277
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 272
+                    "line_number": 279
                 },
                 {
                     "branches": [
@@ -1230,32 +1230,32 @@
                         "count_true": 5,
                         "type": "conditional"
                     },
-                    "line_number": 273
-                },
-                {
-                    "branches": [],
-                    "count": 5,
-                    "line_number": 275
-                },
-                {
-                    "branches": [],
-                    "count": 5,
-                    "line_number": 276
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 277
-                },
-                {
-                    "branches": [],
-                    "count": 1,
                     "line_number": 280
                 },
                 {
                     "branches": [],
-                    "count": 1,
+                    "count": 5,
                     "line_number": 282
+                },
+                {
+                    "branches": [],
+                    "count": 5,
+                    "line_number": 283
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 284
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 287
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 289
                 },
                 {
                     "branches": [
@@ -1284,37 +1284,37 @@
                     "gcovr/decision": {
                         "type": "uncheckable"
                     },
-                    "line_number": 283
-                },
-                {
-                    "branches": [],
-                    "count": 5,
-                    "line_number": 285
-                },
-                {
-                    "branches": [],
-                    "count": 5,
-                    "line_number": 286
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 287
-                },
-                {
-                    "branches": [],
-                    "count": 1,
                     "line_number": 290
                 },
                 {
                     "branches": [],
-                    "count": 1,
+                    "count": 5,
                     "line_number": 292
                 },
                 {
                     "branches": [],
-                    "count": 1,
+                    "count": 5,
                     "line_number": 293
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 294
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 297
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 299
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 300
                 },
                 {
                     "branches": [
@@ -1335,52 +1335,52 @@
                         "count_true": 5,
                         "type": "conditional"
                     },
-                    "line_number": 295
+                    "line_number": 302
                 },
                 {
                     "branches": [],
                     "count": 5,
-                    "line_number": 297
-                },
-                {
-                    "branches": [],
-                    "count": 5,
-                    "line_number": 298
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 301
-                },
-                {
-                    "branches": [],
-                    "count": 1,
                     "line_number": 304
                 },
                 {
                     "branches": [],
-                    "count": 1,
-                    "line_number": 306
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 307
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 309
-                },
-                {
-                    "branches": [],
                     "count": 5,
+                    "line_number": 305
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 308
+                },
+                {
+                    "branches": [],
+                    "count": 1,
                     "line_number": 311
                 },
                 {
                     "branches": [],
+                    "count": 1,
+                    "line_number": 313
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 314
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 316
+                },
+                {
+                    "branches": [],
                     "count": 5,
-                    "line_number": 312
+                    "line_number": 318
+                },
+                {
+                    "branches": [],
+                    "count": 5,
+                    "line_number": 319
                 },
                 {
                     "branches": [
@@ -1401,32 +1401,12 @@
                         "count_true": 4,
                         "type": "conditional"
                     },
-                    "line_number": 313
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 315
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 318
-                },
-                {
-                    "branches": [],
-                    "count": 1,
                     "line_number": 320
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 321
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 323
+                    "line_number": 322
                 },
                 {
                     "branches": [],
@@ -1436,22 +1416,42 @@
                 {
                     "branches": [],
                     "count": 1,
+                    "line_number": 327
+                },
+                {
+                    "branches": [],
+                    "count": 1,
                     "line_number": 328
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 329
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 331
+                    "line_number": 330
                 },
                 {
                     "branches": [],
                     "count": 1,
                     "line_number": 332
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 335
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 336
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 338
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 339
                 },
                 {
                     "branches": [
@@ -1472,27 +1472,27 @@
                         "count_true": 1,
                         "type": "conditional"
                     },
-                    "line_number": 334
+                    "line_number": 341
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 336
+                    "line_number": 343
                 },
                 {
                     "branches": [],
                     "count": 0,
-                    "line_number": 339
+                    "line_number": 346
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 340
+                    "line_number": 347
                 },
                 {
                     "branches": [],
                     "count": 2,
-                    "line_number": 342
+                    "line_number": 349
                 },
                 {
                     "branches": [
@@ -1513,7 +1513,7 @@
                         "count_true": 1,
                         "type": "conditional"
                     },
-                    "line_number": 343
+                    "line_number": 350
                 },
                 {
                     "branches": [
@@ -1534,36 +1534,11 @@
                         "count_true": 10,
                         "type": "conditional"
                     },
-                    "line_number": 344
-                },
-                {
-                    "branches": [],
-                    "count": 10,
-                    "line_number": 345
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 346
-                },
-                {
-                    "branches": [],
-                    "count": 2,
-                    "line_number": 347
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 349
-                },
-                {
-                    "branches": [],
-                    "count": 1,
                     "line_number": 351
                 },
                 {
                     "branches": [],
-                    "count": 1,
+                    "count": 10,
                     "line_number": 352
                 },
                 {
@@ -1573,7 +1548,7 @@
                 },
                 {
                     "branches": [],
-                    "count": 1,
+                    "count": 2,
                     "line_number": 354
                 },
                 {
@@ -1584,7 +1559,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 357
+                    "line_number": 358
                 },
                 {
                     "branches": [],
@@ -1599,7 +1574,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 362
+                    "line_number": 361
                 },
                 {
                     "branches": [],
@@ -1609,7 +1584,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 365
+                    "line_number": 364
                 },
                 {
                     "branches": [],
@@ -1619,7 +1594,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 368
+                    "line_number": 367
                 },
                 {
                     "branches": [],
@@ -1644,7 +1619,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 374
+                    "line_number": 375
                 },
                 {
                     "branches": [],
@@ -1669,7 +1644,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 382
+                    "line_number": 381
                 },
                 {
                     "branches": [],
@@ -1679,7 +1654,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 385
+                    "line_number": 384
                 },
                 {
                     "branches": [],
@@ -1689,7 +1664,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 388
+                    "line_number": 387
                 },
                 {
                     "branches": [],
@@ -1704,7 +1679,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 391
+                    "line_number": 392
                 },
                 {
                     "branches": [],
@@ -1724,7 +1699,32 @@
                 {
                     "branches": [],
                     "count": 1,
+                    "line_number": 397
+                },
+                {
+                    "branches": [],
+                    "count": 1,
                     "line_number": 398
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 400
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 402
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 403
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 405
                 }
             ]
         }

--- a/gcovr/tests/decisions/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/decisions/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -63,9 +63,9 @@
     </tr>
     <tr>
       <th scope="row">Decisions:</th>
-      <td>31</td>
-      <td>57</td>
-      <td class="coverage-low">54.4%</td>
+      <td>33</td>
+      <td>65</td>
+      <td class="coverage-low">50.8%</td>
     </tr>
   </table>
 </div>
@@ -2619,6 +2619,12 @@
       <td class="linebranch">
       </td>
       <td class="linedecision">
+        <details class="linedecisionDetails">
+          <summary class="linedecisionSummary">0/1</summary>
+          <div class="linedecisionContents">
+            <div class="notTakenDecision">&cross; Decision 'true' not taken.</div>
+          </div>
+        </details>
       </td>
       <td class="linecount uncoveredLine">&cross;</td>
       <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">true</span><span class="p">;</span></td>
@@ -2679,6 +2685,12 @@
       <td class="linebranch">
       </td>
       <td class="linedecision">
+        <details class="linedecisionDetails">
+          <summary class="linedecisionSummary">0/1</summary>
+          <div class="linedecisionContents">
+            <div class="notTakenDecision">&cross; Decision 'true' not taken.</div>
+          </div>
+        </details>
       </td>
       <td class="linecount uncoveredLine">&cross;</td>
       <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">false</span><span class="p">;</span></td>
@@ -2807,6 +2819,12 @@
       <td class="linebranch">
       </td>
       <td class="linedecision">
+        <details class="linedecisionDetails">
+          <summary class="linedecisionSummary">0/1</summary>
+          <div class="linedecisionContents">
+            <div class="notTakenDecision">&cross; Decision 'true' not taken.</div>
+          </div>
+        </details>
       </td>
       <td class="linecount uncoveredLine">&cross;</td>
       <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">true</span><span class="p">;</span></td>
@@ -2837,6 +2855,12 @@
       <td class="linebranch">
       </td>
       <td class="linedecision">
+        <details class="linedecisionDetails">
+          <summary class="linedecisionSummary">1/1</summary>
+          <div class="linedecisionContents">
+            <div class="takenDecision">&check; Decision 'true' taken 1 times.</div>
+          </div>
+        </details>
       </td>
       <td class="linecount coveredLine">1</td>
       <td class="src coveredLine">      <span class="k">return</span> <span class="nb">true</span><span class="p">;</span></td>
@@ -2867,6 +2891,12 @@
       <td class="linebranch">
       </td>
       <td class="linedecision">
+        <details class="linedecisionDetails">
+          <summary class="linedecisionSummary">0/1</summary>
+          <div class="linedecisionContents">
+            <div class="notTakenDecision">&cross; Decision 'true' not taken.</div>
+          </div>
+        </details>
       </td>
       <td class="linecount uncoveredLine">&cross;</td>
       <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">false</span><span class="p">;</span></td>
@@ -2975,6 +3005,12 @@
       <td class="linebranch">
       </td>
       <td class="linedecision">
+        <details class="linedecisionDetails">
+          <summary class="linedecisionSummary">0/1</summary>
+          <div class="linedecisionContents">
+            <div class="notTakenDecision">&cross; Decision 'true' not taken.</div>
+          </div>
+        </details>
       </td>
       <td class="linecount uncoveredLine">&cross;</td>
       <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">true</span><span class="p">;</span></td>
@@ -3005,6 +3041,12 @@
       <td class="linebranch">
       </td>
       <td class="linedecision">
+        <details class="linedecisionDetails">
+          <summary class="linedecisionSummary">0/1</summary>
+          <div class="linedecisionContents">
+            <div class="notTakenDecision">&cross; Decision 'true' not taken.</div>
+          </div>
+        </details>
       </td>
       <td class="linecount uncoveredLine">&cross;</td>
       <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">true</span><span class="p">;</span></td>
@@ -3035,6 +3077,12 @@
       <td class="linebranch">
       </td>
       <td class="linedecision">
+        <details class="linedecisionDetails">
+          <summary class="linedecisionSummary">1/1</summary>
+          <div class="linedecisionContents">
+            <div class="takenDecision">&check; Decision 'true' taken 1 times.</div>
+          </div>
+        </details>
       </td>
       <td class="linecount coveredLine">1</td>
       <td class="src coveredLine">      <span class="k">return</span> <span class="nb">false</span><span class="p">;</span></td>

--- a/gcovr/tests/decisions/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/decisions/reference/clang-13/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -118,46 +118,46 @@
     </tr>
     <tr>
       <td>
-        <a href="#l235">checkCompactBranch1False(int)</a>
+        <a href="#l242">checkCompactBranch1False(int)</a>
       </td>
       <td>
-        <a href="#l235">235</a>
+        <a href="#l242">242</a>
       </td>
       <td>
-        <a href="#l235"> called 1 time</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <a href="#l230">checkCompactBranch1True(int)</a>
-      </td>
-      <td>
-        <a href="#l230">230</a>
-      </td>
-      <td>
-        <a href="#l230"> called 1 time</a>
+        <a href="#l242"> called 1 time</a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="#l245">checkCompactBranch2False(int)</a>
+        <a href="#l237">checkCompactBranch1True(int)</a>
       </td>
       <td>
-        <a href="#l245">245</a>
+        <a href="#l237">237</a>
       </td>
       <td>
-        <a href="#l245"> called 1 time</a>
+        <a href="#l237"> called 1 time</a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="#l240">checkCompactBranch2True(int)</a>
+        <a href="#l252">checkCompactBranch2False(int)</a>
       </td>
       <td>
-        <a href="#l240">240</a>
+        <a href="#l252">252</a>
       </td>
       <td>
-        <a href="#l240"> called 1 time</a>
+        <a href="#l252"> called 1 time</a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="#l247">checkCompactBranch2True(int)</a>
+      </td>
+      <td>
+        <a href="#l247">247</a>
+      </td>
+      <td>
+        <a href="#l247"> called 1 time</a>
       </td>
     </tr>
     <tr>
@@ -173,13 +173,13 @@
     </tr>
     <tr>
       <td>
-        <a href="#l280">checkComplexForLoop(int)</a>
+        <a href="#l287">checkComplexForLoop(int)</a>
       </td>
       <td>
-        <a href="#l280">280</a>
+        <a href="#l287">287</a>
       </td>
       <td>
-        <a href="#l280"> called 1 time</a>
+        <a href="#l287"> called 1 time</a>
       </td>
     </tr>
     <tr>
@@ -195,13 +195,13 @@
     </tr>
     <tr>
       <td>
-        <a href="#l304">checkDoWhileLoop(int)</a>
+        <a href="#l311">checkDoWhileLoop(int)</a>
       </td>
       <td>
-        <a href="#l304">304</a>
+        <a href="#l311">311</a>
       </td>
       <td>
-        <a href="#l304"> called 1 time</a>
+        <a href="#l311"> called 1 time</a>
       </td>
     </tr>
     <tr>
@@ -261,24 +261,24 @@
     </tr>
     <tr>
       <td>
-        <a href="#l270">checkForLoop(int)</a>
+        <a href="#l277">checkForLoop(int)</a>
       </td>
       <td>
-        <a href="#l270">270</a>
+        <a href="#l277">277</a>
       </td>
       <td>
-        <a href="#l270"> called 1 time</a>
+        <a href="#l277"> called 1 time</a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="#l318">checkInterpreter(int)</a>
+        <a href="#l325">checkInterpreter(int)</a>
       </td>
       <td>
-        <a href="#l318">318</a>
+        <a href="#l325">325</a>
       </td>
       <td>
-        <a href="#l318"> called 1 time</a>
+        <a href="#l325"> called 1 time</a>
       </td>
     </tr>
     <tr>
@@ -338,101 +338,101 @@
     </tr>
     <tr>
       <td>
-        <a href="#l198">checkSwitch2(int)</a>
+        <a href="#l205">checkSwitch2(int)</a>
       </td>
       <td>
-        <a href="#l198">198</a>
+        <a href="#l205">205</a>
       </td>
       <td>
-        <a href="#l198"> called 1 time</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <a href="#l214">checkSwitch3(int)</a>
-      </td>
-      <td>
-        <a href="#l214">214</a>
-      </td>
-      <td>
-        <a href="#l214"> called 1 time</a>
+        <a href="#l205"> called 1 time</a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="#l255">checkTernary1False(int)</a>
+        <a href="#l221">checkSwitch3(int)</a>
       </td>
       <td>
-        <a href="#l255">255</a>
+        <a href="#l221">221</a>
       </td>
       <td>
-        <a href="#l255"> called 1 time</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <a href="#l250">checkTernary1True(int)</a>
-      </td>
-      <td>
-        <a href="#l250">250</a>
-      </td>
-      <td>
-        <a href="#l250"> called 1 time</a>
+        <a href="#l221"> called 1 time</a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="#l265">checkTernary2False(int)</a>
+        <a href="#l262">checkTernary1False(int)</a>
       </td>
       <td>
-        <a href="#l265">265</a>
+        <a href="#l262">262</a>
       </td>
       <td>
-        <a href="#l265"> called 1 time</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <a href="#l260">checkTernary2True(int)</a>
-      </td>
-      <td>
-        <a href="#l260">260</a>
-      </td>
-      <td>
-        <a href="#l260"> called 1 time</a>
+        <a href="#l262"> called 1 time</a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="#l290">checkWhileLoop(int)</a>
+        <a href="#l257">checkTernary1True(int)</a>
       </td>
       <td>
-        <a href="#l290">290</a>
+        <a href="#l257">257</a>
       </td>
       <td>
-        <a href="#l290"> called 1 time</a>
+        <a href="#l257"> called 1 time</a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="#l349">main</a>
+        <a href="#l272">checkTernary2False(int)</a>
+      </td>
+      <td>
+        <a href="#l272">272</a>
+      </td>
+      <td>
+        <a href="#l272"> called 1 time</a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="#l267">checkTernary2True(int)</a>
+      </td>
+      <td>
+        <a href="#l267">267</a>
+      </td>
+      <td>
+        <a href="#l267"> called 1 time</a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="#l297">checkWhileLoop(int)</a>
+      </td>
+      <td>
+        <a href="#l297">297</a>
+      </td>
+      <td>
+        <a href="#l297"> called 1 time</a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="#l356">main</a>
+      </td>
+      <td>
+        <a href="#l356">356</a>
+      </td>
+      <td>
+        <a href="#l356"> called 1 time</a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="#l349">verify_issue_679(bool)</a>
       </td>
       <td>
         <a href="#l349">349</a>
       </td>
       <td>
-        <a href="#l349"> called 1 time</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <a href="#l342">verify_issue_679(bool)</a>
-      </td>
-      <td>
-        <a href="#l342">342</a>
-      </td>
-      <td>
-        <a href="#l342"> called 2 times</a>
+        <a href="#l349"> called 2 times</a>
       </td>
     </tr>
   </table>
@@ -2591,7 +2591,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src ">   <span class="k">case</span> <span class="mi">10</span><span class="o">:</span></td>
+      <td class="src ">   <span class="cm">/* Comment */</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2600,8 +2600,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount uncoveredLine">&cross;</td>
-      <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">true</span><span class="p">;</span></td>
+      <td class="linecount "></td>
+      <td class="src ">   <span class="k">case</span> <span class="mi">10</span><span class="o">:</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2611,7 +2611,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
+      <td class="src ">      <span class="cm">/* Comment */</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2620,8 +2620,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src ">   <span class="k">default</span><span class="o">:</span></td>
+      <td class="linecount uncoveredLine">&cross;</td>
+      <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">true</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2630,8 +2630,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount uncoveredLine">&cross;</td>
-      <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">false</span><span class="p">;</span></td>
+      <td class="linecount "></td>
+      <td class="src ">      <span class="cm">/* Comment */</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2651,7 +2651,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src ">   <span class="p">}</span></td>
+      <td class="src ">      <span class="cm">/* Comment */</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2660,8 +2660,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="p">}</span></td>
+      <td class="linecount "></td>
+      <td class="src ">   <span class="k">default</span><span class="o">:</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2671,7 +2671,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="src ">      <span class="cm">/* Comment */</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2680,8 +2680,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkSwitch2</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+      <td class="linecount uncoveredLine">&cross;</td>
+      <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">false</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2691,11 +2691,81 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
+      <td class="src ">      <span class="cm">/* Comment */</span></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l200" href="#l200">200</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l201" href="#l201">201</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src ">      <span class="cm">/* Comment */</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l202" href="#l202">202</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src ">   <span class="p">}</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l203" href="#l203">203</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine"><span class="p">}</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l204" href="#l204">204</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l205" href="#l205">205</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkSwitch2</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l206" href="#l206">206</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">{</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l207" href="#l207">207</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">1/3</summary>
@@ -2713,7 +2783,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l201" href="#l201">201</a></td>
+      <td class="lineno"><a id="l208" href="#l208">208</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2723,7 +2793,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l202" href="#l202">202</a></td>
+      <td class="lineno"><a id="l209" href="#l209">209</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2733,7 +2803,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l203" href="#l203">203</a></td>
+      <td class="lineno"><a id="l210" href="#l210">210</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2743,7 +2813,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l204" href="#l204">204</a></td>
+      <td class="lineno"><a id="l211" href="#l211">211</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2753,7 +2823,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l205" href="#l205">205</a></td>
+      <td class="lineno"><a id="l212" href="#l212">212</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2763,7 +2833,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l206" href="#l206">206</a></td>
+      <td class="lineno"><a id="l213" href="#l213">213</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2773,83 +2843,13 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l207" href="#l207">207</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l208" href="#l208">208</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src ">   <span class="k">default</span><span class="o">:</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l209" href="#l209">209</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount uncoveredLine">&cross;</td>
-      <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">false</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l210" href="#l210">210</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l211" href="#l211">211</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src ">   <span class="p">}</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l212" href="#l212">212</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="p">}</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l213" href="#l213">213</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
-    </tr>
-
-    <tr class="source-line">
       <td class="lineno"><a id="l214" href="#l214">214</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkSwitch3</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+      <td class="linecount "></td>
+      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2859,11 +2859,81 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
+      <td class="src ">   <span class="k">default</span><span class="o">:</span></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l216" href="#l216">216</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount uncoveredLine">&cross;</td>
+      <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">false</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l217" href="#l217">217</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l218" href="#l218">218</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src ">   <span class="p">}</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l219" href="#l219">219</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine"><span class="p">}</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l220" href="#l220">220</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l221" href="#l221">221</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkSwitch3</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l222" href="#l222">222</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">{</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l223" href="#l223">223</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">1/3</summary>
@@ -2881,7 +2951,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l217" href="#l217">217</a></td>
+      <td class="lineno"><a id="l224" href="#l224">224</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2891,7 +2961,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l218" href="#l218">218</a></td>
+      <td class="lineno"><a id="l225" href="#l225">225</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2901,83 +2971,13 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l219" href="#l219">219</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount uncoveredLine">&cross;</td>
-      <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">true</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l220" href="#l220">220</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l221" href="#l221">221</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src ">   <span class="k">case</span> <span class="mi">10</span><span class="o">:</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l222" href="#l222">222</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount uncoveredLine">&cross;</td>
-      <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">true</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l223" href="#l223">223</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l224" href="#l224">224</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src ">   <span class="k">default</span><span class="o">:</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l225" href="#l225">225</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">      <span class="k">return</span> <span class="nb">false</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
       <td class="lineno"><a id="l226" href="#l226">226</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
+      <td class="linecount uncoveredLine">&cross;</td>
+      <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">true</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2987,7 +2987,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src ">   <span class="p">}</span></td>
+      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2996,8 +2996,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="p">}</span></td>
+      <td class="linecount "></td>
+      <td class="src ">   <span class="k">case</span> <span class="mi">10</span><span class="o">:</span></td>
     </tr>
 
     <tr class="source-line">
@@ -3006,8 +3006,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount uncoveredLine">&cross;</td>
+      <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">true</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -3016,8 +3016,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkCompactBranch1True</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+      <td class="linecount "></td>
+      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -3027,11 +3027,81 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
+      <td class="src ">   <span class="k">default</span><span class="o">:</span></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l232" href="#l232">232</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">      <span class="k">return</span> <span class="nb">false</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l233" href="#l233">233</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l234" href="#l234">234</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src ">   <span class="p">}</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l235" href="#l235">235</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine"><span class="p">}</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l236" href="#l236">236</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l237" href="#l237">237</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkCompactBranch1True</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l238" href="#l238">238</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">{</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l239" href="#l239">239</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">1/2</summary>
@@ -3055,7 +3125,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l233" href="#l233">233</a></td>
+      <td class="lineno"><a id="l240" href="#l240">240</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3065,7 +3135,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l234" href="#l234">234</a></td>
+      <td class="lineno"><a id="l241" href="#l241">241</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3075,7 +3145,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l235" href="#l235">235</a></td>
+      <td class="lineno"><a id="l242" href="#l242">242</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3085,7 +3155,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l236" href="#l236">236</a></td>
+      <td class="lineno"><a id="l243" href="#l243">243</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3095,7 +3165,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l237" href="#l237">237</a></td>
+      <td class="lineno"><a id="l244" href="#l244">244</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">1/2</summary>
@@ -3119,7 +3189,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l238" href="#l238">238</a></td>
+      <td class="lineno"><a id="l245" href="#l245">245</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3129,7 +3199,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l239" href="#l239">239</a></td>
+      <td class="lineno"><a id="l246" href="#l246">246</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3139,7 +3209,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l240" href="#l240">240</a></td>
+      <td class="lineno"><a id="l247" href="#l247">247</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3149,7 +3219,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l241" href="#l241">241</a></td>
+      <td class="lineno"><a id="l248" href="#l248">248</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3159,7 +3229,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l242" href="#l242">242</a></td>
+      <td class="lineno"><a id="l249" href="#l249">249</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">2/4</summary>
@@ -3184,7 +3254,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l243" href="#l243">243</a></td>
+      <td class="lineno"><a id="l250" href="#l250">250</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3194,7 +3264,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l244" href="#l244">244</a></td>
+      <td class="lineno"><a id="l251" href="#l251">251</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3204,7 +3274,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l245" href="#l245">245</a></td>
+      <td class="lineno"><a id="l252" href="#l252">252</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3214,7 +3284,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l246" href="#l246">246</a></td>
+      <td class="lineno"><a id="l253" href="#l253">253</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3224,7 +3294,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l247" href="#l247">247</a></td>
+      <td class="lineno"><a id="l254" href="#l254">254</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">1/4</summary>
@@ -3249,7 +3319,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l248" href="#l248">248</a></td>
+      <td class="lineno"><a id="l255" href="#l255">255</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3259,83 +3329,13 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l249" href="#l249">249</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l250" href="#l250">250</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkTernary1True</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l251" href="#l251">251</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l252" href="#l252">252</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="k">return</span> <span class="p">(</span><span class="n">a</span> <span class="o">==</span> <span class="mi">5</span><span class="p">)</span> <span class="o">?</span> <span class="nb">true</span> <span class="o">:</span> <span class="nb">false</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l253" href="#l253">253</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "><span class="p">}</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l254" href="#l254">254</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l255" href="#l255">255</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkTernary1False</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
-    </tr>
-
-    <tr class="source-line">
       <td class="lineno"><a id="l256" href="#l256">256</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
@@ -3345,7 +3345,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="k">return</span> <span class="p">(</span><span class="n">a</span> <span class="o">==</span> <span class="mi">5</span><span class="p">)</span> <span class="o">?</span> <span class="nb">true</span> <span class="o">:</span> <span class="nb">false</span><span class="p">;</span></td>
+      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkTernary1True</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
     </tr>
 
     <tr class="source-line">
@@ -3355,7 +3355,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "><span class="p">}</span></td>
+      <td class="src "><span class="p">{</span></td>
     </tr>
 
     <tr class="source-line">
@@ -3364,8 +3364,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="k">return</span> <span class="p">(</span><span class="n">a</span> <span class="o">==</span> <span class="mi">5</span><span class="p">)</span> <span class="o">?</span> <span class="nb">true</span> <span class="o">:</span> <span class="nb">false</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -3374,8 +3374,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkTernary2True</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">}</span></td>
     </tr>
 
     <tr class="source-line">
@@ -3385,11 +3385,81 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l262" href="#l262">262</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkTernary1False</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l263" href="#l263">263</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">{</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l264" href="#l264">264</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="k">return</span> <span class="p">(</span><span class="n">a</span> <span class="o">==</span> <span class="mi">5</span><span class="p">)</span> <span class="o">?</span> <span class="nb">true</span> <span class="o">:</span> <span class="nb">false</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l265" href="#l265">265</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">}</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l266" href="#l266">266</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l267" href="#l267">267</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkTernary2True</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l268" href="#l268">268</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">{</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l269" href="#l269">269</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">1/2</summary>
@@ -3406,7 +3476,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l263" href="#l263">263</a></td>
+      <td class="lineno"><a id="l270" href="#l270">270</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3416,7 +3486,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l264" href="#l264">264</a></td>
+      <td class="lineno"><a id="l271" href="#l271">271</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3426,7 +3496,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l265" href="#l265">265</a></td>
+      <td class="lineno"><a id="l272" href="#l272">272</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3436,7 +3506,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l266" href="#l266">266</a></td>
+      <td class="lineno"><a id="l273" href="#l273">273</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3446,7 +3516,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l267" href="#l267">267</a></td>
+      <td class="lineno"><a id="l274" href="#l274">274</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">1/2</summary>
@@ -3463,7 +3533,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l268" href="#l268">268</a></td>
+      <td class="lineno"><a id="l275" href="#l275">275</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3473,7 +3543,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l269" href="#l269">269</a></td>
+      <td class="lineno"><a id="l276" href="#l276">276</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3483,7 +3553,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l270" href="#l270">270</a></td>
+      <td class="lineno"><a id="l277" href="#l277">277</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3493,7 +3563,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l271" href="#l271">271</a></td>
+      <td class="lineno"><a id="l278" href="#l278">278</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3503,7 +3573,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l272" href="#l272">272</a></td>
+      <td class="lineno"><a id="l279" href="#l279">279</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3513,7 +3583,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l273" href="#l273">273</a></td>
+      <td class="lineno"><a id="l280" href="#l280">280</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">2/2</summary>
@@ -3537,7 +3607,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l274" href="#l274">274</a></td>
+      <td class="lineno"><a id="l281" href="#l281">281</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3547,7 +3617,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l275" href="#l275">275</a></td>
+      <td class="lineno"><a id="l282" href="#l282">282</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3557,7 +3627,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l276" href="#l276">276</a></td>
+      <td class="lineno"><a id="l283" href="#l283">283</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3567,7 +3637,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l277" href="#l277">277</a></td>
+      <td class="lineno"><a id="l284" href="#l284">284</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3577,7 +3647,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l278" href="#l278">278</a></td>
+      <td class="lineno"><a id="l285" href="#l285">285</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3587,7 +3657,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l279" href="#l279">279</a></td>
+      <td class="lineno"><a id="l286" href="#l286">286</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3597,7 +3667,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l280" href="#l280">280</a></td>
+      <td class="lineno"><a id="l287" href="#l287">287</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3607,7 +3677,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l281" href="#l281">281</a></td>
+      <td class="lineno"><a id="l288" href="#l288">288</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3617,7 +3687,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l282" href="#l282">282</a></td>
+      <td class="lineno"><a id="l289" href="#l289">289</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3627,7 +3697,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l283" href="#l283">283</a></td>
+      <td class="lineno"><a id="l290" href="#l290">290</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">4/4</summary>
@@ -3652,7 +3722,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l284" href="#l284">284</a></td>
+      <td class="lineno"><a id="l291" href="#l291">291</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3662,7 +3732,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l285" href="#l285">285</a></td>
+      <td class="lineno"><a id="l292" href="#l292">292</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3672,7 +3742,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l286" href="#l286">286</a></td>
+      <td class="lineno"><a id="l293" href="#l293">293</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3682,7 +3752,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l287" href="#l287">287</a></td>
+      <td class="lineno"><a id="l294" href="#l294">294</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3692,7 +3762,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l288" href="#l288">288</a></td>
+      <td class="lineno"><a id="l295" href="#l295">295</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3702,7 +3772,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l289" href="#l289">289</a></td>
+      <td class="lineno"><a id="l296" href="#l296">296</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3712,7 +3782,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l290" href="#l290">290</a></td>
+      <td class="lineno"><a id="l297" href="#l297">297</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3722,7 +3792,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l291" href="#l291">291</a></td>
+      <td class="lineno"><a id="l298" href="#l298">298</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3732,7 +3802,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l292" href="#l292">292</a></td>
+      <td class="lineno"><a id="l299" href="#l299">299</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3742,7 +3812,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l293" href="#l293">293</a></td>
+      <td class="lineno"><a id="l300" href="#l300">300</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3752,7 +3822,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l294" href="#l294">294</a></td>
+      <td class="lineno"><a id="l301" href="#l301">301</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3762,7 +3832,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l295" href="#l295">295</a></td>
+      <td class="lineno"><a id="l302" href="#l302">302</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">2/2</summary>
@@ -3786,7 +3856,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l296" href="#l296">296</a></td>
+      <td class="lineno"><a id="l303" href="#l303">303</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3796,7 +3866,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l297" href="#l297">297</a></td>
+      <td class="lineno"><a id="l304" href="#l304">304</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3806,7 +3876,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l298" href="#l298">298</a></td>
+      <td class="lineno"><a id="l305" href="#l305">305</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3816,7 +3886,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l299" href="#l299">299</a></td>
+      <td class="lineno"><a id="l306" href="#l306">306</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3826,7 +3896,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l300" href="#l300">300</a></td>
+      <td class="lineno"><a id="l307" href="#l307">307</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3836,7 +3906,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l301" href="#l301">301</a></td>
+      <td class="lineno"><a id="l308" href="#l308">308</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3846,7 +3916,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l302" href="#l302">302</a></td>
+      <td class="lineno"><a id="l309" href="#l309">309</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3856,7 +3926,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l303" href="#l303">303</a></td>
+      <td class="lineno"><a id="l310" href="#l310">310</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3866,7 +3936,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l304" href="#l304">304</a></td>
+      <td class="lineno"><a id="l311" href="#l311">311</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3876,7 +3946,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l305" href="#l305">305</a></td>
+      <td class="lineno"><a id="l312" href="#l312">312</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3886,7 +3956,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l306" href="#l306">306</a></td>
+      <td class="lineno"><a id="l313" href="#l313">313</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3896,7 +3966,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l307" href="#l307">307</a></td>
+      <td class="lineno"><a id="l314" href="#l314">314</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3906,7 +3976,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l308" href="#l308">308</a></td>
+      <td class="lineno"><a id="l315" href="#l315">315</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3916,7 +3986,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l309" href="#l309">309</a></td>
+      <td class="lineno"><a id="l316" href="#l316">316</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3926,7 +3996,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l310" href="#l310">310</a></td>
+      <td class="lineno"><a id="l317" href="#l317">317</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3936,7 +4006,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l311" href="#l311">311</a></td>
+      <td class="lineno"><a id="l318" href="#l318">318</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3946,7 +4016,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l312" href="#l312">312</a></td>
+      <td class="lineno"><a id="l319" href="#l319">319</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3956,7 +4026,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l313" href="#l313">313</a></td>
+      <td class="lineno"><a id="l320" href="#l320">320</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">2/2</summary>
@@ -3980,7 +4050,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l314" href="#l314">314</a></td>
+      <td class="lineno"><a id="l321" href="#l321">321</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3990,7 +4060,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l315" href="#l315">315</a></td>
+      <td class="lineno"><a id="l322" href="#l322">322</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4000,7 +4070,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l316" href="#l316">316</a></td>
+      <td class="lineno"><a id="l323" href="#l323">323</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4010,83 +4080,13 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l317" href="#l317">317</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l318" href="#l318">318</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkInterpreter</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l319" href="#l319">319</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l320" href="#l320">320</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test1</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; while &quot;</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l321" href="#l321">321</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">a</span><span class="o">++</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l322" href="#l322">322</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l323" href="#l323">323</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test2</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; for &quot;</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
       <td class="lineno"><a id="l324" href="#l324">324</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src ">   <span class="p">{</span></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
@@ -4096,7 +4096,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">      <span class="n">a</span><span class="o">++</span><span class="p">;</span></td>
+      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkInterpreter</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4106,7 +4106,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src ">   <span class="p">}</span></td>
+      <td class="src "><span class="p">{</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4115,8 +4115,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test1</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; while &quot;</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4126,21 +4126,11 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test3</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; if(&quot;</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l329" href="#l329">329</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
       <td class="src coveredLine">   <span class="n">a</span><span class="o">++</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l330" href="#l330">330</a></td>
+      <td class="lineno"><a id="l329" href="#l329">329</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4150,13 +4140,23 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l331" href="#l331">331</a></td>
+      <td class="lineno"><a id="l330" href="#l330">330</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test4</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; do &quot;</span><span class="p">;</span></td>
+      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test2</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; for &quot;</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l331" href="#l331">331</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src ">   <span class="p">{</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4166,7 +4166,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">a</span><span class="o">++</span><span class="p">;</span></td>
+      <td class="src coveredLine">      <span class="n">a</span><span class="o">++</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4176,11 +4176,81 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="src ">   <span class="p">}</span></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l334" href="#l334">334</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l335" href="#l335">335</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test3</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; if(&quot;</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l336" href="#l336">336</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">a</span><span class="o">++</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l337" href="#l337">337</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l338" href="#l338">338</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test4</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; do &quot;</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l339" href="#l339">339</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">a</span><span class="o">++</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l340" href="#l340">340</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l341" href="#l341">341</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">1/2</summary>
@@ -4204,7 +4274,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l335" href="#l335">335</a></td>
+      <td class="lineno"><a id="l342" href="#l342">342</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4214,7 +4284,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l336" href="#l336">336</a></td>
+      <td class="lineno"><a id="l343" href="#l343">343</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4224,7 +4294,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l337" href="#l337">337</a></td>
+      <td class="lineno"><a id="l344" href="#l344">344</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4234,7 +4304,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l338" href="#l338">338</a></td>
+      <td class="lineno"><a id="l345" href="#l345">345</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4244,7 +4314,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l339" href="#l339">339</a></td>
+      <td class="lineno"><a id="l346" href="#l346">346</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4254,7 +4324,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l340" href="#l340">340</a></td>
+      <td class="lineno"><a id="l347" href="#l347">347</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4264,7 +4334,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l341" href="#l341">341</a></td>
+      <td class="lineno"><a id="l348" href="#l348">348</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4274,7 +4344,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l342" href="#l342">342</a></td>
+      <td class="lineno"><a id="l349" href="#l349">349</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4284,7 +4354,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l343" href="#l343">343</a></td>
+      <td class="lineno"><a id="l350" href="#l350">350</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">2/2</summary>
@@ -4308,7 +4378,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l344" href="#l344">344</a></td>
+      <td class="lineno"><a id="l351" href="#l351">351</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">2/2</summary>
@@ -4332,7 +4402,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l345" href="#l345">345</a></td>
+      <td class="lineno"><a id="l352" href="#l352">352</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4342,7 +4412,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l346" href="#l346">346</a></td>
+      <td class="lineno"><a id="l353" href="#l353">353</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4352,83 +4422,13 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l347" href="#l347">347</a></td>
+      <td class="lineno"><a id="l354" href="#l354">354</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">2</td>
       <td class="src coveredLine"><span class="p">}</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l348" href="#l348">348</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l349" href="#l349">349</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">int</span> <span class="nf">main</span><span class="p">(</span><span class="kt">int</span> <span class="n">argc</span><span class="p">,</span> <span class="kt">char</span> <span class="o">*</span><span class="n">argv</span><span class="p">[])</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l350" href="#l350">350</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l351" href="#l351">351</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkBiggerTrue</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l352" href="#l352">352</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkBiggerFalse</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l353" href="#l353">353</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkBiggerBoth</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l354" href="#l354">354</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkBiggerBoth</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4448,7 +4448,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkSmallerTrue</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
+      <td class="src coveredLine"><span class="kt">int</span> <span class="nf">main</span><span class="p">(</span><span class="kt">int</span> <span class="n">argc</span><span class="p">,</span> <span class="kt">char</span> <span class="o">*</span><span class="n">argv</span><span class="p">[])</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4457,8 +4457,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkSmallerFalse</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">{</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4467,8 +4467,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkBiggerTrue</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4478,7 +4478,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkEqualTrue</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkBiggerFalse</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4488,7 +4488,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkEqualFalse</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkBiggerBoth</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4497,8 +4497,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkBiggerBoth</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4507,8 +4507,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkNotEqualTrue</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
+      <td class="linecount "></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
@@ -4518,7 +4518,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkNotEqualFalse</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkSmallerTrue</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4527,8 +4527,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkSmallerFalse</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4537,8 +4537,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkComplexTrue</span><span class="p">(</span><span class="mi">8</span><span class="p">);</span></td>
+      <td class="linecount "></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
@@ -4548,11 +4548,21 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkComplexFalse</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkEqualTrue</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l367" href="#l367">367</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkEqualFalse</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l368" href="#l368">368</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4562,23 +4572,13 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l368" href="#l368">368</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkElseIf1</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
-    </tr>
-
-    <tr class="source-line">
       <td class="lineno"><a id="l369" href="#l369">369</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkElseIf2</span><span class="p">(</span><span class="mi">10</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkNotEqualTrue</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4588,7 +4588,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkElseIf3</span><span class="p">(</span><span class="mi">0</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkNotEqualFalse</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4608,7 +4608,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkSwitch1</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkComplexTrue</span><span class="p">(</span><span class="mi">8</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4618,21 +4618,11 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkSwitch2</span><span class="p">(</span><span class="mi">10</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkComplexFalse</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l374" href="#l374">374</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkSwitch3</span><span class="p">(</span><span class="mi">0</span><span class="p">);</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l375" href="#l375">375</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4642,13 +4632,23 @@
     </tr>
 
     <tr class="source-line">
+      <td class="lineno"><a id="l375" href="#l375">375</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkElseIf1</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
+    </tr>
+
+    <tr class="source-line">
       <td class="lineno"><a id="l376" href="#l376">376</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkCompactBranch1True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkElseIf2</span><span class="p">(</span><span class="mi">10</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4658,7 +4658,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkCompactBranch1False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkElseIf3</span><span class="p">(</span><span class="mi">0</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4678,7 +4678,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkCompactBranch2True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkSwitch1</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4688,7 +4688,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkCompactBranch2False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkSwitch2</span><span class="p">(</span><span class="mi">10</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4697,8 +4697,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkSwitch3</span><span class="p">(</span><span class="mi">0</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4707,8 +4707,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkTernary1True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
+      <td class="linecount "></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
@@ -4718,7 +4718,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkTernary1False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkCompactBranch1True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4727,8 +4727,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkCompactBranch1False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4737,8 +4737,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkTernary2True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
+      <td class="linecount "></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
@@ -4748,7 +4748,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkTernary2False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkCompactBranch2True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4757,8 +4757,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkCompactBranch2False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4767,8 +4767,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkForLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
+      <td class="linecount "></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
@@ -4778,7 +4778,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkComplexForLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkTernary1True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4788,21 +4788,11 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkWhileLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkTernary1False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l391" href="#l391">391</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkDoWhileLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l392" href="#l392">392</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4812,13 +4802,23 @@
     </tr>
 
     <tr class="source-line">
+      <td class="lineno"><a id="l392" href="#l392">392</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkTernary2True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
+    </tr>
+
+    <tr class="source-line">
       <td class="lineno"><a id="l393" href="#l393">393</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkInterpreter</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkTernary2False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4838,7 +4838,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">verify_issue_679</span><span class="p">(</span><span class="nb">false</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkForLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4848,7 +4848,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">verify_issue_679</span><span class="p">(</span><span class="nb">true</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkComplexForLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4857,8 +4857,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkWhileLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4868,7 +4868,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="k">return</span> <span class="mi">0</span><span class="p">;</span></td>
+      <td class="src coveredLine">   <span class="n">checkDoWhileLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4878,11 +4878,81 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "><span class="p">}</span></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l400" href="#l400">400</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkInterpreter</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l401" href="#l401">401</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l402" href="#l402">402</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">verify_issue_679</span><span class="p">(</span><span class="nb">false</span><span class="p">);</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l403" href="#l403">403</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">verify_issue_679</span><span class="p">(</span><span class="nb">true</span><span class="p">);</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l404" href="#l404">404</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l405" href="#l405">405</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="k">return</span> <span class="mi">0</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l406" href="#l406">406</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">}</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l407" href="#l407">407</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">

--- a/gcovr/tests/decisions/reference/gcc-11/coverage.functions.html
+++ b/gcovr/tests/decisions/reference/gcc-11/coverage.functions.html
@@ -57,8 +57,8 @@
     <tr>
       <th scope="row">Decisions:</th>
       <td>33</td>
-      <td>65</td>
-      <td class="coverage-low">50.8%</td>
+      <td>63</td>
+      <td class="coverage-low">52.4%</td>
     </tr>
   </table>
 </div>
@@ -122,58 +122,58 @@
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l235">checkCompactBranch1False(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l242">checkCompactBranch1False(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l235">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l242">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l235">235</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l242">242</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l235"> called 1 time</a>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l230">checkCompactBranch1True(int)</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l230">main.cpp</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l230">230</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l230"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l242"> called 1 time</a>
     </td>
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l245">checkCompactBranch2False(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l237">checkCompactBranch1True(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l245">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l237">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l245">245</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l237">237</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l245"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l237"> called 1 time</a>
     </td>
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l240">checkCompactBranch2True(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l252">checkCompactBranch2False(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l240">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l252">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l240">240</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l252">252</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l240"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l252"> called 1 time</a>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l247">checkCompactBranch2True(int)</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l247">main.cpp</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l247">247</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l247"> called 1 time</a>
     </td>
   </tr>
   <tr>
@@ -192,16 +192,16 @@
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l280">checkComplexForLoop(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l287">checkComplexForLoop(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l280">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l287">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l280">280</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l287">287</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l280"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l287"> called 1 time</a>
     </td>
   </tr>
   <tr>
@@ -220,16 +220,16 @@
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l304">checkDoWhileLoop(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l311">checkDoWhileLoop(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l304">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l311">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l304">304</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l311">311</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l304"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l311"> called 1 time</a>
     </td>
   </tr>
   <tr>
@@ -304,30 +304,30 @@
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l270">checkForLoop(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l277">checkForLoop(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l270">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l277">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l270">270</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l277">277</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l270"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l277"> called 1 time</a>
     </td>
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l318">checkInterpreter(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l325">checkInterpreter(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l318">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l325">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l318">318</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l325">325</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l318"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l325"> called 1 time</a>
     </td>
   </tr>
   <tr>
@@ -402,105 +402,119 @@
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l198">checkSwitch2(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l205">checkSwitch2(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l198">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l205">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l198">198</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l205">205</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l198"> called 1 time</a>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l214">checkSwitch3(int)</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l214">main.cpp</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l214">214</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l214"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l205"> called 1 time</a>
     </td>
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l255">checkTernary1False(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l221">checkSwitch3(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l255">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l221">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l255">255</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l221">221</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l255"> called 1 time</a>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l250">checkTernary1True(int)</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l250">main.cpp</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l250">250</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l250"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l221"> called 1 time</a>
     </td>
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l265">checkTernary2False(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l262">checkTernary1False(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l265">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l262">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l265">265</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l262">262</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l265"> called 1 time</a>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l260">checkTernary2True(int)</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l260">main.cpp</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l260">260</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l260"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l262"> called 1 time</a>
     </td>
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l290">checkWhileLoop(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l257">checkTernary1True(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l290">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l257">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l290">290</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l257">257</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l290"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l257"> called 1 time</a>
     </td>
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l349">main</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l272">checkTernary2False(int)</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l272">main.cpp</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l272">272</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l272"> called 1 time</a>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l267">checkTernary2True(int)</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l267">main.cpp</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l267">267</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l267"> called 1 time</a>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l297">checkWhileLoop(int)</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l297">main.cpp</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l297">297</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l297"> called 1 time</a>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l356">main</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l356">main.cpp</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l356">356</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l356"> called 1 time</a>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l349">verify_issue_679(bool)</a>
     </td>
     <td>
       <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l349">main.cpp</a>
@@ -509,21 +523,7 @@
       <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l349">349</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l349"> called 1 time</a>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l342">verify_issue_679(bool)</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l342">main.cpp</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l342">342</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l342"> called 2 times</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l349"> called 2 times</a>
     </td>
   </tr>
 </table>

--- a/gcovr/tests/decisions/reference/gcc-11/coverage.functions.html
+++ b/gcovr/tests/decisions/reference/gcc-11/coverage.functions.html
@@ -57,8 +57,8 @@
     <tr>
       <th scope="row">Decisions:</th>
       <td>33</td>
-      <td>63</td>
-      <td class="coverage-low">52.4%</td>
+      <td>65</td>
+      <td class="coverage-low">50.8%</td>
     </tr>
   </table>
 </div>

--- a/gcovr/tests/decisions/reference/gcc-11/coverage.html
+++ b/gcovr/tests/decisions/reference/gcc-11/coverage.html
@@ -65,8 +65,8 @@
     <tr>
       <th scope="row">Decisions:</th>
       <td>33</td>
-      <td>63</td>
-      <td class="coverage-low">52.4%</td>
+      <td>65</td>
+      <td class="coverage-low">50.8%</td>
     </tr>
   </table>
 </div>
@@ -109,8 +109,8 @@
     <td class="CoverValue function-coverage coverage-high">32 / 32</td>
     <td class="CoverValue branch-coverage coverage-low">51.7%</td>
     <td class="CoverValue branch-coverage coverage-low">45 / 87</td>
-    <td class="CoverValue decision-coverage coverage-low">52.4%</td>
-    <td class="CoverValue decision-coverage coverage-low">33 / 63</td>
+    <td class="CoverValue decision-coverage coverage-low">50.8%</td>
+    <td class="CoverValue decision-coverage coverage-low">33 / 65</td>
   </tr>
 
 </table>

--- a/gcovr/tests/decisions/reference/gcc-11/coverage.html
+++ b/gcovr/tests/decisions/reference/gcc-11/coverage.html
@@ -65,8 +65,8 @@
     <tr>
       <th scope="row">Decisions:</th>
       <td>33</td>
-      <td>65</td>
-      <td class="coverage-low">50.8%</td>
+      <td>63</td>
+      <td class="coverage-low">52.4%</td>
     </tr>
   </table>
 </div>
@@ -109,8 +109,8 @@
     <td class="CoverValue function-coverage coverage-high">32 / 32</td>
     <td class="CoverValue branch-coverage coverage-low">51.7%</td>
     <td class="CoverValue branch-coverage coverage-low">45 / 87</td>
-    <td class="CoverValue decision-coverage coverage-low">50.8%</td>
-    <td class="CoverValue decision-coverage coverage-low">33 / 65</td>
+    <td class="CoverValue decision-coverage coverage-low">52.4%</td>
+    <td class="CoverValue decision-coverage coverage-low">33 / 63</td>
   </tr>
 
 </table>

--- a/gcovr/tests/decisions/reference/gcc-11/coverage.json
+++ b/gcovr/tests/decisions/reference/gcc-11/coverage.json
@@ -20,22 +20,22 @@
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 235,
+                    "lineno": 242,
                     "name": "checkCompactBranch1False(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 230,
+                    "lineno": 237,
                     "name": "checkCompactBranch1True(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 245,
+                    "lineno": 252,
                     "name": "checkCompactBranch2False(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 240,
+                    "lineno": 247,
                     "name": "checkCompactBranch2True(int)"
                 },
                 {
@@ -45,7 +45,7 @@
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 280,
+                    "lineno": 287,
                     "name": "checkComplexForLoop(int)"
                 },
                 {
@@ -55,7 +55,7 @@
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 304,
+                    "lineno": 311,
                     "name": "checkDoWhileLoop(int)"
                 },
                 {
@@ -85,12 +85,12 @@
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 270,
+                    "lineno": 277,
                     "name": "checkForLoop(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 318,
+                    "lineno": 325,
                     "name": "checkInterpreter(int)"
                 },
                 {
@@ -120,47 +120,47 @@
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 198,
+                    "lineno": 205,
                     "name": "checkSwitch2(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 214,
+                    "lineno": 221,
                     "name": "checkSwitch3(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 255,
+                    "lineno": 262,
                     "name": "checkTernary1False(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 250,
+                    "lineno": 257,
                     "name": "checkTernary1True(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 265,
+                    "lineno": 272,
                     "name": "checkTernary2False(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 260,
+                    "lineno": 267,
                     "name": "checkTernary2True(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 290,
+                    "lineno": 297,
                     "name": "checkWhileLoop(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 349,
+                    "lineno": 356,
                     "name": "main"
                 },
                 {
                     "execution_count": 2,
-                    "lineno": 342,
+                    "lineno": 349,
                     "name": "verify_issue_679(bool)"
                 }
             ],
@@ -825,35 +825,27 @@
                 {
                     "branches": [],
                     "count": 0,
-                    "gcovr/decision": {
-                        "count": 0,
-                        "type": "switch"
-                    },
-                    "line_number": 189
-                },
-                {
-                    "branches": [],
-                    "count": 0,
                     "line_number": 190
                 },
                 {
                     "branches": [],
                     "count": 0,
-                    "gcovr/decision": {
-                        "count": 0,
-                        "type": "switch"
-                    },
                     "line_number": 192
                 },
                 {
                     "branches": [],
                     "count": 0,
-                    "line_number": 193
+                    "line_number": 196
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "line_number": 198
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 198
+                    "line_number": 205
                 },
                 {
                     "branches": [
@@ -874,7 +866,7 @@
                         }
                     ],
                     "count": 1,
-                    "line_number": 200
+                    "line_number": 207
                 },
                 {
                     "branches": [],
@@ -883,45 +875,45 @@
                         "count": 0,
                         "type": "switch"
                     },
-                    "line_number": 202
-                },
-                {
-                    "branches": [],
-                    "count": 0,
-                    "line_number": 203
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "gcovr/decision": {
-                        "count": 1,
-                        "type": "switch"
-                    },
-                    "line_number": 205
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 206
-                },
-                {
-                    "branches": [],
-                    "count": 0,
-                    "gcovr/decision": {
-                        "count": 0,
-                        "type": "switch"
-                    },
-                    "line_number": 208
-                },
-                {
-                    "branches": [],
-                    "count": 0,
                     "line_number": 209
                 },
                 {
                     "branches": [],
+                    "count": 0,
+                    "line_number": 210
+                },
+                {
+                    "branches": [],
                     "count": 1,
-                    "line_number": 214
+                    "gcovr/decision": {
+                        "count": 1,
+                        "type": "switch"
+                    },
+                    "line_number": 212
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 213
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "gcovr/decision": {
+                        "count": 0,
+                        "type": "switch"
+                    },
+                    "line_number": 215
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "line_number": 216
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 221
                 },
                 {
                     "branches": [
@@ -942,7 +934,7 @@
                         }
                     ],
                     "count": 1,
-                    "line_number": 216
+                    "line_number": 223
                 },
                 {
                     "branches": [],
@@ -951,12 +943,12 @@
                         "count": 0,
                         "type": "switch"
                     },
-                    "line_number": 218
+                    "line_number": 225
                 },
                 {
                     "branches": [],
                     "count": 0,
-                    "line_number": 219
+                    "line_number": 226
                 },
                 {
                     "branches": [],
@@ -965,12 +957,12 @@
                         "count": 0,
                         "type": "switch"
                     },
-                    "line_number": 221
+                    "line_number": 228
                 },
                 {
                     "branches": [],
                     "count": 0,
-                    "line_number": 222
+                    "line_number": 229
                 },
                 {
                     "branches": [],
@@ -979,17 +971,17 @@
                         "count": 1,
                         "type": "switch"
                     },
-                    "line_number": 224
+                    "line_number": 231
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 225
+                    "line_number": 232
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 230
+                    "line_number": 237
                 },
                 {
                     "branches": [
@@ -1010,12 +1002,12 @@
                         "count_true": 1,
                         "type": "conditional"
                     },
-                    "line_number": 232
+                    "line_number": 239
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 235
+                    "line_number": 242
                 },
                 {
                     "branches": [
@@ -1036,80 +1028,41 @@
                         "count_true": 0,
                         "type": "conditional"
                     },
-                    "line_number": 237
+                    "line_number": 244
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 240
-                },
-                {
-                    "branches": [
-                        {
-                            "count": 1,
-                            "fallthrough": true,
-                            "throw": false
-                        },
-                        {
-                            "count": 0,
-                            "fallthrough": false,
-                            "throw": false
-                        },
-                        {
-                            "count": 1,
-                            "fallthrough": true,
-                            "throw": false
-                        },
-                        {
-                            "count": 0,
-                            "fallthrough": false,
-                            "throw": false
-                        }
-                    ],
-                    "count": 1,
-                    "gcovr/decision": {
-                        "type": "uncheckable"
-                    },
-                    "line_number": 242
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 245
-                },
-                {
-                    "branches": [
-                        {
-                            "count": 0,
-                            "fallthrough": true,
-                            "throw": false
-                        },
-                        {
-                            "count": 1,
-                            "fallthrough": false,
-                            "throw": false
-                        },
-                        {
-                            "count": 0,
-                            "fallthrough": false,
-                            "throw": false
-                        },
-                        {
-                            "count": 0,
-                            "fallthrough": false,
-                            "throw": false
-                        }
-                    ],
-                    "count": 1,
-                    "gcovr/decision": {
-                        "type": "uncheckable"
-                    },
                     "line_number": 247
                 },
                 {
-                    "branches": [],
+                    "branches": [
+                        {
+                            "count": 1,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "count": 1,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
                     "count": 1,
-                    "line_number": 250
+                    "gcovr/decision": {
+                        "type": "uncheckable"
+                    },
+                    "line_number": 249
                 },
                 {
                     "branches": [],
@@ -1117,9 +1070,33 @@
                     "line_number": 252
                 },
                 {
-                    "branches": [],
+                    "branches": [
+                        {
+                            "count": 0,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "count": 1,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
                     "count": 1,
-                    "line_number": 255
+                    "gcovr/decision": {
+                        "type": "uncheckable"
+                    },
+                    "line_number": 254
                 },
                 {
                     "branches": [],
@@ -1129,38 +1106,53 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 260
+                    "line_number": 259
                 },
                 {
-                    "branches": [
-                        {
-                            "count": 1,
-                            "fallthrough": true,
-                            "throw": false
-                        },
-                        {
-                            "count": 0,
-                            "fallthrough": false,
-                            "throw": false
-                        },
-                        {
-                            "count": 1,
-                            "fallthrough": true,
-                            "throw": false
-                        },
-                        {
-                            "count": 0,
-                            "fallthrough": false,
-                            "throw": false
-                        }
-                    ],
+                    "branches": [],
                     "count": 1,
                     "line_number": 262
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 265
+                    "line_number": 264
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 267
+                },
+                {
+                    "branches": [
+                        {
+                            "count": 1,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "count": 1,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
+                    "count": 1,
+                    "line_number": 269
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 272
                 },
                 {
                     "branches": [
@@ -1186,17 +1178,17 @@
                         }
                     ],
                     "count": 1,
-                    "line_number": 267
+                    "line_number": 274
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 270
+                    "line_number": 277
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 272
+                    "line_number": 279
                 },
                 {
                     "branches": [
@@ -1217,27 +1209,27 @@
                         "count_true": 5,
                         "type": "conditional"
                     },
-                    "line_number": 273
-                },
-                {
-                    "branches": [],
-                    "count": 5,
-                    "line_number": 275
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 277
-                },
-                {
-                    "branches": [],
-                    "count": 1,
                     "line_number": 280
                 },
                 {
                     "branches": [],
-                    "count": 1,
+                    "count": 5,
                     "line_number": 282
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 284
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 287
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 289
                 },
                 {
                     "branches": [
@@ -1266,32 +1258,32 @@
                     "gcovr/decision": {
                         "type": "uncheckable"
                     },
-                    "line_number": 283
-                },
-                {
-                    "branches": [],
-                    "count": 5,
-                    "line_number": 285
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 287
-                },
-                {
-                    "branches": [],
-                    "count": 1,
                     "line_number": 290
                 },
                 {
                     "branches": [],
-                    "count": 1,
+                    "count": 5,
                     "line_number": 292
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 293
+                    "line_number": 294
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 297
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 299
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 300
                 },
                 {
                     "branches": [
@@ -1312,47 +1304,47 @@
                         "count_true": 5,
                         "type": "conditional"
                     },
-                    "line_number": 295
+                    "line_number": 302
                 },
                 {
                     "branches": [],
                     "count": 5,
-                    "line_number": 297
-                },
-                {
-                    "branches": [],
-                    "count": 5,
-                    "line_number": 298
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 301
-                },
-                {
-                    "branches": [],
-                    "count": 1,
                     "line_number": 304
                 },
                 {
                     "branches": [],
-                    "count": 1,
-                    "line_number": 306
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 307
-                },
-                {
-                    "branches": [],
                     "count": 5,
+                    "line_number": 305
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 308
+                },
+                {
+                    "branches": [],
+                    "count": 1,
                     "line_number": 311
                 },
                 {
                     "branches": [],
+                    "count": 1,
+                    "line_number": 313
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 314
+                },
+                {
+                    "branches": [],
                     "count": 5,
-                    "line_number": 312
+                    "line_number": 318
+                },
+                {
+                    "branches": [],
+                    "count": 5,
+                    "line_number": 319
                 },
                 {
                     "branches": [
@@ -1373,32 +1365,12 @@
                         "count_true": 4,
                         "type": "conditional"
                     },
-                    "line_number": 313
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 315
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 318
-                },
-                {
-                    "branches": [],
-                    "count": 1,
                     "line_number": 320
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 321
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 323
+                    "line_number": 322
                 },
                 {
                     "branches": [],
@@ -1408,22 +1380,42 @@
                 {
                     "branches": [],
                     "count": 1,
+                    "line_number": 327
+                },
+                {
+                    "branches": [],
+                    "count": 1,
                     "line_number": 328
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 329
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 331
+                    "line_number": 330
                 },
                 {
                     "branches": [],
                     "count": 1,
                     "line_number": 332
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 335
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 336
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 338
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 339
                 },
                 {
                     "branches": [
@@ -1444,22 +1436,22 @@
                         "count_true": 1,
                         "type": "conditional"
                     },
-                    "line_number": 334
+                    "line_number": 341
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 336
+                    "line_number": 343
                 },
                 {
                     "branches": [],
                     "count": 0,
-                    "line_number": 339
+                    "line_number": 346
                 },
                 {
                     "branches": [],
                     "count": 2,
-                    "line_number": 342
+                    "line_number": 349
                 },
                 {
                     "branches": [
@@ -1480,7 +1472,7 @@
                         "count_true": 1,
                         "type": "conditional"
                     },
-                    "line_number": 343
+                    "line_number": 350
                 },
                 {
                     "branches": [
@@ -1501,36 +1493,11 @@
                         "count_true": 10,
                         "type": "conditional"
                     },
-                    "line_number": 344
-                },
-                {
-                    "branches": [],
-                    "count": 2,
-                    "line_number": 347
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 349
-                },
-                {
-                    "branches": [],
-                    "count": 1,
                     "line_number": 351
                 },
                 {
                     "branches": [],
-                    "count": 1,
-                    "line_number": 352
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 353
-                },
-                {
-                    "branches": [],
-                    "count": 1,
+                    "count": 2,
                     "line_number": 354
                 },
                 {
@@ -1541,7 +1508,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 357
+                    "line_number": 358
                 },
                 {
                     "branches": [],
@@ -1556,7 +1523,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 362
+                    "line_number": 361
                 },
                 {
                     "branches": [],
@@ -1566,7 +1533,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 365
+                    "line_number": 364
                 },
                 {
                     "branches": [],
@@ -1576,7 +1543,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 368
+                    "line_number": 367
                 },
                 {
                     "branches": [],
@@ -1601,7 +1568,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 374
+                    "line_number": 375
                 },
                 {
                     "branches": [],
@@ -1626,7 +1593,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 382
+                    "line_number": 381
                 },
                 {
                     "branches": [],
@@ -1636,7 +1603,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 385
+                    "line_number": 384
                 },
                 {
                     "branches": [],
@@ -1646,7 +1613,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 388
+                    "line_number": 387
                 },
                 {
                     "branches": [],
@@ -1661,7 +1628,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 391
+                    "line_number": 392
                 },
                 {
                     "branches": [],
@@ -1681,7 +1648,32 @@
                 {
                     "branches": [],
                     "count": 1,
+                    "line_number": 397
+                },
+                {
+                    "branches": [],
+                    "count": 1,
                     "line_number": 398
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 400
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 402
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 403
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 405
                 }
             ]
         }

--- a/gcovr/tests/decisions/reference/gcc-11/coverage.json
+++ b/gcovr/tests/decisions/reference/gcc-11/coverage.json
@@ -825,6 +825,10 @@
                 {
                     "branches": [],
                     "count": 0,
+                    "gcovr/decision": {
+                        "count": 0,
+                        "type": "switch"
+                    },
                     "line_number": 190
                 },
                 {
@@ -835,6 +839,10 @@
                 {
                     "branches": [],
                     "count": 0,
+                    "gcovr/decision": {
+                        "count": 0,
+                        "type": "switch"
+                    },
                     "line_number": 196
                 },
                 {

--- a/gcovr/tests/decisions/reference/gcc-11/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/decisions/reference/gcc-11/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -64,8 +64,8 @@
     <tr>
       <th scope="row">Decisions:</th>
       <td>33</td>
-      <td>65</td>
-      <td class="coverage-low">50.8%</td>
+      <td>63</td>
+      <td class="coverage-low">52.4%</td>
     </tr>
   </table>
 </div>
@@ -118,46 +118,46 @@
     </tr>
     <tr>
       <td>
-        <a href="#l235">checkCompactBranch1False(int)</a>
+        <a href="#l242">checkCompactBranch1False(int)</a>
       </td>
       <td>
-        <a href="#l235">235</a>
+        <a href="#l242">242</a>
       </td>
       <td>
-        <a href="#l235"> called 1 time</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <a href="#l230">checkCompactBranch1True(int)</a>
-      </td>
-      <td>
-        <a href="#l230">230</a>
-      </td>
-      <td>
-        <a href="#l230"> called 1 time</a>
+        <a href="#l242"> called 1 time</a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="#l245">checkCompactBranch2False(int)</a>
+        <a href="#l237">checkCompactBranch1True(int)</a>
       </td>
       <td>
-        <a href="#l245">245</a>
+        <a href="#l237">237</a>
       </td>
       <td>
-        <a href="#l245"> called 1 time</a>
+        <a href="#l237"> called 1 time</a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="#l240">checkCompactBranch2True(int)</a>
+        <a href="#l252">checkCompactBranch2False(int)</a>
       </td>
       <td>
-        <a href="#l240">240</a>
+        <a href="#l252">252</a>
       </td>
       <td>
-        <a href="#l240"> called 1 time</a>
+        <a href="#l252"> called 1 time</a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="#l247">checkCompactBranch2True(int)</a>
+      </td>
+      <td>
+        <a href="#l247">247</a>
+      </td>
+      <td>
+        <a href="#l247"> called 1 time</a>
       </td>
     </tr>
     <tr>
@@ -173,13 +173,13 @@
     </tr>
     <tr>
       <td>
-        <a href="#l280">checkComplexForLoop(int)</a>
+        <a href="#l287">checkComplexForLoop(int)</a>
       </td>
       <td>
-        <a href="#l280">280</a>
+        <a href="#l287">287</a>
       </td>
       <td>
-        <a href="#l280"> called 1 time</a>
+        <a href="#l287"> called 1 time</a>
       </td>
     </tr>
     <tr>
@@ -195,13 +195,13 @@
     </tr>
     <tr>
       <td>
-        <a href="#l304">checkDoWhileLoop(int)</a>
+        <a href="#l311">checkDoWhileLoop(int)</a>
       </td>
       <td>
-        <a href="#l304">304</a>
+        <a href="#l311">311</a>
       </td>
       <td>
-        <a href="#l304"> called 1 time</a>
+        <a href="#l311"> called 1 time</a>
       </td>
     </tr>
     <tr>
@@ -261,24 +261,24 @@
     </tr>
     <tr>
       <td>
-        <a href="#l270">checkForLoop(int)</a>
+        <a href="#l277">checkForLoop(int)</a>
       </td>
       <td>
-        <a href="#l270">270</a>
+        <a href="#l277">277</a>
       </td>
       <td>
-        <a href="#l270"> called 1 time</a>
+        <a href="#l277"> called 1 time</a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="#l318">checkInterpreter(int)</a>
+        <a href="#l325">checkInterpreter(int)</a>
       </td>
       <td>
-        <a href="#l318">318</a>
+        <a href="#l325">325</a>
       </td>
       <td>
-        <a href="#l318"> called 1 time</a>
+        <a href="#l325"> called 1 time</a>
       </td>
     </tr>
     <tr>
@@ -338,101 +338,101 @@
     </tr>
     <tr>
       <td>
-        <a href="#l198">checkSwitch2(int)</a>
+        <a href="#l205">checkSwitch2(int)</a>
       </td>
       <td>
-        <a href="#l198">198</a>
+        <a href="#l205">205</a>
       </td>
       <td>
-        <a href="#l198"> called 1 time</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <a href="#l214">checkSwitch3(int)</a>
-      </td>
-      <td>
-        <a href="#l214">214</a>
-      </td>
-      <td>
-        <a href="#l214"> called 1 time</a>
+        <a href="#l205"> called 1 time</a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="#l255">checkTernary1False(int)</a>
+        <a href="#l221">checkSwitch3(int)</a>
       </td>
       <td>
-        <a href="#l255">255</a>
+        <a href="#l221">221</a>
       </td>
       <td>
-        <a href="#l255"> called 1 time</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <a href="#l250">checkTernary1True(int)</a>
-      </td>
-      <td>
-        <a href="#l250">250</a>
-      </td>
-      <td>
-        <a href="#l250"> called 1 time</a>
+        <a href="#l221"> called 1 time</a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="#l265">checkTernary2False(int)</a>
+        <a href="#l262">checkTernary1False(int)</a>
       </td>
       <td>
-        <a href="#l265">265</a>
+        <a href="#l262">262</a>
       </td>
       <td>
-        <a href="#l265"> called 1 time</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <a href="#l260">checkTernary2True(int)</a>
-      </td>
-      <td>
-        <a href="#l260">260</a>
-      </td>
-      <td>
-        <a href="#l260"> called 1 time</a>
+        <a href="#l262"> called 1 time</a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="#l290">checkWhileLoop(int)</a>
+        <a href="#l257">checkTernary1True(int)</a>
       </td>
       <td>
-        <a href="#l290">290</a>
+        <a href="#l257">257</a>
       </td>
       <td>
-        <a href="#l290"> called 1 time</a>
+        <a href="#l257"> called 1 time</a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="#l349">main</a>
+        <a href="#l272">checkTernary2False(int)</a>
+      </td>
+      <td>
+        <a href="#l272">272</a>
+      </td>
+      <td>
+        <a href="#l272"> called 1 time</a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="#l267">checkTernary2True(int)</a>
+      </td>
+      <td>
+        <a href="#l267">267</a>
+      </td>
+      <td>
+        <a href="#l267"> called 1 time</a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="#l297">checkWhileLoop(int)</a>
+      </td>
+      <td>
+        <a href="#l297">297</a>
+      </td>
+      <td>
+        <a href="#l297"> called 1 time</a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="#l356">main</a>
+      </td>
+      <td>
+        <a href="#l356">356</a>
+      </td>
+      <td>
+        <a href="#l356"> called 1 time</a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="#l349">verify_issue_679(bool)</a>
       </td>
       <td>
         <a href="#l349">349</a>
       </td>
       <td>
-        <a href="#l349"> called 1 time</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <a href="#l342">verify_issue_679(bool)</a>
-      </td>
-      <td>
-        <a href="#l342">342</a>
-      </td>
-      <td>
-        <a href="#l342"> called 2 times</a>
+        <a href="#l349"> called 2 times</a>
       </td>
     </tr>
   </table>
@@ -2589,15 +2589,9 @@
       <td class="linebranch">
       </td>
       <td class="linedecision">
-        <details class="linedecisionDetails">
-          <summary class="linedecisionSummary">0/1</summary>
-          <div class="linedecisionContents">
-            <div class="notTakenDecision">&cross; Decision 'true' not taken.</div>
-          </div>
-        </details>
       </td>
-      <td class="linecount uncoveredLine">&cross;</td>
-      <td class="src uncoveredLine">   <span class="k">case</span> <span class="mi">10</span><span class="o">:</span></td>
+      <td class="linecount "></td>
+      <td class="src ">   <span class="cm">/* Comment */</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2607,7 +2601,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount uncoveredLine">&cross;</td>
-      <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">true</span><span class="p">;</span></td>
+      <td class="src uncoveredLine">   <span class="k">case</span> <span class="mi">10</span><span class="o">:</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2617,7 +2611,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
+      <td class="src ">      <span class="cm">/* Comment */</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2625,15 +2619,9 @@
       <td class="linebranch">
       </td>
       <td class="linedecision">
-        <details class="linedecisionDetails">
-          <summary class="linedecisionSummary">0/1</summary>
-          <div class="linedecisionContents">
-            <div class="notTakenDecision">&cross; Decision 'true' not taken.</div>
-          </div>
-        </details>
       </td>
       <td class="linecount uncoveredLine">&cross;</td>
-      <td class="src uncoveredLine">   <span class="k">default</span><span class="o">:</span></td>
+      <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">true</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2642,8 +2630,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount uncoveredLine">&cross;</td>
-      <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">false</span><span class="p">;</span></td>
+      <td class="linecount "></td>
+      <td class="src ">      <span class="cm">/* Comment */</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2663,7 +2651,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src ">   <span class="p">}</span></td>
+      <td class="src ">      <span class="cm">/* Comment */</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2672,8 +2660,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "><span class="p">}</span></td>
+      <td class="linecount uncoveredLine">&cross;</td>
+      <td class="src uncoveredLine">   <span class="k">default</span><span class="o">:</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2683,7 +2671,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="src ">      <span class="cm">/* Comment */</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2692,8 +2680,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkSwitch2</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+      <td class="linecount uncoveredLine">&cross;</td>
+      <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">false</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2703,11 +2691,81 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
+      <td class="src ">      <span class="cm">/* Comment */</span></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l200" href="#l200">200</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l201" href="#l201">201</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src ">      <span class="cm">/* Comment */</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l202" href="#l202">202</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src ">   <span class="p">}</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l203" href="#l203">203</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">}</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l204" href="#l204">204</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l205" href="#l205">205</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkSwitch2</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l206" href="#l206">206</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">{</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l207" href="#l207">207</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">1/3</summary>
@@ -2725,7 +2783,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l201" href="#l201">201</a></td>
+      <td class="lineno"><a id="l208" href="#l208">208</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2735,7 +2793,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l202" href="#l202">202</a></td>
+      <td class="lineno"><a id="l209" href="#l209">209</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2751,7 +2809,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l203" href="#l203">203</a></td>
+      <td class="lineno"><a id="l210" href="#l210">210</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2761,7 +2819,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l204" href="#l204">204</a></td>
+      <td class="lineno"><a id="l211" href="#l211">211</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2771,7 +2829,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l205" href="#l205">205</a></td>
+      <td class="lineno"><a id="l212" href="#l212">212</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2787,7 +2845,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l206" href="#l206">206</a></td>
+      <td class="lineno"><a id="l213" href="#l213">213</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2797,7 +2855,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l207" href="#l207">207</a></td>
+      <td class="lineno"><a id="l214" href="#l214">214</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2807,7 +2865,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l208" href="#l208">208</a></td>
+      <td class="lineno"><a id="l215" href="#l215">215</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2823,7 +2881,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l209" href="#l209">209</a></td>
+      <td class="lineno"><a id="l216" href="#l216">216</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2833,7 +2891,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l210" href="#l210">210</a></td>
+      <td class="lineno"><a id="l217" href="#l217">217</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2843,7 +2901,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l211" href="#l211">211</a></td>
+      <td class="lineno"><a id="l218" href="#l218">218</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2853,7 +2911,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l212" href="#l212">212</a></td>
+      <td class="lineno"><a id="l219" href="#l219">219</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2863,7 +2921,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l213" href="#l213">213</a></td>
+      <td class="lineno"><a id="l220" href="#l220">220</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2873,7 +2931,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l214" href="#l214">214</a></td>
+      <td class="lineno"><a id="l221" href="#l221">221</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2883,7 +2941,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l215" href="#l215">215</a></td>
+      <td class="lineno"><a id="l222" href="#l222">222</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2893,7 +2951,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l216" href="#l216">216</a></td>
+      <td class="lineno"><a id="l223" href="#l223">223</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">1/3</summary>
@@ -2911,7 +2969,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l217" href="#l217">217</a></td>
+      <td class="lineno"><a id="l224" href="#l224">224</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2921,7 +2979,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l218" href="#l218">218</a></td>
+      <td class="lineno"><a id="l225" href="#l225">225</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2937,7 +2995,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l219" href="#l219">219</a></td>
+      <td class="lineno"><a id="l226" href="#l226">226</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2947,7 +3005,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l220" href="#l220">220</a></td>
+      <td class="lineno"><a id="l227" href="#l227">227</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2957,7 +3015,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l221" href="#l221">221</a></td>
+      <td class="lineno"><a id="l228" href="#l228">228</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2973,7 +3031,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l222" href="#l222">222</a></td>
+      <td class="lineno"><a id="l229" href="#l229">229</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2983,7 +3041,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l223" href="#l223">223</a></td>
+      <td class="lineno"><a id="l230" href="#l230">230</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2993,7 +3051,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l224" href="#l224">224</a></td>
+      <td class="lineno"><a id="l231" href="#l231">231</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3009,7 +3067,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l225" href="#l225">225</a></td>
+      <td class="lineno"><a id="l232" href="#l232">232</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3019,7 +3077,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l226" href="#l226">226</a></td>
+      <td class="lineno"><a id="l233" href="#l233">233</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3029,7 +3087,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l227" href="#l227">227</a></td>
+      <td class="lineno"><a id="l234" href="#l234">234</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3039,7 +3097,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l228" href="#l228">228</a></td>
+      <td class="lineno"><a id="l235" href="#l235">235</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3049,7 +3107,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l229" href="#l229">229</a></td>
+      <td class="lineno"><a id="l236" href="#l236">236</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3059,7 +3117,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l230" href="#l230">230</a></td>
+      <td class="lineno"><a id="l237" href="#l237">237</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3069,7 +3127,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l231" href="#l231">231</a></td>
+      <td class="lineno"><a id="l238" href="#l238">238</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3079,7 +3137,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l232" href="#l232">232</a></td>
+      <td class="lineno"><a id="l239" href="#l239">239</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">1/2</summary>
@@ -3103,7 +3161,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l233" href="#l233">233</a></td>
+      <td class="lineno"><a id="l240" href="#l240">240</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3113,7 +3171,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l234" href="#l234">234</a></td>
+      <td class="lineno"><a id="l241" href="#l241">241</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3123,7 +3181,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l235" href="#l235">235</a></td>
+      <td class="lineno"><a id="l242" href="#l242">242</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3133,7 +3191,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l236" href="#l236">236</a></td>
+      <td class="lineno"><a id="l243" href="#l243">243</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3143,7 +3201,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l237" href="#l237">237</a></td>
+      <td class="lineno"><a id="l244" href="#l244">244</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">1/2</summary>
@@ -3167,98 +3225,13 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l238" href="#l238">238</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "><span class="p">}</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l239" href="#l239">239</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l240" href="#l240">240</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkCompactBranch2True</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l241" href="#l241">241</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l242" href="#l242">242</a></td>
-      <td class="linebranch">
-        <details class="linebranchDetails">
-        <summary class="linebranchSummary">2/4</summary>
-        <div class="linebranchContents">
-          <div class="takenBranch">&check; Branch 0 taken 1 times.</div>
-          <div class="notTakenBranch">&cross; Branch 1 not taken.</div>
-          <div class="takenBranch">&check; Branch 2 taken 1 times.</div>
-          <div class="notTakenBranch">&cross; Branch 3 not taken.</div>
-        </div>
-        </details>
-      </td>
-      <td class="linedecision">
-        <details class="linedecisionDetails">
-          <summary class="linedecisionSummary">0/1</summary>
-          <div class="linedecisionContents">
-            <div class="uncheckedDecision">? Decision couldn't be analyzed.</div>
-          </div>
-        </details>
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="k">if</span> <span class="p">(</span><span class="n">a</span> <span class="o">&gt;</span> <span class="mi">5</span> <span class="o">&amp;&amp;</span> <span class="n">a</span> <span class="o">&lt;</span> <span class="mi">10</span><span class="p">)</span> <span class="p">{</span> <span class="k">return</span> <span class="nb">true</span><span class="p">;</span> <span class="p">}</span> <span class="k">else</span> <span class="p">{</span> <span class="k">return</span> <span class="nb">false</span><span class="p">;</span> <span class="p">}</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l243" href="#l243">243</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "><span class="p">}</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l244" href="#l244">244</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
-    </tr>
-
-    <tr class="source-line">
       <td class="lineno"><a id="l245" href="#l245">245</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkCompactBranch2False</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">}</span></td>
     </tr>
 
     <tr class="source-line">
@@ -3268,11 +3241,96 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l247" href="#l247">247</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkCompactBranch2True</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l248" href="#l248">248</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">{</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l249" href="#l249">249</a></td>
+      <td class="linebranch">
+        <details class="linebranchDetails">
+        <summary class="linebranchSummary">2/4</summary>
+        <div class="linebranchContents">
+          <div class="takenBranch">&check; Branch 0 taken 1 times.</div>
+          <div class="notTakenBranch">&cross; Branch 1 not taken.</div>
+          <div class="takenBranch">&check; Branch 2 taken 1 times.</div>
+          <div class="notTakenBranch">&cross; Branch 3 not taken.</div>
+        </div>
+        </details>
+      </td>
+      <td class="linedecision">
+        <details class="linedecisionDetails">
+          <summary class="linedecisionSummary">0/1</summary>
+          <div class="linedecisionContents">
+            <div class="uncheckedDecision">? Decision couldn't be analyzed.</div>
+          </div>
+        </details>
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="k">if</span> <span class="p">(</span><span class="n">a</span> <span class="o">&gt;</span> <span class="mi">5</span> <span class="o">&amp;&amp;</span> <span class="n">a</span> <span class="o">&lt;</span> <span class="mi">10</span><span class="p">)</span> <span class="p">{</span> <span class="k">return</span> <span class="nb">true</span><span class="p">;</span> <span class="p">}</span> <span class="k">else</span> <span class="p">{</span> <span class="k">return</span> <span class="nb">false</span><span class="p">;</span> <span class="p">}</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l250" href="#l250">250</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">}</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l251" href="#l251">251</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l252" href="#l252">252</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkCompactBranch2False</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l253" href="#l253">253</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">{</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l254" href="#l254">254</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">1/4</summary>
@@ -3297,83 +3355,13 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l248" href="#l248">248</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "><span class="p">}</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l249" href="#l249">249</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l250" href="#l250">250</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkTernary1True</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l251" href="#l251">251</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l252" href="#l252">252</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="k">return</span> <span class="p">(</span><span class="n">a</span> <span class="o">==</span> <span class="mi">5</span><span class="p">)</span> <span class="o">?</span> <span class="nb">true</span> <span class="o">:</span> <span class="nb">false</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l253" href="#l253">253</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "><span class="p">}</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l254" href="#l254">254</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
-    </tr>
-
-    <tr class="source-line">
       <td class="lineno"><a id="l255" href="#l255">255</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkTernary1False</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">}</span></td>
     </tr>
 
     <tr class="source-line">
@@ -3383,7 +3371,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
@@ -3393,7 +3381,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="k">return</span> <span class="p">(</span><span class="n">a</span> <span class="o">==</span> <span class="mi">5</span><span class="p">)</span> <span class="o">?</span> <span class="nb">true</span> <span class="o">:</span> <span class="nb">false</span><span class="p">;</span></td>
+      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkTernary1True</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
     </tr>
 
     <tr class="source-line">
@@ -3403,7 +3391,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "><span class="p">}</span></td>
+      <td class="src "><span class="p">{</span></td>
     </tr>
 
     <tr class="source-line">
@@ -3412,8 +3400,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="k">return</span> <span class="p">(</span><span class="n">a</span> <span class="o">==</span> <span class="mi">5</span><span class="p">)</span> <span class="o">?</span> <span class="nb">true</span> <span class="o">:</span> <span class="nb">false</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -3422,8 +3410,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkTernary2True</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">}</span></td>
     </tr>
 
     <tr class="source-line">
@@ -3433,11 +3421,81 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l262" href="#l262">262</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkTernary1False</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l263" href="#l263">263</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">{</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l264" href="#l264">264</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="k">return</span> <span class="p">(</span><span class="n">a</span> <span class="o">==</span> <span class="mi">5</span><span class="p">)</span> <span class="o">?</span> <span class="nb">true</span> <span class="o">:</span> <span class="nb">false</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l265" href="#l265">265</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">}</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l266" href="#l266">266</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l267" href="#l267">267</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkTernary2True</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l268" href="#l268">268</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">{</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l269" href="#l269">269</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">2/4</summary>
@@ -3456,7 +3514,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l263" href="#l263">263</a></td>
+      <td class="lineno"><a id="l270" href="#l270">270</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3466,7 +3524,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l264" href="#l264">264</a></td>
+      <td class="lineno"><a id="l271" href="#l271">271</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3476,7 +3534,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l265" href="#l265">265</a></td>
+      <td class="lineno"><a id="l272" href="#l272">272</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3486,7 +3544,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l266" href="#l266">266</a></td>
+      <td class="lineno"><a id="l273" href="#l273">273</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3496,7 +3554,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l267" href="#l267">267</a></td>
+      <td class="lineno"><a id="l274" href="#l274">274</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">1/4</summary>
@@ -3515,7 +3573,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l268" href="#l268">268</a></td>
+      <td class="lineno"><a id="l275" href="#l275">275</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3525,7 +3583,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l269" href="#l269">269</a></td>
+      <td class="lineno"><a id="l276" href="#l276">276</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3535,7 +3593,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l270" href="#l270">270</a></td>
+      <td class="lineno"><a id="l277" href="#l277">277</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3545,7 +3603,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l271" href="#l271">271</a></td>
+      <td class="lineno"><a id="l278" href="#l278">278</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3555,7 +3613,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l272" href="#l272">272</a></td>
+      <td class="lineno"><a id="l279" href="#l279">279</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3565,7 +3623,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l273" href="#l273">273</a></td>
+      <td class="lineno"><a id="l280" href="#l280">280</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">2/2</summary>
@@ -3589,7 +3647,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l274" href="#l274">274</a></td>
+      <td class="lineno"><a id="l281" href="#l281">281</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3599,7 +3657,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l275" href="#l275">275</a></td>
+      <td class="lineno"><a id="l282" href="#l282">282</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3609,7 +3667,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l276" href="#l276">276</a></td>
+      <td class="lineno"><a id="l283" href="#l283">283</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3619,7 +3677,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l277" href="#l277">277</a></td>
+      <td class="lineno"><a id="l284" href="#l284">284</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3629,7 +3687,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l278" href="#l278">278</a></td>
+      <td class="lineno"><a id="l285" href="#l285">285</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3639,7 +3697,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l279" href="#l279">279</a></td>
+      <td class="lineno"><a id="l286" href="#l286">286</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3649,7 +3707,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l280" href="#l280">280</a></td>
+      <td class="lineno"><a id="l287" href="#l287">287</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3659,7 +3717,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l281" href="#l281">281</a></td>
+      <td class="lineno"><a id="l288" href="#l288">288</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3669,7 +3727,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l282" href="#l282">282</a></td>
+      <td class="lineno"><a id="l289" href="#l289">289</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3679,7 +3737,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l283" href="#l283">283</a></td>
+      <td class="lineno"><a id="l290" href="#l290">290</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">3/4</summary>
@@ -3704,7 +3762,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l284" href="#l284">284</a></td>
+      <td class="lineno"><a id="l291" href="#l291">291</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3714,7 +3772,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l285" href="#l285">285</a></td>
+      <td class="lineno"><a id="l292" href="#l292">292</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3724,7 +3782,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l286" href="#l286">286</a></td>
+      <td class="lineno"><a id="l293" href="#l293">293</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3734,7 +3792,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l287" href="#l287">287</a></td>
+      <td class="lineno"><a id="l294" href="#l294">294</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3744,7 +3802,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l288" href="#l288">288</a></td>
+      <td class="lineno"><a id="l295" href="#l295">295</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3754,7 +3812,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l289" href="#l289">289</a></td>
+      <td class="lineno"><a id="l296" href="#l296">296</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3764,7 +3822,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l290" href="#l290">290</a></td>
+      <td class="lineno"><a id="l297" href="#l297">297</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3774,7 +3832,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l291" href="#l291">291</a></td>
+      <td class="lineno"><a id="l298" href="#l298">298</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3784,7 +3842,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l292" href="#l292">292</a></td>
+      <td class="lineno"><a id="l299" href="#l299">299</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3794,7 +3852,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l293" href="#l293">293</a></td>
+      <td class="lineno"><a id="l300" href="#l300">300</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3804,7 +3862,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l294" href="#l294">294</a></td>
+      <td class="lineno"><a id="l301" href="#l301">301</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3814,7 +3872,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l295" href="#l295">295</a></td>
+      <td class="lineno"><a id="l302" href="#l302">302</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">2/2</summary>
@@ -3838,7 +3896,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l296" href="#l296">296</a></td>
+      <td class="lineno"><a id="l303" href="#l303">303</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3848,7 +3906,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l297" href="#l297">297</a></td>
+      <td class="lineno"><a id="l304" href="#l304">304</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3858,7 +3916,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l298" href="#l298">298</a></td>
+      <td class="lineno"><a id="l305" href="#l305">305</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3868,7 +3926,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l299" href="#l299">299</a></td>
+      <td class="lineno"><a id="l306" href="#l306">306</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3878,7 +3936,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l300" href="#l300">300</a></td>
+      <td class="lineno"><a id="l307" href="#l307">307</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3888,7 +3946,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l301" href="#l301">301</a></td>
+      <td class="lineno"><a id="l308" href="#l308">308</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3898,7 +3956,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l302" href="#l302">302</a></td>
+      <td class="lineno"><a id="l309" href="#l309">309</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3908,7 +3966,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l303" href="#l303">303</a></td>
+      <td class="lineno"><a id="l310" href="#l310">310</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3918,7 +3976,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l304" href="#l304">304</a></td>
+      <td class="lineno"><a id="l311" href="#l311">311</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3928,7 +3986,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l305" href="#l305">305</a></td>
+      <td class="lineno"><a id="l312" href="#l312">312</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3938,7 +3996,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l306" href="#l306">306</a></td>
+      <td class="lineno"><a id="l313" href="#l313">313</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3948,7 +4006,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l307" href="#l307">307</a></td>
+      <td class="lineno"><a id="l314" href="#l314">314</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3958,7 +4016,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l308" href="#l308">308</a></td>
+      <td class="lineno"><a id="l315" href="#l315">315</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3968,7 +4026,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l309" href="#l309">309</a></td>
+      <td class="lineno"><a id="l316" href="#l316">316</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3978,7 +4036,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l310" href="#l310">310</a></td>
+      <td class="lineno"><a id="l317" href="#l317">317</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3988,7 +4046,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l311" href="#l311">311</a></td>
+      <td class="lineno"><a id="l318" href="#l318">318</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3998,7 +4056,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l312" href="#l312">312</a></td>
+      <td class="lineno"><a id="l319" href="#l319">319</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4008,7 +4066,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l313" href="#l313">313</a></td>
+      <td class="lineno"><a id="l320" href="#l320">320</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">2/2</summary>
@@ -4032,7 +4090,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l314" href="#l314">314</a></td>
+      <td class="lineno"><a id="l321" href="#l321">321</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4042,7 +4100,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l315" href="#l315">315</a></td>
+      <td class="lineno"><a id="l322" href="#l322">322</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4052,7 +4110,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l316" href="#l316">316</a></td>
+      <td class="lineno"><a id="l323" href="#l323">323</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4062,83 +4120,13 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l317" href="#l317">317</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l318" href="#l318">318</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkInterpreter</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l319" href="#l319">319</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l320" href="#l320">320</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test1</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; while &quot;</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l321" href="#l321">321</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">a</span><span class="o">++</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l322" href="#l322">322</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l323" href="#l323">323</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test2</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; for &quot;</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
       <td class="lineno"><a id="l324" href="#l324">324</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src ">   <span class="p">{</span></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
@@ -4148,7 +4136,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">      <span class="n">a</span><span class="o">++</span><span class="p">;</span></td>
+      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkInterpreter</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4158,7 +4146,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src ">   <span class="p">}</span></td>
+      <td class="src "><span class="p">{</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4167,8 +4155,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test1</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; while &quot;</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4178,21 +4166,11 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test3</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; if(&quot;</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l329" href="#l329">329</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
       <td class="src coveredLine">   <span class="n">a</span><span class="o">++</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l330" href="#l330">330</a></td>
+      <td class="lineno"><a id="l329" href="#l329">329</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4202,13 +4180,23 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l331" href="#l331">331</a></td>
+      <td class="lineno"><a id="l330" href="#l330">330</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test4</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; do &quot;</span><span class="p">;</span></td>
+      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test2</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; for &quot;</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l331" href="#l331">331</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src ">   <span class="p">{</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4218,7 +4206,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">a</span><span class="o">++</span><span class="p">;</span></td>
+      <td class="src coveredLine">      <span class="n">a</span><span class="o">++</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4228,11 +4216,81 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="src ">   <span class="p">}</span></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l334" href="#l334">334</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l335" href="#l335">335</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test3</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; if(&quot;</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l336" href="#l336">336</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">a</span><span class="o">++</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l337" href="#l337">337</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l338" href="#l338">338</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test4</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; do &quot;</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l339" href="#l339">339</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">a</span><span class="o">++</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l340" href="#l340">340</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l341" href="#l341">341</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">1/2</summary>
@@ -4256,7 +4314,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l335" href="#l335">335</a></td>
+      <td class="lineno"><a id="l342" href="#l342">342</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4266,7 +4324,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l336" href="#l336">336</a></td>
+      <td class="lineno"><a id="l343" href="#l343">343</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4276,7 +4334,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l337" href="#l337">337</a></td>
+      <td class="lineno"><a id="l344" href="#l344">344</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4286,7 +4344,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l338" href="#l338">338</a></td>
+      <td class="lineno"><a id="l345" href="#l345">345</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4296,7 +4354,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l339" href="#l339">339</a></td>
+      <td class="lineno"><a id="l346" href="#l346">346</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4306,7 +4364,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l340" href="#l340">340</a></td>
+      <td class="lineno"><a id="l347" href="#l347">347</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4316,7 +4374,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l341" href="#l341">341</a></td>
+      <td class="lineno"><a id="l348" href="#l348">348</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4326,7 +4384,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l342" href="#l342">342</a></td>
+      <td class="lineno"><a id="l349" href="#l349">349</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4336,7 +4394,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l343" href="#l343">343</a></td>
+      <td class="lineno"><a id="l350" href="#l350">350</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">2/2</summary>
@@ -4360,7 +4418,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l344" href="#l344">344</a></td>
+      <td class="lineno"><a id="l351" href="#l351">351</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">2/2</summary>
@@ -4384,7 +4442,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l345" href="#l345">345</a></td>
+      <td class="lineno"><a id="l352" href="#l352">352</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4394,7 +4452,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l346" href="#l346">346</a></td>
+      <td class="lineno"><a id="l353" href="#l353">353</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4404,83 +4462,13 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l347" href="#l347">347</a></td>
+      <td class="lineno"><a id="l354" href="#l354">354</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">2</td>
       <td class="src coveredLine"><span class="p">}</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l348" href="#l348">348</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l349" href="#l349">349</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">int</span> <span class="nf">main</span><span class="p">(</span><span class="kt">int</span> <span class="n">argc</span><span class="p">,</span> <span class="kt">char</span> <span class="o">*</span><span class="n">argv</span><span class="p">[])</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l350" href="#l350">350</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l351" href="#l351">351</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkBiggerTrue</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l352" href="#l352">352</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkBiggerFalse</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l353" href="#l353">353</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkBiggerBoth</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l354" href="#l354">354</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkBiggerBoth</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4500,7 +4488,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkSmallerTrue</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
+      <td class="src coveredLine"><span class="kt">int</span> <span class="nf">main</span><span class="p">(</span><span class="kt">int</span> <span class="n">argc</span><span class="p">,</span> <span class="kt">char</span> <span class="o">*</span><span class="n">argv</span><span class="p">[])</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4509,8 +4497,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkSmallerFalse</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">{</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4519,8 +4507,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkBiggerTrue</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4530,7 +4518,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkEqualTrue</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkBiggerFalse</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4540,7 +4528,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkEqualFalse</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkBiggerBoth</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4549,8 +4537,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkBiggerBoth</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4559,8 +4547,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkNotEqualTrue</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
+      <td class="linecount "></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
@@ -4570,7 +4558,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkNotEqualFalse</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkSmallerTrue</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4579,8 +4567,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkSmallerFalse</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4589,8 +4577,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkComplexTrue</span><span class="p">(</span><span class="mi">8</span><span class="p">);</span></td>
+      <td class="linecount "></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
@@ -4600,11 +4588,21 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkComplexFalse</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkEqualTrue</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l367" href="#l367">367</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkEqualFalse</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l368" href="#l368">368</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4614,23 +4612,13 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l368" href="#l368">368</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkElseIf1</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
-    </tr>
-
-    <tr class="source-line">
       <td class="lineno"><a id="l369" href="#l369">369</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkElseIf2</span><span class="p">(</span><span class="mi">10</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkNotEqualTrue</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4640,7 +4628,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkElseIf3</span><span class="p">(</span><span class="mi">0</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkNotEqualFalse</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4660,7 +4648,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkSwitch1</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkComplexTrue</span><span class="p">(</span><span class="mi">8</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4670,21 +4658,11 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkSwitch2</span><span class="p">(</span><span class="mi">10</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkComplexFalse</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l374" href="#l374">374</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkSwitch3</span><span class="p">(</span><span class="mi">0</span><span class="p">);</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l375" href="#l375">375</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4694,13 +4672,23 @@
     </tr>
 
     <tr class="source-line">
+      <td class="lineno"><a id="l375" href="#l375">375</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkElseIf1</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
+    </tr>
+
+    <tr class="source-line">
       <td class="lineno"><a id="l376" href="#l376">376</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkCompactBranch1True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkElseIf2</span><span class="p">(</span><span class="mi">10</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4710,7 +4698,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkCompactBranch1False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkElseIf3</span><span class="p">(</span><span class="mi">0</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4730,7 +4718,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkCompactBranch2True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkSwitch1</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4740,7 +4728,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkCompactBranch2False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkSwitch2</span><span class="p">(</span><span class="mi">10</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4749,8 +4737,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkSwitch3</span><span class="p">(</span><span class="mi">0</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4759,8 +4747,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkTernary1True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
+      <td class="linecount "></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
@@ -4770,7 +4758,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkTernary1False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkCompactBranch1True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4779,8 +4767,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkCompactBranch1False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4789,8 +4777,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkTernary2True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
+      <td class="linecount "></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
@@ -4800,7 +4788,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkTernary2False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkCompactBranch2True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4809,8 +4797,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkCompactBranch2False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4819,8 +4807,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkForLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
+      <td class="linecount "></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
@@ -4830,7 +4818,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkComplexForLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkTernary1True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4840,21 +4828,11 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkWhileLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkTernary1False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l391" href="#l391">391</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkDoWhileLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l392" href="#l392">392</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4864,13 +4842,23 @@
     </tr>
 
     <tr class="source-line">
+      <td class="lineno"><a id="l392" href="#l392">392</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkTernary2True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
+    </tr>
+
+    <tr class="source-line">
       <td class="lineno"><a id="l393" href="#l393">393</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkInterpreter</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkTernary2False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4890,7 +4878,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">verify_issue_679</span><span class="p">(</span><span class="nb">false</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkForLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4900,7 +4888,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">verify_issue_679</span><span class="p">(</span><span class="nb">true</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkComplexForLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4909,8 +4897,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkWhileLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4920,7 +4908,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="k">return</span> <span class="mi">0</span><span class="p">;</span></td>
+      <td class="src coveredLine">   <span class="n">checkDoWhileLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4930,11 +4918,81 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "><span class="p">}</span></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l400" href="#l400">400</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkInterpreter</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l401" href="#l401">401</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l402" href="#l402">402</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">verify_issue_679</span><span class="p">(</span><span class="nb">false</span><span class="p">);</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l403" href="#l403">403</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">verify_issue_679</span><span class="p">(</span><span class="nb">true</span><span class="p">);</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l404" href="#l404">404</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l405" href="#l405">405</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="k">return</span> <span class="mi">0</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l406" href="#l406">406</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">}</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l407" href="#l407">407</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">

--- a/gcovr/tests/decisions/reference/gcc-11/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/decisions/reference/gcc-11/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -64,8 +64,8 @@
     <tr>
       <th scope="row">Decisions:</th>
       <td>33</td>
-      <td>63</td>
-      <td class="coverage-low">52.4%</td>
+      <td>65</td>
+      <td class="coverage-low">50.8%</td>
     </tr>
   </table>
 </div>
@@ -2599,6 +2599,12 @@
       <td class="linebranch">
       </td>
       <td class="linedecision">
+        <details class="linedecisionDetails">
+          <summary class="linedecisionSummary">0/1</summary>
+          <div class="linedecisionContents">
+            <div class="notTakenDecision">&cross; Decision 'true' not taken.</div>
+          </div>
+        </details>
       </td>
       <td class="linecount uncoveredLine">&cross;</td>
       <td class="src uncoveredLine">   <span class="k">case</span> <span class="mi">10</span><span class="o">:</span></td>
@@ -2659,6 +2665,12 @@
       <td class="linebranch">
       </td>
       <td class="linedecision">
+        <details class="linedecisionDetails">
+          <summary class="linedecisionSummary">0/1</summary>
+          <div class="linedecisionContents">
+            <div class="notTakenDecision">&cross; Decision 'true' not taken.</div>
+          </div>
+        </details>
       </td>
       <td class="linecount uncoveredLine">&cross;</td>
       <td class="src uncoveredLine">   <span class="k">default</span><span class="o">:</span></td>

--- a/gcovr/tests/decisions/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/decisions/reference/gcc-5/coverage.functions.html
@@ -56,9 +56,9 @@
     </tr>
     <tr>
       <th scope="row">Decisions:</th>
-      <td>31</td>
-      <td>57</td>
-      <td class="coverage-low">54.4%</td>
+      <td>33</td>
+      <td>65</td>
+      <td class="coverage-low">50.8%</td>
     </tr>
   </table>
 </div>

--- a/gcovr/tests/decisions/reference/gcc-5/coverage.functions.html
+++ b/gcovr/tests/decisions/reference/gcc-5/coverage.functions.html
@@ -122,58 +122,58 @@
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l235">checkCompactBranch1False(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l242">checkCompactBranch1False(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l235">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l242">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l235">235</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l242">242</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l235"> called 1 time</a>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l230">checkCompactBranch1True(int)</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l230">main.cpp</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l230">230</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l230"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l242"> called 1 time</a>
     </td>
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l245">checkCompactBranch2False(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l237">checkCompactBranch1True(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l245">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l237">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l245">245</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l237">237</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l245"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l237"> called 1 time</a>
     </td>
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l240">checkCompactBranch2True(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l252">checkCompactBranch2False(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l240">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l252">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l240">240</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l252">252</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l240"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l252"> called 1 time</a>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l247">checkCompactBranch2True(int)</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l247">main.cpp</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l247">247</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l247"> called 1 time</a>
     </td>
   </tr>
   <tr>
@@ -192,16 +192,16 @@
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l280">checkComplexForLoop(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l287">checkComplexForLoop(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l280">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l287">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l280">280</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l287">287</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l280"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l287"> called 1 time</a>
     </td>
   </tr>
   <tr>
@@ -220,16 +220,16 @@
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l304">checkDoWhileLoop(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l311">checkDoWhileLoop(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l304">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l311">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l304">304</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l311">311</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l304"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l311"> called 1 time</a>
     </td>
   </tr>
   <tr>
@@ -304,30 +304,30 @@
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l270">checkForLoop(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l277">checkForLoop(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l270">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l277">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l270">270</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l277">277</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l270"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l277"> called 1 time</a>
     </td>
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l318">checkInterpreter(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l325">checkInterpreter(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l318">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l325">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l318">318</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l325">325</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l318"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l325"> called 1 time</a>
     </td>
   </tr>
   <tr>
@@ -402,105 +402,119 @@
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l198">checkSwitch2(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l205">checkSwitch2(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l198">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l205">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l198">198</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l205">205</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l198"> called 1 time</a>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l214">checkSwitch3(int)</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l214">main.cpp</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l214">214</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l214"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l205"> called 1 time</a>
     </td>
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l255">checkTernary1False(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l221">checkSwitch3(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l255">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l221">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l255">255</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l221">221</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l255"> called 1 time</a>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l250">checkTernary1True(int)</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l250">main.cpp</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l250">250</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l250"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l221"> called 1 time</a>
     </td>
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l265">checkTernary2False(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l262">checkTernary1False(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l265">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l262">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l265">265</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l262">262</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l265"> called 1 time</a>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l260">checkTernary2True(int)</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l260">main.cpp</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l260">260</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l260"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l262"> called 1 time</a>
     </td>
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l290">checkWhileLoop(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l257">checkTernary1True(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l290">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l257">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l290">290</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l257">257</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l290"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l257"> called 1 time</a>
     </td>
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l349">main</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l272">checkTernary2False(int)</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l272">main.cpp</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l272">272</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l272"> called 1 time</a>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l267">checkTernary2True(int)</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l267">main.cpp</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l267">267</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l267"> called 1 time</a>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l297">checkWhileLoop(int)</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l297">main.cpp</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l297">297</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l297"> called 1 time</a>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l356">main</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l356">main.cpp</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l356">356</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l356"> called 1 time</a>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l349">verify_issue_679(bool)</a>
     </td>
     <td>
       <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l349">main.cpp</a>
@@ -509,21 +523,7 @@
       <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l349">349</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l349"> called 1 time</a>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l342">verify_issue_679(bool)</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l342">main.cpp</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l342">342</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l342"> called 2 times</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l349"> called 2 times</a>
     </td>
   </tr>
 </table>

--- a/gcovr/tests/decisions/reference/gcc-5/coverage.html
+++ b/gcovr/tests/decisions/reference/gcc-5/coverage.html
@@ -64,9 +64,9 @@
     </tr>
     <tr>
       <th scope="row">Decisions:</th>
-      <td>31</td>
-      <td>57</td>
-      <td class="coverage-low">54.4%</td>
+      <td>33</td>
+      <td>65</td>
+      <td class="coverage-low">50.8%</td>
     </tr>
   </table>
 </div>
@@ -109,8 +109,8 @@
     <td class="CoverValue function-coverage coverage-high">32 / 32</td>
     <td class="CoverValue branch-coverage coverage-low">51.7%</td>
     <td class="CoverValue branch-coverage coverage-low">45 / 87</td>
-    <td class="CoverValue decision-coverage coverage-low">54.4%</td>
-    <td class="CoverValue decision-coverage coverage-low">31 / 57</td>
+    <td class="CoverValue decision-coverage coverage-low">50.8%</td>
+    <td class="CoverValue decision-coverage coverage-low">33 / 65</td>
   </tr>
 
 </table>

--- a/gcovr/tests/decisions/reference/gcc-5/coverage.json
+++ b/gcovr/tests/decisions/reference/gcc-5/coverage.json
@@ -20,22 +20,22 @@
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 235,
+                    "lineno": 242,
                     "name": "checkCompactBranch1False(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 230,
+                    "lineno": 237,
                     "name": "checkCompactBranch1True(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 245,
+                    "lineno": 252,
                     "name": "checkCompactBranch2False(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 240,
+                    "lineno": 247,
                     "name": "checkCompactBranch2True(int)"
                 },
                 {
@@ -45,7 +45,7 @@
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 280,
+                    "lineno": 287,
                     "name": "checkComplexForLoop(int)"
                 },
                 {
@@ -55,7 +55,7 @@
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 304,
+                    "lineno": 311,
                     "name": "checkDoWhileLoop(int)"
                 },
                 {
@@ -85,12 +85,12 @@
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 270,
+                    "lineno": 277,
                     "name": "checkForLoop(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 318,
+                    "lineno": 325,
                     "name": "checkInterpreter(int)"
                 },
                 {
@@ -120,47 +120,47 @@
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 198,
+                    "lineno": 205,
                     "name": "checkSwitch2(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 214,
+                    "lineno": 221,
                     "name": "checkSwitch3(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 255,
+                    "lineno": 262,
                     "name": "checkTernary1False(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 250,
+                    "lineno": 257,
                     "name": "checkTernary1True(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 265,
+                    "lineno": 272,
                     "name": "checkTernary2False(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 260,
+                    "lineno": 267,
                     "name": "checkTernary2True(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 290,
+                    "lineno": 297,
                     "name": "checkWhileLoop(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 349,
+                    "lineno": 356,
                     "name": "main"
                 },
                 {
                     "execution_count": 2,
-                    "lineno": 342,
+                    "lineno": 349,
                     "name": "verify_issue_679(bool)"
                 }
             ],
@@ -825,19 +825,19 @@
                 {
                     "branches": [],
                     "count": 0,
-                    "line_number": 190
+                    "line_number": 192
                 },
                 {
                     "branches": [],
                     "count": 0,
-                    "line_number": 193
-                },
-                {
-                    "branches": [],
-                    "count": 1,
                     "line_number": 198
                 },
                 {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 205
+                },
+                {
                     "branches": [
                         {
                             "count": 0,
@@ -856,68 +856,68 @@
                         }
                     ],
                     "count": 1,
-                    "line_number": 200
+                    "line_number": 207
                 },
                 {
                     "branches": [],
                     "count": 0,
-                    "line_number": 203
+                    "line_number": 210
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 206
+                    "line_number": 213
                 },
                 {
                     "branches": [],
                     "count": 0,
-                    "line_number": 209
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 214
-                },
-                {
-                    "branches": [
-                        {
-                            "count": 0,
-                            "fallthrough": false,
-                            "throw": false
-                        },
-                        {
-                            "count": 0,
-                            "fallthrough": false,
-                            "throw": false
-                        },
-                        {
-                            "count": 1,
-                            "fallthrough": false,
-                            "throw": false
-                        }
-                    ],
-                    "count": 1,
                     "line_number": 216
                 },
                 {
                     "branches": [],
-                    "count": 0,
-                    "line_number": 219
+                    "count": 1,
+                    "line_number": 221
+                },
+                {
+                    "branches": [
+                        {
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "count": 1,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
+                    "count": 1,
+                    "line_number": 223
                 },
                 {
                     "branches": [],
                     "count": 0,
-                    "line_number": 222
+                    "line_number": 226
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "line_number": 229
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 225
+                    "line_number": 232
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 230
+                    "line_number": 237
                 },
                 {
                     "branches": [
@@ -938,12 +938,12 @@
                         "count_true": 1,
                         "type": "conditional"
                     },
-                    "line_number": 232
+                    "line_number": 239
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 235
+                    "line_number": 242
                 },
                 {
                     "branches": [
@@ -964,80 +964,41 @@
                         "count_true": 0,
                         "type": "conditional"
                     },
-                    "line_number": 237
+                    "line_number": 244
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 240
-                },
-                {
-                    "branches": [
-                        {
-                            "count": 1,
-                            "fallthrough": true,
-                            "throw": false
-                        },
-                        {
-                            "count": 0,
-                            "fallthrough": false,
-                            "throw": false
-                        },
-                        {
-                            "count": 1,
-                            "fallthrough": true,
-                            "throw": false
-                        },
-                        {
-                            "count": 0,
-                            "fallthrough": false,
-                            "throw": false
-                        }
-                    ],
-                    "count": 1,
-                    "gcovr/decision": {
-                        "type": "uncheckable"
-                    },
-                    "line_number": 242
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 245
-                },
-                {
-                    "branches": [
-                        {
-                            "count": 0,
-                            "fallthrough": true,
-                            "throw": false
-                        },
-                        {
-                            "count": 1,
-                            "fallthrough": false,
-                            "throw": false
-                        },
-                        {
-                            "count": 0,
-                            "fallthrough": false,
-                            "throw": false
-                        },
-                        {
-                            "count": 0,
-                            "fallthrough": false,
-                            "throw": false
-                        }
-                    ],
-                    "count": 1,
-                    "gcovr/decision": {
-                        "type": "uncheckable"
-                    },
                     "line_number": 247
                 },
                 {
-                    "branches": [],
+                    "branches": [
+                        {
+                            "count": 1,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "count": 1,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
                     "count": 1,
-                    "line_number": 250
+                    "gcovr/decision": {
+                        "type": "uncheckable"
+                    },
+                    "line_number": 249
                 },
                 {
                     "branches": [],
@@ -1045,9 +1006,33 @@
                     "line_number": 252
                 },
                 {
-                    "branches": [],
+                    "branches": [
+                        {
+                            "count": 0,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "count": 1,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
                     "count": 1,
-                    "line_number": 255
+                    "gcovr/decision": {
+                        "type": "uncheckable"
+                    },
+                    "line_number": 254
                 },
                 {
                     "branches": [],
@@ -1057,38 +1042,53 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 260
+                    "line_number": 259
                 },
                 {
-                    "branches": [
-                        {
-                            "count": 1,
-                            "fallthrough": true,
-                            "throw": false
-                        },
-                        {
-                            "count": 0,
-                            "fallthrough": false,
-                            "throw": false
-                        },
-                        {
-                            "count": 1,
-                            "fallthrough": true,
-                            "throw": false
-                        },
-                        {
-                            "count": 0,
-                            "fallthrough": false,
-                            "throw": false
-                        }
-                    ],
+                    "branches": [],
                     "count": 1,
                     "line_number": 262
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 265
+                    "line_number": 264
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 267
+                },
+                {
+                    "branches": [
+                        {
+                            "count": 1,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "count": 1,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
+                    "count": 1,
+                    "line_number": 269
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 272
                 },
                 {
                     "branches": [
@@ -1114,17 +1114,17 @@
                         }
                     ],
                     "count": 1,
-                    "line_number": 267
+                    "line_number": 274
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 270
+                    "line_number": 277
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 272
+                    "line_number": 279
                 },
                 {
                     "branches": [
@@ -1145,27 +1145,27 @@
                         "count_true": 5,
                         "type": "conditional"
                     },
-                    "line_number": 273
-                },
-                {
-                    "branches": [],
-                    "count": 5,
-                    "line_number": 275
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 277
-                },
-                {
-                    "branches": [],
-                    "count": 1,
                     "line_number": 280
                 },
                 {
                     "branches": [],
-                    "count": 1,
+                    "count": 5,
                     "line_number": 282
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 284
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 287
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 289
                 },
                 {
                     "branches": [
@@ -1194,32 +1194,32 @@
                     "gcovr/decision": {
                         "type": "uncheckable"
                     },
-                    "line_number": 283
-                },
-                {
-                    "branches": [],
-                    "count": 5,
-                    "line_number": 285
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 287
-                },
-                {
-                    "branches": [],
-                    "count": 1,
                     "line_number": 290
                 },
                 {
                     "branches": [],
-                    "count": 1,
+                    "count": 5,
                     "line_number": 292
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 293
+                    "line_number": 294
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 297
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 299
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 300
                 },
                 {
                     "branches": [
@@ -1240,52 +1240,52 @@
                         "count_true": 5,
                         "type": "conditional"
                     },
-                    "line_number": 295
+                    "line_number": 302
                 },
                 {
                     "branches": [],
                     "count": 5,
-                    "line_number": 297
-                },
-                {
-                    "branches": [],
-                    "count": 5,
-                    "line_number": 298
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 301
-                },
-                {
-                    "branches": [],
-                    "count": 1,
                     "line_number": 304
                 },
                 {
                     "branches": [],
-                    "count": 1,
-                    "line_number": 306
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 307
-                },
-                {
-                    "branches": [],
-                    "count": 4,
-                    "line_number": 309
-                },
-                {
-                    "branches": [],
                     "count": 5,
+                    "line_number": 305
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 308
+                },
+                {
+                    "branches": [],
+                    "count": 1,
                     "line_number": 311
                 },
                 {
                     "branches": [],
+                    "count": 1,
+                    "line_number": 313
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 314
+                },
+                {
+                    "branches": [],
+                    "count": 4,
+                    "line_number": 316
+                },
+                {
+                    "branches": [],
                     "count": 5,
-                    "line_number": 312
+                    "line_number": 318
+                },
+                {
+                    "branches": [],
+                    "count": 5,
+                    "line_number": 319
                 },
                 {
                     "branches": [
@@ -1306,32 +1306,12 @@
                         "count_true": 4,
                         "type": "conditional"
                     },
-                    "line_number": 313
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 315
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 318
-                },
-                {
-                    "branches": [],
-                    "count": 1,
                     "line_number": 320
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 321
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 323
+                    "line_number": 322
                 },
                 {
                     "branches": [],
@@ -1341,22 +1321,42 @@
                 {
                     "branches": [],
                     "count": 1,
+                    "line_number": 327
+                },
+                {
+                    "branches": [],
+                    "count": 1,
                     "line_number": 328
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 329
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 331
+                    "line_number": 330
                 },
                 {
                     "branches": [],
                     "count": 1,
                     "line_number": 332
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 335
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 336
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 338
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 339
                 },
                 {
                     "branches": [
@@ -1377,22 +1377,22 @@
                         "count_true": 1,
                         "type": "conditional"
                     },
-                    "line_number": 334
+                    "line_number": 341
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 336
+                    "line_number": 343
                 },
                 {
                     "branches": [],
                     "count": 0,
-                    "line_number": 339
+                    "line_number": 346
                 },
                 {
                     "branches": [],
                     "count": 2,
-                    "line_number": 342
+                    "line_number": 349
                 },
                 {
                     "branches": [
@@ -1413,7 +1413,7 @@
                         "count_true": 1,
                         "type": "conditional"
                     },
-                    "line_number": 343
+                    "line_number": 350
                 },
                 {
                     "branches": [
@@ -1434,36 +1434,11 @@
                         "count_true": 10,
                         "type": "conditional"
                     },
-                    "line_number": 344
-                },
-                {
-                    "branches": [],
-                    "count": 2,
-                    "line_number": 347
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 349
-                },
-                {
-                    "branches": [],
-                    "count": 1,
                     "line_number": 351
                 },
                 {
                     "branches": [],
-                    "count": 1,
-                    "line_number": 352
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 353
-                },
-                {
-                    "branches": [],
-                    "count": 1,
+                    "count": 2,
                     "line_number": 354
                 },
                 {
@@ -1474,7 +1449,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 357
+                    "line_number": 358
                 },
                 {
                     "branches": [],
@@ -1489,7 +1464,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 362
+                    "line_number": 361
                 },
                 {
                     "branches": [],
@@ -1499,7 +1474,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 365
+                    "line_number": 364
                 },
                 {
                     "branches": [],
@@ -1509,7 +1484,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 368
+                    "line_number": 367
                 },
                 {
                     "branches": [],
@@ -1534,7 +1509,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 374
+                    "line_number": 375
                 },
                 {
                     "branches": [],
@@ -1559,7 +1534,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 382
+                    "line_number": 381
                 },
                 {
                     "branches": [],
@@ -1569,7 +1544,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 385
+                    "line_number": 384
                 },
                 {
                     "branches": [],
@@ -1579,7 +1554,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 388
+                    "line_number": 387
                 },
                 {
                     "branches": [],
@@ -1594,7 +1569,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 391
+                    "line_number": 392
                 },
                 {
                     "branches": [],
@@ -1614,7 +1589,32 @@
                 {
                     "branches": [],
                     "count": 1,
+                    "line_number": 397
+                },
+                {
+                    "branches": [],
+                    "count": 1,
                     "line_number": 398
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 400
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 402
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 403
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 405
                 }
             ]
         }

--- a/gcovr/tests/decisions/reference/gcc-5/coverage.json
+++ b/gcovr/tests/decisions/reference/gcc-5/coverage.json
@@ -825,11 +825,19 @@
                 {
                     "branches": [],
                     "count": 0,
+                    "gcovr/decision": {
+                        "count": 0,
+                        "type": "switch"
+                    },
                     "line_number": 192
                 },
                 {
                     "branches": [],
                     "count": 0,
+                    "gcovr/decision": {
+                        "count": 0,
+                        "type": "switch"
+                    },
                     "line_number": 198
                 },
                 {
@@ -861,16 +869,28 @@
                 {
                     "branches": [],
                     "count": 0,
+                    "gcovr/decision": {
+                        "count": 0,
+                        "type": "switch"
+                    },
                     "line_number": 210
                 },
                 {
                     "branches": [],
                     "count": 1,
+                    "gcovr/decision": {
+                        "count": 1,
+                        "type": "switch"
+                    },
                     "line_number": 213
                 },
                 {
                     "branches": [],
                     "count": 0,
+                    "gcovr/decision": {
+                        "count": 0,
+                        "type": "switch"
+                    },
                     "line_number": 216
                 },
                 {
@@ -902,16 +922,28 @@
                 {
                     "branches": [],
                     "count": 0,
+                    "gcovr/decision": {
+                        "count": 0,
+                        "type": "switch"
+                    },
                     "line_number": 226
                 },
                 {
                     "branches": [],
                     "count": 0,
+                    "gcovr/decision": {
+                        "count": 0,
+                        "type": "switch"
+                    },
                     "line_number": 229
                 },
                 {
                     "branches": [],
                     "count": 1,
+                    "gcovr/decision": {
+                        "count": 1,
+                        "type": "switch"
+                    },
                     "line_number": 232
                 },
                 {

--- a/gcovr/tests/decisions/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/decisions/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -63,9 +63,9 @@
     </tr>
     <tr>
       <th scope="row">Decisions:</th>
-      <td>31</td>
-      <td>57</td>
-      <td class="coverage-low">54.4%</td>
+      <td>33</td>
+      <td>65</td>
+      <td class="coverage-low">50.8%</td>
     </tr>
   </table>
 </div>
@@ -2619,6 +2619,12 @@
       <td class="linebranch">
       </td>
       <td class="linedecision">
+        <details class="linedecisionDetails">
+          <summary class="linedecisionSummary">0/1</summary>
+          <div class="linedecisionContents">
+            <div class="notTakenDecision">&cross; Decision 'true' not taken.</div>
+          </div>
+        </details>
       </td>
       <td class="linecount uncoveredLine">&cross;</td>
       <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">true</span><span class="p">;</span></td>
@@ -2679,6 +2685,12 @@
       <td class="linebranch">
       </td>
       <td class="linedecision">
+        <details class="linedecisionDetails">
+          <summary class="linedecisionSummary">0/1</summary>
+          <div class="linedecisionContents">
+            <div class="notTakenDecision">&cross; Decision 'true' not taken.</div>
+          </div>
+        </details>
       </td>
       <td class="linecount uncoveredLine">&cross;</td>
       <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">false</span><span class="p">;</span></td>
@@ -2807,6 +2819,12 @@
       <td class="linebranch">
       </td>
       <td class="linedecision">
+        <details class="linedecisionDetails">
+          <summary class="linedecisionSummary">0/1</summary>
+          <div class="linedecisionContents">
+            <div class="notTakenDecision">&cross; Decision 'true' not taken.</div>
+          </div>
+        </details>
       </td>
       <td class="linecount uncoveredLine">&cross;</td>
       <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">true</span><span class="p">;</span></td>
@@ -2837,6 +2855,12 @@
       <td class="linebranch">
       </td>
       <td class="linedecision">
+        <details class="linedecisionDetails">
+          <summary class="linedecisionSummary">1/1</summary>
+          <div class="linedecisionContents">
+            <div class="takenDecision">&check; Decision 'true' taken 1 times.</div>
+          </div>
+        </details>
       </td>
       <td class="linecount coveredLine">1</td>
       <td class="src coveredLine">      <span class="k">return</span> <span class="nb">true</span><span class="p">;</span></td>
@@ -2867,6 +2891,12 @@
       <td class="linebranch">
       </td>
       <td class="linedecision">
+        <details class="linedecisionDetails">
+          <summary class="linedecisionSummary">0/1</summary>
+          <div class="linedecisionContents">
+            <div class="notTakenDecision">&cross; Decision 'true' not taken.</div>
+          </div>
+        </details>
       </td>
       <td class="linecount uncoveredLine">&cross;</td>
       <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">false</span><span class="p">;</span></td>
@@ -2975,6 +3005,12 @@
       <td class="linebranch">
       </td>
       <td class="linedecision">
+        <details class="linedecisionDetails">
+          <summary class="linedecisionSummary">0/1</summary>
+          <div class="linedecisionContents">
+            <div class="notTakenDecision">&cross; Decision 'true' not taken.</div>
+          </div>
+        </details>
       </td>
       <td class="linecount uncoveredLine">&cross;</td>
       <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">true</span><span class="p">;</span></td>
@@ -3005,6 +3041,12 @@
       <td class="linebranch">
       </td>
       <td class="linedecision">
+        <details class="linedecisionDetails">
+          <summary class="linedecisionSummary">0/1</summary>
+          <div class="linedecisionContents">
+            <div class="notTakenDecision">&cross; Decision 'true' not taken.</div>
+          </div>
+        </details>
       </td>
       <td class="linecount uncoveredLine">&cross;</td>
       <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">true</span><span class="p">;</span></td>
@@ -3035,6 +3077,12 @@
       <td class="linebranch">
       </td>
       <td class="linedecision">
+        <details class="linedecisionDetails">
+          <summary class="linedecisionSummary">1/1</summary>
+          <div class="linedecisionContents">
+            <div class="takenDecision">&check; Decision 'true' taken 1 times.</div>
+          </div>
+        </details>
       </td>
       <td class="linecount coveredLine">1</td>
       <td class="src coveredLine">      <span class="k">return</span> <span class="nb">false</span><span class="p">;</span></td>

--- a/gcovr/tests/decisions/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/decisions/reference/gcc-5/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -118,46 +118,46 @@
     </tr>
     <tr>
       <td>
-        <a href="#l235">checkCompactBranch1False(int)</a>
+        <a href="#l242">checkCompactBranch1False(int)</a>
       </td>
       <td>
-        <a href="#l235">235</a>
+        <a href="#l242">242</a>
       </td>
       <td>
-        <a href="#l235"> called 1 time</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <a href="#l230">checkCompactBranch1True(int)</a>
-      </td>
-      <td>
-        <a href="#l230">230</a>
-      </td>
-      <td>
-        <a href="#l230"> called 1 time</a>
+        <a href="#l242"> called 1 time</a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="#l245">checkCompactBranch2False(int)</a>
+        <a href="#l237">checkCompactBranch1True(int)</a>
       </td>
       <td>
-        <a href="#l245">245</a>
+        <a href="#l237">237</a>
       </td>
       <td>
-        <a href="#l245"> called 1 time</a>
+        <a href="#l237"> called 1 time</a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="#l240">checkCompactBranch2True(int)</a>
+        <a href="#l252">checkCompactBranch2False(int)</a>
       </td>
       <td>
-        <a href="#l240">240</a>
+        <a href="#l252">252</a>
       </td>
       <td>
-        <a href="#l240"> called 1 time</a>
+        <a href="#l252"> called 1 time</a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="#l247">checkCompactBranch2True(int)</a>
+      </td>
+      <td>
+        <a href="#l247">247</a>
+      </td>
+      <td>
+        <a href="#l247"> called 1 time</a>
       </td>
     </tr>
     <tr>
@@ -173,13 +173,13 @@
     </tr>
     <tr>
       <td>
-        <a href="#l280">checkComplexForLoop(int)</a>
+        <a href="#l287">checkComplexForLoop(int)</a>
       </td>
       <td>
-        <a href="#l280">280</a>
+        <a href="#l287">287</a>
       </td>
       <td>
-        <a href="#l280"> called 1 time</a>
+        <a href="#l287"> called 1 time</a>
       </td>
     </tr>
     <tr>
@@ -195,13 +195,13 @@
     </tr>
     <tr>
       <td>
-        <a href="#l304">checkDoWhileLoop(int)</a>
+        <a href="#l311">checkDoWhileLoop(int)</a>
       </td>
       <td>
-        <a href="#l304">304</a>
+        <a href="#l311">311</a>
       </td>
       <td>
-        <a href="#l304"> called 1 time</a>
+        <a href="#l311"> called 1 time</a>
       </td>
     </tr>
     <tr>
@@ -261,24 +261,24 @@
     </tr>
     <tr>
       <td>
-        <a href="#l270">checkForLoop(int)</a>
+        <a href="#l277">checkForLoop(int)</a>
       </td>
       <td>
-        <a href="#l270">270</a>
+        <a href="#l277">277</a>
       </td>
       <td>
-        <a href="#l270"> called 1 time</a>
+        <a href="#l277"> called 1 time</a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="#l318">checkInterpreter(int)</a>
+        <a href="#l325">checkInterpreter(int)</a>
       </td>
       <td>
-        <a href="#l318">318</a>
+        <a href="#l325">325</a>
       </td>
       <td>
-        <a href="#l318"> called 1 time</a>
+        <a href="#l325"> called 1 time</a>
       </td>
     </tr>
     <tr>
@@ -338,101 +338,101 @@
     </tr>
     <tr>
       <td>
-        <a href="#l198">checkSwitch2(int)</a>
+        <a href="#l205">checkSwitch2(int)</a>
       </td>
       <td>
-        <a href="#l198">198</a>
+        <a href="#l205">205</a>
       </td>
       <td>
-        <a href="#l198"> called 1 time</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <a href="#l214">checkSwitch3(int)</a>
-      </td>
-      <td>
-        <a href="#l214">214</a>
-      </td>
-      <td>
-        <a href="#l214"> called 1 time</a>
+        <a href="#l205"> called 1 time</a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="#l255">checkTernary1False(int)</a>
+        <a href="#l221">checkSwitch3(int)</a>
       </td>
       <td>
-        <a href="#l255">255</a>
+        <a href="#l221">221</a>
       </td>
       <td>
-        <a href="#l255"> called 1 time</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <a href="#l250">checkTernary1True(int)</a>
-      </td>
-      <td>
-        <a href="#l250">250</a>
-      </td>
-      <td>
-        <a href="#l250"> called 1 time</a>
+        <a href="#l221"> called 1 time</a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="#l265">checkTernary2False(int)</a>
+        <a href="#l262">checkTernary1False(int)</a>
       </td>
       <td>
-        <a href="#l265">265</a>
+        <a href="#l262">262</a>
       </td>
       <td>
-        <a href="#l265"> called 1 time</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <a href="#l260">checkTernary2True(int)</a>
-      </td>
-      <td>
-        <a href="#l260">260</a>
-      </td>
-      <td>
-        <a href="#l260"> called 1 time</a>
+        <a href="#l262"> called 1 time</a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="#l290">checkWhileLoop(int)</a>
+        <a href="#l257">checkTernary1True(int)</a>
       </td>
       <td>
-        <a href="#l290">290</a>
+        <a href="#l257">257</a>
       </td>
       <td>
-        <a href="#l290"> called 1 time</a>
+        <a href="#l257"> called 1 time</a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="#l349">main</a>
+        <a href="#l272">checkTernary2False(int)</a>
+      </td>
+      <td>
+        <a href="#l272">272</a>
+      </td>
+      <td>
+        <a href="#l272"> called 1 time</a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="#l267">checkTernary2True(int)</a>
+      </td>
+      <td>
+        <a href="#l267">267</a>
+      </td>
+      <td>
+        <a href="#l267"> called 1 time</a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="#l297">checkWhileLoop(int)</a>
+      </td>
+      <td>
+        <a href="#l297">297</a>
+      </td>
+      <td>
+        <a href="#l297"> called 1 time</a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="#l356">main</a>
+      </td>
+      <td>
+        <a href="#l356">356</a>
+      </td>
+      <td>
+        <a href="#l356"> called 1 time</a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="#l349">verify_issue_679(bool)</a>
       </td>
       <td>
         <a href="#l349">349</a>
       </td>
       <td>
-        <a href="#l349"> called 1 time</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <a href="#l342">verify_issue_679(bool)</a>
-      </td>
-      <td>
-        <a href="#l342">342</a>
-      </td>
-      <td>
-        <a href="#l342"> called 2 times</a>
+        <a href="#l349"> called 2 times</a>
       </td>
     </tr>
   </table>
@@ -2591,7 +2591,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src ">   <span class="k">case</span> <span class="mi">10</span><span class="o">:</span></td>
+      <td class="src ">   <span class="cm">/* Comment */</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2600,8 +2600,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount uncoveredLine">&cross;</td>
-      <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">true</span><span class="p">;</span></td>
+      <td class="linecount "></td>
+      <td class="src ">   <span class="k">case</span> <span class="mi">10</span><span class="o">:</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2611,7 +2611,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
+      <td class="src ">      <span class="cm">/* Comment */</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2620,8 +2620,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src ">   <span class="k">default</span><span class="o">:</span></td>
+      <td class="linecount uncoveredLine">&cross;</td>
+      <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">true</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2630,8 +2630,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount uncoveredLine">&cross;</td>
-      <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">false</span><span class="p">;</span></td>
+      <td class="linecount "></td>
+      <td class="src ">      <span class="cm">/* Comment */</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2651,7 +2651,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src ">   <span class="p">}</span></td>
+      <td class="src ">      <span class="cm">/* Comment */</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2661,7 +2661,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "><span class="p">}</span></td>
+      <td class="src ">   <span class="k">default</span><span class="o">:</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2671,7 +2671,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="src ">      <span class="cm">/* Comment */</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2680,8 +2680,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkSwitch2</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+      <td class="linecount uncoveredLine">&cross;</td>
+      <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">false</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2691,11 +2691,81 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
+      <td class="src ">      <span class="cm">/* Comment */</span></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l200" href="#l200">200</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l201" href="#l201">201</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src ">      <span class="cm">/* Comment */</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l202" href="#l202">202</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src ">   <span class="p">}</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l203" href="#l203">203</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">}</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l204" href="#l204">204</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l205" href="#l205">205</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkSwitch2</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l206" href="#l206">206</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">{</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l207" href="#l207">207</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">1/3</summary>
@@ -2713,7 +2783,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l201" href="#l201">201</a></td>
+      <td class="lineno"><a id="l208" href="#l208">208</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2723,7 +2793,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l202" href="#l202">202</a></td>
+      <td class="lineno"><a id="l209" href="#l209">209</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2733,7 +2803,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l203" href="#l203">203</a></td>
+      <td class="lineno"><a id="l210" href="#l210">210</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2743,83 +2813,13 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l204" href="#l204">204</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l205" href="#l205">205</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src ">   <span class="k">case</span> <span class="mi">10</span><span class="o">:</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l206" href="#l206">206</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">      <span class="k">return</span> <span class="nb">true</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l207" href="#l207">207</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l208" href="#l208">208</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src ">   <span class="k">default</span><span class="o">:</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l209" href="#l209">209</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount uncoveredLine">&cross;</td>
-      <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">false</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l210" href="#l210">210</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
       <td class="lineno"><a id="l211" href="#l211">211</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src ">   <span class="p">}</span></td>
+      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2829,7 +2829,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "><span class="p">}</span></td>
+      <td class="src ">   <span class="k">case</span> <span class="mi">10</span><span class="o">:</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2838,8 +2838,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">      <span class="k">return</span> <span class="nb">true</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2848,8 +2848,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkSwitch3</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+      <td class="linecount "></td>
+      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2859,11 +2859,81 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
+      <td class="src ">   <span class="k">default</span><span class="o">:</span></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l216" href="#l216">216</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount uncoveredLine">&cross;</td>
+      <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">false</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l217" href="#l217">217</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l218" href="#l218">218</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src ">   <span class="p">}</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l219" href="#l219">219</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">}</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l220" href="#l220">220</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l221" href="#l221">221</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkSwitch3</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l222" href="#l222">222</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">{</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l223" href="#l223">223</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">1/3</summary>
@@ -2881,7 +2951,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l217" href="#l217">217</a></td>
+      <td class="lineno"><a id="l224" href="#l224">224</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2891,7 +2961,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l218" href="#l218">218</a></td>
+      <td class="lineno"><a id="l225" href="#l225">225</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2901,83 +2971,13 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l219" href="#l219">219</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount uncoveredLine">&cross;</td>
-      <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">true</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l220" href="#l220">220</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l221" href="#l221">221</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src ">   <span class="k">case</span> <span class="mi">10</span><span class="o">:</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l222" href="#l222">222</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount uncoveredLine">&cross;</td>
-      <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">true</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l223" href="#l223">223</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l224" href="#l224">224</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src ">   <span class="k">default</span><span class="o">:</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l225" href="#l225">225</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">      <span class="k">return</span> <span class="nb">false</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
       <td class="lineno"><a id="l226" href="#l226">226</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
+      <td class="linecount uncoveredLine">&cross;</td>
+      <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">true</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2987,7 +2987,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src ">   <span class="p">}</span></td>
+      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2997,7 +2997,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "><span class="p">}</span></td>
+      <td class="src ">   <span class="k">case</span> <span class="mi">10</span><span class="o">:</span></td>
     </tr>
 
     <tr class="source-line">
@@ -3006,8 +3006,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount uncoveredLine">&cross;</td>
+      <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">true</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -3016,8 +3016,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkCompactBranch1True</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+      <td class="linecount "></td>
+      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -3027,11 +3027,81 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
+      <td class="src ">   <span class="k">default</span><span class="o">:</span></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l232" href="#l232">232</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">      <span class="k">return</span> <span class="nb">false</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l233" href="#l233">233</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l234" href="#l234">234</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src ">   <span class="p">}</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l235" href="#l235">235</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">}</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l236" href="#l236">236</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l237" href="#l237">237</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkCompactBranch1True</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l238" href="#l238">238</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">{</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l239" href="#l239">239</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">1/2</summary>
@@ -3055,7 +3125,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l233" href="#l233">233</a></td>
+      <td class="lineno"><a id="l240" href="#l240">240</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3065,7 +3135,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l234" href="#l234">234</a></td>
+      <td class="lineno"><a id="l241" href="#l241">241</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3075,7 +3145,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l235" href="#l235">235</a></td>
+      <td class="lineno"><a id="l242" href="#l242">242</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3085,7 +3155,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l236" href="#l236">236</a></td>
+      <td class="lineno"><a id="l243" href="#l243">243</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3095,7 +3165,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l237" href="#l237">237</a></td>
+      <td class="lineno"><a id="l244" href="#l244">244</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">1/2</summary>
@@ -3119,98 +3189,13 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l238" href="#l238">238</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "><span class="p">}</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l239" href="#l239">239</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l240" href="#l240">240</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkCompactBranch2True</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l241" href="#l241">241</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l242" href="#l242">242</a></td>
-      <td class="linebranch">
-        <details class="linebranchDetails">
-        <summary class="linebranchSummary">2/4</summary>
-        <div class="linebranchContents">
-          <div class="takenBranch">&check; Branch 0 taken 1 times.</div>
-          <div class="notTakenBranch">&cross; Branch 1 not taken.</div>
-          <div class="takenBranch">&check; Branch 2 taken 1 times.</div>
-          <div class="notTakenBranch">&cross; Branch 3 not taken.</div>
-        </div>
-        </details>
-      </td>
-      <td class="linedecision">
-        <details class="linedecisionDetails">
-          <summary class="linedecisionSummary">0/1</summary>
-          <div class="linedecisionContents">
-            <div class="uncheckedDecision">? Decision couldn't be analyzed.</div>
-          </div>
-        </details>
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="k">if</span> <span class="p">(</span><span class="n">a</span> <span class="o">&gt;</span> <span class="mi">5</span> <span class="o">&amp;&amp;</span> <span class="n">a</span> <span class="o">&lt;</span> <span class="mi">10</span><span class="p">)</span> <span class="p">{</span> <span class="k">return</span> <span class="nb">true</span><span class="p">;</span> <span class="p">}</span> <span class="k">else</span> <span class="p">{</span> <span class="k">return</span> <span class="nb">false</span><span class="p">;</span> <span class="p">}</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l243" href="#l243">243</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "><span class="p">}</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l244" href="#l244">244</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
-    </tr>
-
-    <tr class="source-line">
       <td class="lineno"><a id="l245" href="#l245">245</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkCompactBranch2False</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">}</span></td>
     </tr>
 
     <tr class="source-line">
@@ -3220,11 +3205,96 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l247" href="#l247">247</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkCompactBranch2True</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l248" href="#l248">248</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">{</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l249" href="#l249">249</a></td>
+      <td class="linebranch">
+        <details class="linebranchDetails">
+        <summary class="linebranchSummary">2/4</summary>
+        <div class="linebranchContents">
+          <div class="takenBranch">&check; Branch 0 taken 1 times.</div>
+          <div class="notTakenBranch">&cross; Branch 1 not taken.</div>
+          <div class="takenBranch">&check; Branch 2 taken 1 times.</div>
+          <div class="notTakenBranch">&cross; Branch 3 not taken.</div>
+        </div>
+        </details>
+      </td>
+      <td class="linedecision">
+        <details class="linedecisionDetails">
+          <summary class="linedecisionSummary">0/1</summary>
+          <div class="linedecisionContents">
+            <div class="uncheckedDecision">? Decision couldn't be analyzed.</div>
+          </div>
+        </details>
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="k">if</span> <span class="p">(</span><span class="n">a</span> <span class="o">&gt;</span> <span class="mi">5</span> <span class="o">&amp;&amp;</span> <span class="n">a</span> <span class="o">&lt;</span> <span class="mi">10</span><span class="p">)</span> <span class="p">{</span> <span class="k">return</span> <span class="nb">true</span><span class="p">;</span> <span class="p">}</span> <span class="k">else</span> <span class="p">{</span> <span class="k">return</span> <span class="nb">false</span><span class="p">;</span> <span class="p">}</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l250" href="#l250">250</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">}</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l251" href="#l251">251</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l252" href="#l252">252</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkCompactBranch2False</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l253" href="#l253">253</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">{</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l254" href="#l254">254</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">1/4</summary>
@@ -3249,83 +3319,13 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l248" href="#l248">248</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "><span class="p">}</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l249" href="#l249">249</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l250" href="#l250">250</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkTernary1True</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l251" href="#l251">251</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l252" href="#l252">252</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="k">return</span> <span class="p">(</span><span class="n">a</span> <span class="o">==</span> <span class="mi">5</span><span class="p">)</span> <span class="o">?</span> <span class="nb">true</span> <span class="o">:</span> <span class="nb">false</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l253" href="#l253">253</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "><span class="p">}</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l254" href="#l254">254</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
-    </tr>
-
-    <tr class="source-line">
       <td class="lineno"><a id="l255" href="#l255">255</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkTernary1False</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">}</span></td>
     </tr>
 
     <tr class="source-line">
@@ -3335,7 +3335,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
@@ -3345,7 +3345,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="k">return</span> <span class="p">(</span><span class="n">a</span> <span class="o">==</span> <span class="mi">5</span><span class="p">)</span> <span class="o">?</span> <span class="nb">true</span> <span class="o">:</span> <span class="nb">false</span><span class="p">;</span></td>
+      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkTernary1True</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
     </tr>
 
     <tr class="source-line">
@@ -3355,7 +3355,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "><span class="p">}</span></td>
+      <td class="src "><span class="p">{</span></td>
     </tr>
 
     <tr class="source-line">
@@ -3364,8 +3364,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="k">return</span> <span class="p">(</span><span class="n">a</span> <span class="o">==</span> <span class="mi">5</span><span class="p">)</span> <span class="o">?</span> <span class="nb">true</span> <span class="o">:</span> <span class="nb">false</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -3374,8 +3374,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkTernary2True</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">}</span></td>
     </tr>
 
     <tr class="source-line">
@@ -3385,11 +3385,81 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l262" href="#l262">262</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkTernary1False</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l263" href="#l263">263</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">{</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l264" href="#l264">264</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="k">return</span> <span class="p">(</span><span class="n">a</span> <span class="o">==</span> <span class="mi">5</span><span class="p">)</span> <span class="o">?</span> <span class="nb">true</span> <span class="o">:</span> <span class="nb">false</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l265" href="#l265">265</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">}</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l266" href="#l266">266</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l267" href="#l267">267</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkTernary2True</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l268" href="#l268">268</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">{</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l269" href="#l269">269</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">2/4</summary>
@@ -3408,7 +3478,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l263" href="#l263">263</a></td>
+      <td class="lineno"><a id="l270" href="#l270">270</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3418,7 +3488,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l264" href="#l264">264</a></td>
+      <td class="lineno"><a id="l271" href="#l271">271</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3428,7 +3498,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l265" href="#l265">265</a></td>
+      <td class="lineno"><a id="l272" href="#l272">272</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3438,7 +3508,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l266" href="#l266">266</a></td>
+      <td class="lineno"><a id="l273" href="#l273">273</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3448,7 +3518,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l267" href="#l267">267</a></td>
+      <td class="lineno"><a id="l274" href="#l274">274</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">1/4</summary>
@@ -3467,7 +3537,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l268" href="#l268">268</a></td>
+      <td class="lineno"><a id="l275" href="#l275">275</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3477,7 +3547,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l269" href="#l269">269</a></td>
+      <td class="lineno"><a id="l276" href="#l276">276</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3487,7 +3557,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l270" href="#l270">270</a></td>
+      <td class="lineno"><a id="l277" href="#l277">277</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3497,7 +3567,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l271" href="#l271">271</a></td>
+      <td class="lineno"><a id="l278" href="#l278">278</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3507,7 +3577,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l272" href="#l272">272</a></td>
+      <td class="lineno"><a id="l279" href="#l279">279</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3517,7 +3587,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l273" href="#l273">273</a></td>
+      <td class="lineno"><a id="l280" href="#l280">280</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">2/2</summary>
@@ -3541,7 +3611,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l274" href="#l274">274</a></td>
+      <td class="lineno"><a id="l281" href="#l281">281</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3551,7 +3621,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l275" href="#l275">275</a></td>
+      <td class="lineno"><a id="l282" href="#l282">282</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3561,7 +3631,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l276" href="#l276">276</a></td>
+      <td class="lineno"><a id="l283" href="#l283">283</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3571,7 +3641,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l277" href="#l277">277</a></td>
+      <td class="lineno"><a id="l284" href="#l284">284</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3581,7 +3651,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l278" href="#l278">278</a></td>
+      <td class="lineno"><a id="l285" href="#l285">285</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3591,7 +3661,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l279" href="#l279">279</a></td>
+      <td class="lineno"><a id="l286" href="#l286">286</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3601,7 +3671,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l280" href="#l280">280</a></td>
+      <td class="lineno"><a id="l287" href="#l287">287</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3611,7 +3681,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l281" href="#l281">281</a></td>
+      <td class="lineno"><a id="l288" href="#l288">288</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3621,7 +3691,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l282" href="#l282">282</a></td>
+      <td class="lineno"><a id="l289" href="#l289">289</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3631,7 +3701,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l283" href="#l283">283</a></td>
+      <td class="lineno"><a id="l290" href="#l290">290</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">3/4</summary>
@@ -3656,7 +3726,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l284" href="#l284">284</a></td>
+      <td class="lineno"><a id="l291" href="#l291">291</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3666,7 +3736,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l285" href="#l285">285</a></td>
+      <td class="lineno"><a id="l292" href="#l292">292</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3676,7 +3746,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l286" href="#l286">286</a></td>
+      <td class="lineno"><a id="l293" href="#l293">293</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3686,7 +3756,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l287" href="#l287">287</a></td>
+      <td class="lineno"><a id="l294" href="#l294">294</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3696,7 +3766,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l288" href="#l288">288</a></td>
+      <td class="lineno"><a id="l295" href="#l295">295</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3706,7 +3776,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l289" href="#l289">289</a></td>
+      <td class="lineno"><a id="l296" href="#l296">296</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3716,7 +3786,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l290" href="#l290">290</a></td>
+      <td class="lineno"><a id="l297" href="#l297">297</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3726,7 +3796,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l291" href="#l291">291</a></td>
+      <td class="lineno"><a id="l298" href="#l298">298</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3736,7 +3806,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l292" href="#l292">292</a></td>
+      <td class="lineno"><a id="l299" href="#l299">299</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3746,7 +3816,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l293" href="#l293">293</a></td>
+      <td class="lineno"><a id="l300" href="#l300">300</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3756,7 +3826,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l294" href="#l294">294</a></td>
+      <td class="lineno"><a id="l301" href="#l301">301</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3766,7 +3836,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l295" href="#l295">295</a></td>
+      <td class="lineno"><a id="l302" href="#l302">302</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">2/2</summary>
@@ -3790,7 +3860,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l296" href="#l296">296</a></td>
+      <td class="lineno"><a id="l303" href="#l303">303</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3800,7 +3870,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l297" href="#l297">297</a></td>
+      <td class="lineno"><a id="l304" href="#l304">304</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3810,7 +3880,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l298" href="#l298">298</a></td>
+      <td class="lineno"><a id="l305" href="#l305">305</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3820,7 +3890,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l299" href="#l299">299</a></td>
+      <td class="lineno"><a id="l306" href="#l306">306</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3830,7 +3900,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l300" href="#l300">300</a></td>
+      <td class="lineno"><a id="l307" href="#l307">307</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3840,7 +3910,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l301" href="#l301">301</a></td>
+      <td class="lineno"><a id="l308" href="#l308">308</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3850,7 +3920,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l302" href="#l302">302</a></td>
+      <td class="lineno"><a id="l309" href="#l309">309</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3860,7 +3930,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l303" href="#l303">303</a></td>
+      <td class="lineno"><a id="l310" href="#l310">310</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3870,7 +3940,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l304" href="#l304">304</a></td>
+      <td class="lineno"><a id="l311" href="#l311">311</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3880,7 +3950,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l305" href="#l305">305</a></td>
+      <td class="lineno"><a id="l312" href="#l312">312</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3890,7 +3960,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l306" href="#l306">306</a></td>
+      <td class="lineno"><a id="l313" href="#l313">313</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3900,7 +3970,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l307" href="#l307">307</a></td>
+      <td class="lineno"><a id="l314" href="#l314">314</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3910,7 +3980,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l308" href="#l308">308</a></td>
+      <td class="lineno"><a id="l315" href="#l315">315</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3920,7 +3990,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l309" href="#l309">309</a></td>
+      <td class="lineno"><a id="l316" href="#l316">316</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3930,7 +4000,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l310" href="#l310">310</a></td>
+      <td class="lineno"><a id="l317" href="#l317">317</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3940,7 +4010,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l311" href="#l311">311</a></td>
+      <td class="lineno"><a id="l318" href="#l318">318</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3950,7 +4020,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l312" href="#l312">312</a></td>
+      <td class="lineno"><a id="l319" href="#l319">319</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3960,7 +4030,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l313" href="#l313">313</a></td>
+      <td class="lineno"><a id="l320" href="#l320">320</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">2/2</summary>
@@ -3984,7 +4054,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l314" href="#l314">314</a></td>
+      <td class="lineno"><a id="l321" href="#l321">321</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3994,7 +4064,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l315" href="#l315">315</a></td>
+      <td class="lineno"><a id="l322" href="#l322">322</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4004,7 +4074,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l316" href="#l316">316</a></td>
+      <td class="lineno"><a id="l323" href="#l323">323</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4014,83 +4084,13 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l317" href="#l317">317</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l318" href="#l318">318</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkInterpreter</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l319" href="#l319">319</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l320" href="#l320">320</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test1</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; while &quot;</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l321" href="#l321">321</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">a</span><span class="o">++</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l322" href="#l322">322</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l323" href="#l323">323</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test2</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; for &quot;</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
       <td class="lineno"><a id="l324" href="#l324">324</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src ">   <span class="p">{</span></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
@@ -4100,7 +4100,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">      <span class="n">a</span><span class="o">++</span><span class="p">;</span></td>
+      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkInterpreter</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4110,7 +4110,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src ">   <span class="p">}</span></td>
+      <td class="src "><span class="p">{</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4119,8 +4119,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test1</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; while &quot;</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4130,21 +4130,11 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test3</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; if(&quot;</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l329" href="#l329">329</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
       <td class="src coveredLine">   <span class="n">a</span><span class="o">++</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l330" href="#l330">330</a></td>
+      <td class="lineno"><a id="l329" href="#l329">329</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4154,13 +4144,23 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l331" href="#l331">331</a></td>
+      <td class="lineno"><a id="l330" href="#l330">330</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test4</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; do &quot;</span><span class="p">;</span></td>
+      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test2</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; for &quot;</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l331" href="#l331">331</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src ">   <span class="p">{</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4170,7 +4170,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">a</span><span class="o">++</span><span class="p">;</span></td>
+      <td class="src coveredLine">      <span class="n">a</span><span class="o">++</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4180,11 +4180,81 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="src ">   <span class="p">}</span></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l334" href="#l334">334</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l335" href="#l335">335</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test3</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; if(&quot;</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l336" href="#l336">336</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">a</span><span class="o">++</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l337" href="#l337">337</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l338" href="#l338">338</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test4</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; do &quot;</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l339" href="#l339">339</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">a</span><span class="o">++</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l340" href="#l340">340</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l341" href="#l341">341</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">1/2</summary>
@@ -4208,7 +4278,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l335" href="#l335">335</a></td>
+      <td class="lineno"><a id="l342" href="#l342">342</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4218,7 +4288,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l336" href="#l336">336</a></td>
+      <td class="lineno"><a id="l343" href="#l343">343</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4228,7 +4298,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l337" href="#l337">337</a></td>
+      <td class="lineno"><a id="l344" href="#l344">344</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4238,7 +4308,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l338" href="#l338">338</a></td>
+      <td class="lineno"><a id="l345" href="#l345">345</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4248,7 +4318,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l339" href="#l339">339</a></td>
+      <td class="lineno"><a id="l346" href="#l346">346</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4258,7 +4328,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l340" href="#l340">340</a></td>
+      <td class="lineno"><a id="l347" href="#l347">347</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4268,7 +4338,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l341" href="#l341">341</a></td>
+      <td class="lineno"><a id="l348" href="#l348">348</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4278,7 +4348,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l342" href="#l342">342</a></td>
+      <td class="lineno"><a id="l349" href="#l349">349</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4288,7 +4358,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l343" href="#l343">343</a></td>
+      <td class="lineno"><a id="l350" href="#l350">350</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">2/2</summary>
@@ -4312,7 +4382,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l344" href="#l344">344</a></td>
+      <td class="lineno"><a id="l351" href="#l351">351</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">2/2</summary>
@@ -4336,7 +4406,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l345" href="#l345">345</a></td>
+      <td class="lineno"><a id="l352" href="#l352">352</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4346,7 +4416,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l346" href="#l346">346</a></td>
+      <td class="lineno"><a id="l353" href="#l353">353</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4356,83 +4426,13 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l347" href="#l347">347</a></td>
+      <td class="lineno"><a id="l354" href="#l354">354</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">2</td>
       <td class="src coveredLine"><span class="p">}</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l348" href="#l348">348</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l349" href="#l349">349</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">int</span> <span class="nf">main</span><span class="p">(</span><span class="kt">int</span> <span class="n">argc</span><span class="p">,</span> <span class="kt">char</span> <span class="o">*</span><span class="n">argv</span><span class="p">[])</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l350" href="#l350">350</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l351" href="#l351">351</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkBiggerTrue</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l352" href="#l352">352</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkBiggerFalse</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l353" href="#l353">353</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkBiggerBoth</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l354" href="#l354">354</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkBiggerBoth</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4452,7 +4452,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkSmallerTrue</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
+      <td class="src coveredLine"><span class="kt">int</span> <span class="nf">main</span><span class="p">(</span><span class="kt">int</span> <span class="n">argc</span><span class="p">,</span> <span class="kt">char</span> <span class="o">*</span><span class="n">argv</span><span class="p">[])</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4461,8 +4461,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkSmallerFalse</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">{</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4471,8 +4471,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkBiggerTrue</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4482,7 +4482,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkEqualTrue</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkBiggerFalse</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4492,7 +4492,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkEqualFalse</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkBiggerBoth</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4501,8 +4501,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkBiggerBoth</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4511,8 +4511,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkNotEqualTrue</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
+      <td class="linecount "></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
@@ -4522,7 +4522,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkNotEqualFalse</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkSmallerTrue</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4531,8 +4531,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkSmallerFalse</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4541,8 +4541,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkComplexTrue</span><span class="p">(</span><span class="mi">8</span><span class="p">);</span></td>
+      <td class="linecount "></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
@@ -4552,11 +4552,21 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkComplexFalse</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkEqualTrue</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l367" href="#l367">367</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkEqualFalse</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l368" href="#l368">368</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4566,23 +4576,13 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l368" href="#l368">368</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkElseIf1</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
-    </tr>
-
-    <tr class="source-line">
       <td class="lineno"><a id="l369" href="#l369">369</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkElseIf2</span><span class="p">(</span><span class="mi">10</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkNotEqualTrue</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4592,7 +4592,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkElseIf3</span><span class="p">(</span><span class="mi">0</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkNotEqualFalse</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4612,7 +4612,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkSwitch1</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkComplexTrue</span><span class="p">(</span><span class="mi">8</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4622,21 +4622,11 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkSwitch2</span><span class="p">(</span><span class="mi">10</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkComplexFalse</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l374" href="#l374">374</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkSwitch3</span><span class="p">(</span><span class="mi">0</span><span class="p">);</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l375" href="#l375">375</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4646,13 +4636,23 @@
     </tr>
 
     <tr class="source-line">
+      <td class="lineno"><a id="l375" href="#l375">375</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkElseIf1</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
+    </tr>
+
+    <tr class="source-line">
       <td class="lineno"><a id="l376" href="#l376">376</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkCompactBranch1True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkElseIf2</span><span class="p">(</span><span class="mi">10</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4662,7 +4662,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkCompactBranch1False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkElseIf3</span><span class="p">(</span><span class="mi">0</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4682,7 +4682,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkCompactBranch2True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkSwitch1</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4692,7 +4692,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkCompactBranch2False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkSwitch2</span><span class="p">(</span><span class="mi">10</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4701,8 +4701,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkSwitch3</span><span class="p">(</span><span class="mi">0</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4711,8 +4711,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkTernary1True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
+      <td class="linecount "></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
@@ -4722,7 +4722,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkTernary1False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkCompactBranch1True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4731,8 +4731,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkCompactBranch1False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4741,8 +4741,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkTernary2True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
+      <td class="linecount "></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
@@ -4752,7 +4752,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkTernary2False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkCompactBranch2True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4761,8 +4761,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkCompactBranch2False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4771,8 +4771,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkForLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
+      <td class="linecount "></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
@@ -4782,7 +4782,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkComplexForLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkTernary1True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4792,21 +4792,11 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkWhileLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkTernary1False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l391" href="#l391">391</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkDoWhileLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l392" href="#l392">392</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4816,13 +4806,23 @@
     </tr>
 
     <tr class="source-line">
+      <td class="lineno"><a id="l392" href="#l392">392</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkTernary2True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
+    </tr>
+
+    <tr class="source-line">
       <td class="lineno"><a id="l393" href="#l393">393</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkInterpreter</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkTernary2False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4842,7 +4842,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">verify_issue_679</span><span class="p">(</span><span class="nb">false</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkForLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4852,7 +4852,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">verify_issue_679</span><span class="p">(</span><span class="nb">true</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkComplexForLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4861,8 +4861,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkWhileLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4872,7 +4872,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="k">return</span> <span class="mi">0</span><span class="p">;</span></td>
+      <td class="src coveredLine">   <span class="n">checkDoWhileLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4882,11 +4882,81 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "><span class="p">}</span></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l400" href="#l400">400</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkInterpreter</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l401" href="#l401">401</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l402" href="#l402">402</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">verify_issue_679</span><span class="p">(</span><span class="nb">false</span><span class="p">);</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l403" href="#l403">403</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">verify_issue_679</span><span class="p">(</span><span class="nb">true</span><span class="p">);</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l404" href="#l404">404</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l405" href="#l405">405</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="k">return</span> <span class="mi">0</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l406" href="#l406">406</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">}</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l407" href="#l407">407</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">

--- a/gcovr/tests/decisions/reference/gcc-8/coverage.functions.html
+++ b/gcovr/tests/decisions/reference/gcc-8/coverage.functions.html
@@ -57,8 +57,8 @@
     <tr>
       <th scope="row">Decisions:</th>
       <td>33</td>
-      <td>65</td>
-      <td class="coverage-low">50.8%</td>
+      <td>63</td>
+      <td class="coverage-low">52.4%</td>
     </tr>
   </table>
 </div>
@@ -122,58 +122,58 @@
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l235">checkCompactBranch1False(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l242">checkCompactBranch1False(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l235">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l242">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l235">235</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l242">242</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l235"> called 1 time</a>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l230">checkCompactBranch1True(int)</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l230">main.cpp</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l230">230</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l230"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l242"> called 1 time</a>
     </td>
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l245">checkCompactBranch2False(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l237">checkCompactBranch1True(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l245">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l237">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l245">245</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l237">237</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l245"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l237"> called 1 time</a>
     </td>
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l240">checkCompactBranch2True(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l252">checkCompactBranch2False(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l240">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l252">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l240">240</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l252">252</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l240"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l252"> called 1 time</a>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l247">checkCompactBranch2True(int)</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l247">main.cpp</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l247">247</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l247"> called 1 time</a>
     </td>
   </tr>
   <tr>
@@ -192,16 +192,16 @@
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l280">checkComplexForLoop(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l287">checkComplexForLoop(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l280">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l287">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l280">280</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l287">287</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l280"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l287"> called 1 time</a>
     </td>
   </tr>
   <tr>
@@ -220,16 +220,16 @@
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l304">checkDoWhileLoop(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l311">checkDoWhileLoop(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l304">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l311">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l304">304</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l311">311</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l304"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l311"> called 1 time</a>
     </td>
   </tr>
   <tr>
@@ -304,30 +304,30 @@
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l270">checkForLoop(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l277">checkForLoop(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l270">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l277">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l270">270</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l277">277</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l270"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l277"> called 1 time</a>
     </td>
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l318">checkInterpreter(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l325">checkInterpreter(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l318">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l325">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l318">318</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l325">325</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l318"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l325"> called 1 time</a>
     </td>
   </tr>
   <tr>
@@ -402,105 +402,119 @@
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l198">checkSwitch2(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l205">checkSwitch2(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l198">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l205">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l198">198</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l205">205</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l198"> called 1 time</a>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l214">checkSwitch3(int)</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l214">main.cpp</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l214">214</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l214"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l205"> called 1 time</a>
     </td>
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l255">checkTernary1False(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l221">checkSwitch3(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l255">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l221">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l255">255</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l221">221</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l255"> called 1 time</a>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l250">checkTernary1True(int)</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l250">main.cpp</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l250">250</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l250"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l221"> called 1 time</a>
     </td>
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l265">checkTernary2False(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l262">checkTernary1False(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l265">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l262">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l265">265</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l262">262</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l265"> called 1 time</a>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l260">checkTernary2True(int)</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l260">main.cpp</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l260">260</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l260"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l262"> called 1 time</a>
     </td>
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l290">checkWhileLoop(int)</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l257">checkTernary1True(int)</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l290">main.cpp</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l257">main.cpp</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l290">290</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l257">257</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l290"> called 1 time</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l257"> called 1 time</a>
     </td>
   </tr>
   <tr>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l349">main</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l272">checkTernary2False(int)</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l272">main.cpp</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l272">272</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l272"> called 1 time</a>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l267">checkTernary2True(int)</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l267">main.cpp</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l267">267</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l267"> called 1 time</a>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l297">checkWhileLoop(int)</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l297">main.cpp</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l297">297</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l297"> called 1 time</a>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l356">main</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l356">main.cpp</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l356">356</a>
+    </td>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l356"> called 1 time</a>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l349">verify_issue_679(bool)</a>
     </td>
     <td>
       <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l349">main.cpp</a>
@@ -509,21 +523,7 @@
       <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l349">349</a>
     </td>
     <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l349"> called 1 time</a>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l342">verify_issue_679(bool)</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l342">main.cpp</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l342">342</a>
-    </td>
-    <td>
-      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l342"> called 2 times</a>
+      <a href="coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html#l349"> called 2 times</a>
     </td>
   </tr>
 </table>

--- a/gcovr/tests/decisions/reference/gcc-8/coverage.functions.html
+++ b/gcovr/tests/decisions/reference/gcc-8/coverage.functions.html
@@ -57,8 +57,8 @@
     <tr>
       <th scope="row">Decisions:</th>
       <td>33</td>
-      <td>63</td>
-      <td class="coverage-low">52.4%</td>
+      <td>65</td>
+      <td class="coverage-low">50.8%</td>
     </tr>
   </table>
 </div>

--- a/gcovr/tests/decisions/reference/gcc-8/coverage.html
+++ b/gcovr/tests/decisions/reference/gcc-8/coverage.html
@@ -65,8 +65,8 @@
     <tr>
       <th scope="row">Decisions:</th>
       <td>33</td>
-      <td>63</td>
-      <td class="coverage-low">52.4%</td>
+      <td>65</td>
+      <td class="coverage-low">50.8%</td>
     </tr>
   </table>
 </div>
@@ -109,8 +109,8 @@
     <td class="CoverValue function-coverage coverage-high">32 / 32</td>
     <td class="CoverValue branch-coverage coverage-low">51.7%</td>
     <td class="CoverValue branch-coverage coverage-low">45 / 87</td>
-    <td class="CoverValue decision-coverage coverage-low">52.4%</td>
-    <td class="CoverValue decision-coverage coverage-low">33 / 63</td>
+    <td class="CoverValue decision-coverage coverage-low">50.8%</td>
+    <td class="CoverValue decision-coverage coverage-low">33 / 65</td>
   </tr>
 
 </table>

--- a/gcovr/tests/decisions/reference/gcc-8/coverage.html
+++ b/gcovr/tests/decisions/reference/gcc-8/coverage.html
@@ -65,8 +65,8 @@
     <tr>
       <th scope="row">Decisions:</th>
       <td>33</td>
-      <td>65</td>
-      <td class="coverage-low">50.8%</td>
+      <td>63</td>
+      <td class="coverage-low">52.4%</td>
     </tr>
   </table>
 </div>
@@ -109,8 +109,8 @@
     <td class="CoverValue function-coverage coverage-high">32 / 32</td>
     <td class="CoverValue branch-coverage coverage-low">51.7%</td>
     <td class="CoverValue branch-coverage coverage-low">45 / 87</td>
-    <td class="CoverValue decision-coverage coverage-low">50.8%</td>
-    <td class="CoverValue decision-coverage coverage-low">33 / 65</td>
+    <td class="CoverValue decision-coverage coverage-low">52.4%</td>
+    <td class="CoverValue decision-coverage coverage-low">33 / 63</td>
   </tr>
 
 </table>

--- a/gcovr/tests/decisions/reference/gcc-8/coverage.json
+++ b/gcovr/tests/decisions/reference/gcc-8/coverage.json
@@ -825,6 +825,10 @@
                 {
                     "branches": [],
                     "count": 0,
+                    "gcovr/decision": {
+                        "count": 0,
+                        "type": "switch"
+                    },
                     "line_number": 190
                 },
                 {
@@ -835,6 +839,10 @@
                 {
                     "branches": [],
                     "count": 0,
+                    "gcovr/decision": {
+                        "count": 0,
+                        "type": "switch"
+                    },
                     "line_number": 196
                 },
                 {

--- a/gcovr/tests/decisions/reference/gcc-8/coverage.json
+++ b/gcovr/tests/decisions/reference/gcc-8/coverage.json
@@ -20,22 +20,22 @@
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 235,
+                    "lineno": 242,
                     "name": "checkCompactBranch1False(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 230,
+                    "lineno": 237,
                     "name": "checkCompactBranch1True(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 245,
+                    "lineno": 252,
                     "name": "checkCompactBranch2False(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 240,
+                    "lineno": 247,
                     "name": "checkCompactBranch2True(int)"
                 },
                 {
@@ -45,7 +45,7 @@
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 280,
+                    "lineno": 287,
                     "name": "checkComplexForLoop(int)"
                 },
                 {
@@ -55,7 +55,7 @@
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 304,
+                    "lineno": 311,
                     "name": "checkDoWhileLoop(int)"
                 },
                 {
@@ -85,12 +85,12 @@
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 270,
+                    "lineno": 277,
                     "name": "checkForLoop(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 318,
+                    "lineno": 325,
                     "name": "checkInterpreter(int)"
                 },
                 {
@@ -120,47 +120,47 @@
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 198,
+                    "lineno": 205,
                     "name": "checkSwitch2(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 214,
+                    "lineno": 221,
                     "name": "checkSwitch3(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 255,
+                    "lineno": 262,
                     "name": "checkTernary1False(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 250,
+                    "lineno": 257,
                     "name": "checkTernary1True(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 265,
+                    "lineno": 272,
                     "name": "checkTernary2False(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 260,
+                    "lineno": 267,
                     "name": "checkTernary2True(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 290,
+                    "lineno": 297,
                     "name": "checkWhileLoop(int)"
                 },
                 {
                     "execution_count": 1,
-                    "lineno": 349,
+                    "lineno": 356,
                     "name": "main"
                 },
                 {
                     "execution_count": 2,
-                    "lineno": 342,
+                    "lineno": 349,
                     "name": "verify_issue_679(bool)"
                 }
             ],
@@ -825,35 +825,27 @@
                 {
                     "branches": [],
                     "count": 0,
-                    "gcovr/decision": {
-                        "count": 0,
-                        "type": "switch"
-                    },
-                    "line_number": 189
-                },
-                {
-                    "branches": [],
-                    "count": 0,
                     "line_number": 190
                 },
                 {
                     "branches": [],
                     "count": 0,
-                    "gcovr/decision": {
-                        "count": 0,
-                        "type": "switch"
-                    },
                     "line_number": 192
                 },
                 {
                     "branches": [],
                     "count": 0,
-                    "line_number": 193
+                    "line_number": 196
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "line_number": 198
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 198
+                    "line_number": 205
                 },
                 {
                     "branches": [
@@ -874,7 +866,7 @@
                         }
                     ],
                     "count": 1,
-                    "line_number": 200
+                    "line_number": 207
                 },
                 {
                     "branches": [],
@@ -883,45 +875,45 @@
                         "count": 0,
                         "type": "switch"
                     },
-                    "line_number": 202
-                },
-                {
-                    "branches": [],
-                    "count": 0,
-                    "line_number": 203
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "gcovr/decision": {
-                        "count": 1,
-                        "type": "switch"
-                    },
-                    "line_number": 205
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 206
-                },
-                {
-                    "branches": [],
-                    "count": 0,
-                    "gcovr/decision": {
-                        "count": 0,
-                        "type": "switch"
-                    },
-                    "line_number": 208
-                },
-                {
-                    "branches": [],
-                    "count": 0,
                     "line_number": 209
                 },
                 {
                     "branches": [],
+                    "count": 0,
+                    "line_number": 210
+                },
+                {
+                    "branches": [],
                     "count": 1,
-                    "line_number": 214
+                    "gcovr/decision": {
+                        "count": 1,
+                        "type": "switch"
+                    },
+                    "line_number": 212
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 213
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "gcovr/decision": {
+                        "count": 0,
+                        "type": "switch"
+                    },
+                    "line_number": 215
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "line_number": 216
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 221
                 },
                 {
                     "branches": [
@@ -942,7 +934,7 @@
                         }
                     ],
                     "count": 1,
-                    "line_number": 216
+                    "line_number": 223
                 },
                 {
                     "branches": [],
@@ -951,12 +943,12 @@
                         "count": 0,
                         "type": "switch"
                     },
-                    "line_number": 218
+                    "line_number": 225
                 },
                 {
                     "branches": [],
                     "count": 0,
-                    "line_number": 219
+                    "line_number": 226
                 },
                 {
                     "branches": [],
@@ -965,12 +957,12 @@
                         "count": 0,
                         "type": "switch"
                     },
-                    "line_number": 221
+                    "line_number": 228
                 },
                 {
                     "branches": [],
                     "count": 0,
-                    "line_number": 222
+                    "line_number": 229
                 },
                 {
                     "branches": [],
@@ -979,17 +971,17 @@
                         "count": 1,
                         "type": "switch"
                     },
-                    "line_number": 224
+                    "line_number": 231
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 225
+                    "line_number": 232
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 230
+                    "line_number": 237
                 },
                 {
                     "branches": [
@@ -1010,12 +1002,12 @@
                         "count_true": 1,
                         "type": "conditional"
                     },
-                    "line_number": 232
+                    "line_number": 239
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 235
+                    "line_number": 242
                 },
                 {
                     "branches": [
@@ -1036,80 +1028,41 @@
                         "count_true": 0,
                         "type": "conditional"
                     },
-                    "line_number": 237
+                    "line_number": 244
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 240
-                },
-                {
-                    "branches": [
-                        {
-                            "count": 1,
-                            "fallthrough": true,
-                            "throw": false
-                        },
-                        {
-                            "count": 0,
-                            "fallthrough": false,
-                            "throw": false
-                        },
-                        {
-                            "count": 1,
-                            "fallthrough": true,
-                            "throw": false
-                        },
-                        {
-                            "count": 0,
-                            "fallthrough": false,
-                            "throw": false
-                        }
-                    ],
-                    "count": 1,
-                    "gcovr/decision": {
-                        "type": "uncheckable"
-                    },
-                    "line_number": 242
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 245
-                },
-                {
-                    "branches": [
-                        {
-                            "count": 0,
-                            "fallthrough": true,
-                            "throw": false
-                        },
-                        {
-                            "count": 1,
-                            "fallthrough": false,
-                            "throw": false
-                        },
-                        {
-                            "count": 0,
-                            "fallthrough": false,
-                            "throw": false
-                        },
-                        {
-                            "count": 0,
-                            "fallthrough": false,
-                            "throw": false
-                        }
-                    ],
-                    "count": 1,
-                    "gcovr/decision": {
-                        "type": "uncheckable"
-                    },
                     "line_number": 247
                 },
                 {
-                    "branches": [],
+                    "branches": [
+                        {
+                            "count": 1,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "count": 1,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
                     "count": 1,
-                    "line_number": 250
+                    "gcovr/decision": {
+                        "type": "uncheckable"
+                    },
+                    "line_number": 249
                 },
                 {
                     "branches": [],
@@ -1117,9 +1070,33 @@
                     "line_number": 252
                 },
                 {
-                    "branches": [],
+                    "branches": [
+                        {
+                            "count": 0,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "count": 1,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
                     "count": 1,
-                    "line_number": 255
+                    "gcovr/decision": {
+                        "type": "uncheckable"
+                    },
+                    "line_number": 254
                 },
                 {
                     "branches": [],
@@ -1129,38 +1106,53 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 260
+                    "line_number": 259
                 },
                 {
-                    "branches": [
-                        {
-                            "count": 1,
-                            "fallthrough": true,
-                            "throw": false
-                        },
-                        {
-                            "count": 0,
-                            "fallthrough": false,
-                            "throw": false
-                        },
-                        {
-                            "count": 1,
-                            "fallthrough": true,
-                            "throw": false
-                        },
-                        {
-                            "count": 0,
-                            "fallthrough": false,
-                            "throw": false
-                        }
-                    ],
+                    "branches": [],
                     "count": 1,
                     "line_number": 262
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 265
+                    "line_number": 264
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 267
+                },
+                {
+                    "branches": [
+                        {
+                            "count": 1,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "count": 1,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
+                    "count": 1,
+                    "line_number": 269
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 272
                 },
                 {
                     "branches": [
@@ -1186,17 +1178,17 @@
                         }
                     ],
                     "count": 1,
-                    "line_number": 267
+                    "line_number": 274
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 270
+                    "line_number": 277
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 272
+                    "line_number": 279
                 },
                 {
                     "branches": [
@@ -1217,27 +1209,27 @@
                         "count_true": 5,
                         "type": "conditional"
                     },
-                    "line_number": 273
-                },
-                {
-                    "branches": [],
-                    "count": 5,
-                    "line_number": 275
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 277
-                },
-                {
-                    "branches": [],
-                    "count": 1,
                     "line_number": 280
                 },
                 {
                     "branches": [],
-                    "count": 1,
+                    "count": 5,
                     "line_number": 282
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 284
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 287
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 289
                 },
                 {
                     "branches": [
@@ -1266,32 +1258,32 @@
                     "gcovr/decision": {
                         "type": "uncheckable"
                     },
-                    "line_number": 283
-                },
-                {
-                    "branches": [],
-                    "count": 5,
-                    "line_number": 285
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 287
-                },
-                {
-                    "branches": [],
-                    "count": 1,
                     "line_number": 290
                 },
                 {
                     "branches": [],
-                    "count": 1,
+                    "count": 5,
                     "line_number": 292
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 293
+                    "line_number": 294
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 297
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 299
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 300
                 },
                 {
                     "branches": [
@@ -1312,52 +1304,52 @@
                         "count_true": 5,
                         "type": "conditional"
                     },
-                    "line_number": 295
+                    "line_number": 302
                 },
                 {
                     "branches": [],
                     "count": 5,
-                    "line_number": 297
-                },
-                {
-                    "branches": [],
-                    "count": 5,
-                    "line_number": 298
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 301
-                },
-                {
-                    "branches": [],
-                    "count": 1,
                     "line_number": 304
                 },
                 {
                     "branches": [],
-                    "count": 1,
-                    "line_number": 306
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 307
-                },
-                {
-                    "branches": [],
-                    "count": 4,
-                    "line_number": 309
-                },
-                {
-                    "branches": [],
                     "count": 5,
+                    "line_number": 305
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 308
+                },
+                {
+                    "branches": [],
+                    "count": 1,
                     "line_number": 311
                 },
                 {
                     "branches": [],
+                    "count": 1,
+                    "line_number": 313
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 314
+                },
+                {
+                    "branches": [],
+                    "count": 4,
+                    "line_number": 316
+                },
+                {
+                    "branches": [],
                     "count": 5,
-                    "line_number": 312
+                    "line_number": 318
+                },
+                {
+                    "branches": [],
+                    "count": 5,
+                    "line_number": 319
                 },
                 {
                     "branches": [
@@ -1378,32 +1370,12 @@
                         "count_true": 4,
                         "type": "conditional"
                     },
-                    "line_number": 313
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 315
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 318
-                },
-                {
-                    "branches": [],
-                    "count": 1,
                     "line_number": 320
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 321
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 323
+                    "line_number": 322
                 },
                 {
                     "branches": [],
@@ -1413,22 +1385,42 @@
                 {
                     "branches": [],
                     "count": 1,
+                    "line_number": 327
+                },
+                {
+                    "branches": [],
+                    "count": 1,
                     "line_number": 328
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 329
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 331
+                    "line_number": 330
                 },
                 {
                     "branches": [],
                     "count": 1,
                     "line_number": 332
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 335
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 336
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 338
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 339
                 },
                 {
                     "branches": [
@@ -1449,22 +1441,22 @@
                         "count_true": 1,
                         "type": "conditional"
                     },
-                    "line_number": 334
+                    "line_number": 341
                 },
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 336
+                    "line_number": 343
                 },
                 {
                     "branches": [],
                     "count": 0,
-                    "line_number": 339
+                    "line_number": 346
                 },
                 {
                     "branches": [],
                     "count": 2,
-                    "line_number": 342
+                    "line_number": 349
                 },
                 {
                     "branches": [
@@ -1485,7 +1477,7 @@
                         "count_true": 1,
                         "type": "conditional"
                     },
-                    "line_number": 343
+                    "line_number": 350
                 },
                 {
                     "branches": [
@@ -1506,36 +1498,11 @@
                         "count_true": 10,
                         "type": "conditional"
                     },
-                    "line_number": 344
-                },
-                {
-                    "branches": [],
-                    "count": 2,
-                    "line_number": 347
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 349
-                },
-                {
-                    "branches": [],
-                    "count": 1,
                     "line_number": 351
                 },
                 {
                     "branches": [],
-                    "count": 1,
-                    "line_number": 352
-                },
-                {
-                    "branches": [],
-                    "count": 1,
-                    "line_number": 353
-                },
-                {
-                    "branches": [],
-                    "count": 1,
+                    "count": 2,
                     "line_number": 354
                 },
                 {
@@ -1546,7 +1513,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 357
+                    "line_number": 358
                 },
                 {
                     "branches": [],
@@ -1561,7 +1528,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 362
+                    "line_number": 361
                 },
                 {
                     "branches": [],
@@ -1571,7 +1538,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 365
+                    "line_number": 364
                 },
                 {
                     "branches": [],
@@ -1581,7 +1548,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 368
+                    "line_number": 367
                 },
                 {
                     "branches": [],
@@ -1606,7 +1573,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 374
+                    "line_number": 375
                 },
                 {
                     "branches": [],
@@ -1631,7 +1598,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 382
+                    "line_number": 381
                 },
                 {
                     "branches": [],
@@ -1641,7 +1608,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 385
+                    "line_number": 384
                 },
                 {
                     "branches": [],
@@ -1651,7 +1618,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 388
+                    "line_number": 387
                 },
                 {
                     "branches": [],
@@ -1666,7 +1633,7 @@
                 {
                     "branches": [],
                     "count": 1,
-                    "line_number": 391
+                    "line_number": 392
                 },
                 {
                     "branches": [],
@@ -1686,7 +1653,32 @@
                 {
                     "branches": [],
                     "count": 1,
+                    "line_number": 397
+                },
+                {
+                    "branches": [],
+                    "count": 1,
                     "line_number": 398
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 400
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 402
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 403
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "line_number": 405
                 }
             ]
         }

--- a/gcovr/tests/decisions/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/decisions/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -64,8 +64,8 @@
     <tr>
       <th scope="row">Decisions:</th>
       <td>33</td>
-      <td>65</td>
-      <td class="coverage-low">50.8%</td>
+      <td>63</td>
+      <td class="coverage-low">52.4%</td>
     </tr>
   </table>
 </div>
@@ -118,46 +118,46 @@
     </tr>
     <tr>
       <td>
-        <a href="#l235">checkCompactBranch1False(int)</a>
+        <a href="#l242">checkCompactBranch1False(int)</a>
       </td>
       <td>
-        <a href="#l235">235</a>
+        <a href="#l242">242</a>
       </td>
       <td>
-        <a href="#l235"> called 1 time</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <a href="#l230">checkCompactBranch1True(int)</a>
-      </td>
-      <td>
-        <a href="#l230">230</a>
-      </td>
-      <td>
-        <a href="#l230"> called 1 time</a>
+        <a href="#l242"> called 1 time</a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="#l245">checkCompactBranch2False(int)</a>
+        <a href="#l237">checkCompactBranch1True(int)</a>
       </td>
       <td>
-        <a href="#l245">245</a>
+        <a href="#l237">237</a>
       </td>
       <td>
-        <a href="#l245"> called 1 time</a>
+        <a href="#l237"> called 1 time</a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="#l240">checkCompactBranch2True(int)</a>
+        <a href="#l252">checkCompactBranch2False(int)</a>
       </td>
       <td>
-        <a href="#l240">240</a>
+        <a href="#l252">252</a>
       </td>
       <td>
-        <a href="#l240"> called 1 time</a>
+        <a href="#l252"> called 1 time</a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="#l247">checkCompactBranch2True(int)</a>
+      </td>
+      <td>
+        <a href="#l247">247</a>
+      </td>
+      <td>
+        <a href="#l247"> called 1 time</a>
       </td>
     </tr>
     <tr>
@@ -173,13 +173,13 @@
     </tr>
     <tr>
       <td>
-        <a href="#l280">checkComplexForLoop(int)</a>
+        <a href="#l287">checkComplexForLoop(int)</a>
       </td>
       <td>
-        <a href="#l280">280</a>
+        <a href="#l287">287</a>
       </td>
       <td>
-        <a href="#l280"> called 1 time</a>
+        <a href="#l287"> called 1 time</a>
       </td>
     </tr>
     <tr>
@@ -195,13 +195,13 @@
     </tr>
     <tr>
       <td>
-        <a href="#l304">checkDoWhileLoop(int)</a>
+        <a href="#l311">checkDoWhileLoop(int)</a>
       </td>
       <td>
-        <a href="#l304">304</a>
+        <a href="#l311">311</a>
       </td>
       <td>
-        <a href="#l304"> called 1 time</a>
+        <a href="#l311"> called 1 time</a>
       </td>
     </tr>
     <tr>
@@ -261,24 +261,24 @@
     </tr>
     <tr>
       <td>
-        <a href="#l270">checkForLoop(int)</a>
+        <a href="#l277">checkForLoop(int)</a>
       </td>
       <td>
-        <a href="#l270">270</a>
+        <a href="#l277">277</a>
       </td>
       <td>
-        <a href="#l270"> called 1 time</a>
+        <a href="#l277"> called 1 time</a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="#l318">checkInterpreter(int)</a>
+        <a href="#l325">checkInterpreter(int)</a>
       </td>
       <td>
-        <a href="#l318">318</a>
+        <a href="#l325">325</a>
       </td>
       <td>
-        <a href="#l318"> called 1 time</a>
+        <a href="#l325"> called 1 time</a>
       </td>
     </tr>
     <tr>
@@ -338,101 +338,101 @@
     </tr>
     <tr>
       <td>
-        <a href="#l198">checkSwitch2(int)</a>
+        <a href="#l205">checkSwitch2(int)</a>
       </td>
       <td>
-        <a href="#l198">198</a>
+        <a href="#l205">205</a>
       </td>
       <td>
-        <a href="#l198"> called 1 time</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <a href="#l214">checkSwitch3(int)</a>
-      </td>
-      <td>
-        <a href="#l214">214</a>
-      </td>
-      <td>
-        <a href="#l214"> called 1 time</a>
+        <a href="#l205"> called 1 time</a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="#l255">checkTernary1False(int)</a>
+        <a href="#l221">checkSwitch3(int)</a>
       </td>
       <td>
-        <a href="#l255">255</a>
+        <a href="#l221">221</a>
       </td>
       <td>
-        <a href="#l255"> called 1 time</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <a href="#l250">checkTernary1True(int)</a>
-      </td>
-      <td>
-        <a href="#l250">250</a>
-      </td>
-      <td>
-        <a href="#l250"> called 1 time</a>
+        <a href="#l221"> called 1 time</a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="#l265">checkTernary2False(int)</a>
+        <a href="#l262">checkTernary1False(int)</a>
       </td>
       <td>
-        <a href="#l265">265</a>
+        <a href="#l262">262</a>
       </td>
       <td>
-        <a href="#l265"> called 1 time</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <a href="#l260">checkTernary2True(int)</a>
-      </td>
-      <td>
-        <a href="#l260">260</a>
-      </td>
-      <td>
-        <a href="#l260"> called 1 time</a>
+        <a href="#l262"> called 1 time</a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="#l290">checkWhileLoop(int)</a>
+        <a href="#l257">checkTernary1True(int)</a>
       </td>
       <td>
-        <a href="#l290">290</a>
+        <a href="#l257">257</a>
       </td>
       <td>
-        <a href="#l290"> called 1 time</a>
+        <a href="#l257"> called 1 time</a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="#l349">main</a>
+        <a href="#l272">checkTernary2False(int)</a>
+      </td>
+      <td>
+        <a href="#l272">272</a>
+      </td>
+      <td>
+        <a href="#l272"> called 1 time</a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="#l267">checkTernary2True(int)</a>
+      </td>
+      <td>
+        <a href="#l267">267</a>
+      </td>
+      <td>
+        <a href="#l267"> called 1 time</a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="#l297">checkWhileLoop(int)</a>
+      </td>
+      <td>
+        <a href="#l297">297</a>
+      </td>
+      <td>
+        <a href="#l297"> called 1 time</a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="#l356">main</a>
+      </td>
+      <td>
+        <a href="#l356">356</a>
+      </td>
+      <td>
+        <a href="#l356"> called 1 time</a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="#l349">verify_issue_679(bool)</a>
       </td>
       <td>
         <a href="#l349">349</a>
       </td>
       <td>
-        <a href="#l349"> called 1 time</a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <a href="#l342">verify_issue_679(bool)</a>
-      </td>
-      <td>
-        <a href="#l342">342</a>
-      </td>
-      <td>
-        <a href="#l342"> called 2 times</a>
+        <a href="#l349"> called 2 times</a>
       </td>
     </tr>
   </table>
@@ -2589,15 +2589,9 @@
       <td class="linebranch">
       </td>
       <td class="linedecision">
-        <details class="linedecisionDetails">
-          <summary class="linedecisionSummary">0/1</summary>
-          <div class="linedecisionContents">
-            <div class="notTakenDecision">&cross; Decision 'true' not taken.</div>
-          </div>
-        </details>
       </td>
-      <td class="linecount uncoveredLine">&cross;</td>
-      <td class="src uncoveredLine">   <span class="k">case</span> <span class="mi">10</span><span class="o">:</span></td>
+      <td class="linecount "></td>
+      <td class="src ">   <span class="cm">/* Comment */</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2607,7 +2601,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount uncoveredLine">&cross;</td>
-      <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">true</span><span class="p">;</span></td>
+      <td class="src uncoveredLine">   <span class="k">case</span> <span class="mi">10</span><span class="o">:</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2617,7 +2611,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
+      <td class="src ">      <span class="cm">/* Comment */</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2625,15 +2619,9 @@
       <td class="linebranch">
       </td>
       <td class="linedecision">
-        <details class="linedecisionDetails">
-          <summary class="linedecisionSummary">0/1</summary>
-          <div class="linedecisionContents">
-            <div class="notTakenDecision">&cross; Decision 'true' not taken.</div>
-          </div>
-        </details>
       </td>
       <td class="linecount uncoveredLine">&cross;</td>
-      <td class="src uncoveredLine">   <span class="k">default</span><span class="o">:</span></td>
+      <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">true</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2642,8 +2630,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount uncoveredLine">&cross;</td>
-      <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">false</span><span class="p">;</span></td>
+      <td class="linecount "></td>
+      <td class="src ">      <span class="cm">/* Comment */</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2663,7 +2651,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src ">   <span class="p">}</span></td>
+      <td class="src ">      <span class="cm">/* Comment */</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2672,8 +2660,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "><span class="p">}</span></td>
+      <td class="linecount uncoveredLine">&cross;</td>
+      <td class="src uncoveredLine">   <span class="k">default</span><span class="o">:</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2683,7 +2671,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="src ">      <span class="cm">/* Comment */</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2692,8 +2680,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkSwitch2</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+      <td class="linecount uncoveredLine">&cross;</td>
+      <td class="src uncoveredLine">      <span class="k">return</span> <span class="nb">false</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -2703,11 +2691,81 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
+      <td class="src ">      <span class="cm">/* Comment */</span></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l200" href="#l200">200</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src ">      <span class="k">break</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l201" href="#l201">201</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src ">      <span class="cm">/* Comment */</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l202" href="#l202">202</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src ">   <span class="p">}</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l203" href="#l203">203</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">}</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l204" href="#l204">204</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l205" href="#l205">205</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkSwitch2</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l206" href="#l206">206</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">{</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l207" href="#l207">207</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">1/3</summary>
@@ -2725,7 +2783,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l201" href="#l201">201</a></td>
+      <td class="lineno"><a id="l208" href="#l208">208</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2735,7 +2793,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l202" href="#l202">202</a></td>
+      <td class="lineno"><a id="l209" href="#l209">209</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2751,7 +2809,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l203" href="#l203">203</a></td>
+      <td class="lineno"><a id="l210" href="#l210">210</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2761,7 +2819,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l204" href="#l204">204</a></td>
+      <td class="lineno"><a id="l211" href="#l211">211</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2771,7 +2829,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l205" href="#l205">205</a></td>
+      <td class="lineno"><a id="l212" href="#l212">212</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2787,7 +2845,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l206" href="#l206">206</a></td>
+      <td class="lineno"><a id="l213" href="#l213">213</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2797,7 +2855,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l207" href="#l207">207</a></td>
+      <td class="lineno"><a id="l214" href="#l214">214</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2807,7 +2865,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l208" href="#l208">208</a></td>
+      <td class="lineno"><a id="l215" href="#l215">215</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2823,7 +2881,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l209" href="#l209">209</a></td>
+      <td class="lineno"><a id="l216" href="#l216">216</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2833,7 +2891,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l210" href="#l210">210</a></td>
+      <td class="lineno"><a id="l217" href="#l217">217</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2843,7 +2901,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l211" href="#l211">211</a></td>
+      <td class="lineno"><a id="l218" href="#l218">218</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2853,7 +2911,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l212" href="#l212">212</a></td>
+      <td class="lineno"><a id="l219" href="#l219">219</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2863,7 +2921,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l213" href="#l213">213</a></td>
+      <td class="lineno"><a id="l220" href="#l220">220</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2873,7 +2931,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l214" href="#l214">214</a></td>
+      <td class="lineno"><a id="l221" href="#l221">221</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2883,7 +2941,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l215" href="#l215">215</a></td>
+      <td class="lineno"><a id="l222" href="#l222">222</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2893,7 +2951,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l216" href="#l216">216</a></td>
+      <td class="lineno"><a id="l223" href="#l223">223</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">1/3</summary>
@@ -2911,7 +2969,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l217" href="#l217">217</a></td>
+      <td class="lineno"><a id="l224" href="#l224">224</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2921,7 +2979,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l218" href="#l218">218</a></td>
+      <td class="lineno"><a id="l225" href="#l225">225</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2937,7 +2995,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l219" href="#l219">219</a></td>
+      <td class="lineno"><a id="l226" href="#l226">226</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2947,7 +3005,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l220" href="#l220">220</a></td>
+      <td class="lineno"><a id="l227" href="#l227">227</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2957,7 +3015,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l221" href="#l221">221</a></td>
+      <td class="lineno"><a id="l228" href="#l228">228</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2973,7 +3031,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l222" href="#l222">222</a></td>
+      <td class="lineno"><a id="l229" href="#l229">229</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2983,7 +3041,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l223" href="#l223">223</a></td>
+      <td class="lineno"><a id="l230" href="#l230">230</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -2993,7 +3051,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l224" href="#l224">224</a></td>
+      <td class="lineno"><a id="l231" href="#l231">231</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3009,7 +3067,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l225" href="#l225">225</a></td>
+      <td class="lineno"><a id="l232" href="#l232">232</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3019,7 +3077,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l226" href="#l226">226</a></td>
+      <td class="lineno"><a id="l233" href="#l233">233</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3029,7 +3087,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l227" href="#l227">227</a></td>
+      <td class="lineno"><a id="l234" href="#l234">234</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3039,7 +3097,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l228" href="#l228">228</a></td>
+      <td class="lineno"><a id="l235" href="#l235">235</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3049,7 +3107,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l229" href="#l229">229</a></td>
+      <td class="lineno"><a id="l236" href="#l236">236</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3059,7 +3117,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l230" href="#l230">230</a></td>
+      <td class="lineno"><a id="l237" href="#l237">237</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3069,7 +3127,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l231" href="#l231">231</a></td>
+      <td class="lineno"><a id="l238" href="#l238">238</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3079,7 +3137,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l232" href="#l232">232</a></td>
+      <td class="lineno"><a id="l239" href="#l239">239</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">1/2</summary>
@@ -3103,7 +3161,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l233" href="#l233">233</a></td>
+      <td class="lineno"><a id="l240" href="#l240">240</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3113,7 +3171,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l234" href="#l234">234</a></td>
+      <td class="lineno"><a id="l241" href="#l241">241</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3123,7 +3181,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l235" href="#l235">235</a></td>
+      <td class="lineno"><a id="l242" href="#l242">242</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3133,7 +3191,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l236" href="#l236">236</a></td>
+      <td class="lineno"><a id="l243" href="#l243">243</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3143,7 +3201,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l237" href="#l237">237</a></td>
+      <td class="lineno"><a id="l244" href="#l244">244</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">1/2</summary>
@@ -3167,98 +3225,13 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l238" href="#l238">238</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "><span class="p">}</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l239" href="#l239">239</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l240" href="#l240">240</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkCompactBranch2True</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l241" href="#l241">241</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l242" href="#l242">242</a></td>
-      <td class="linebranch">
-        <details class="linebranchDetails">
-        <summary class="linebranchSummary">2/4</summary>
-        <div class="linebranchContents">
-          <div class="takenBranch">&check; Branch 0 taken 1 times.</div>
-          <div class="notTakenBranch">&cross; Branch 1 not taken.</div>
-          <div class="takenBranch">&check; Branch 2 taken 1 times.</div>
-          <div class="notTakenBranch">&cross; Branch 3 not taken.</div>
-        </div>
-        </details>
-      </td>
-      <td class="linedecision">
-        <details class="linedecisionDetails">
-          <summary class="linedecisionSummary">0/1</summary>
-          <div class="linedecisionContents">
-            <div class="uncheckedDecision">? Decision couldn't be analyzed.</div>
-          </div>
-        </details>
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="k">if</span> <span class="p">(</span><span class="n">a</span> <span class="o">&gt;</span> <span class="mi">5</span> <span class="o">&amp;&amp;</span> <span class="n">a</span> <span class="o">&lt;</span> <span class="mi">10</span><span class="p">)</span> <span class="p">{</span> <span class="k">return</span> <span class="nb">true</span><span class="p">;</span> <span class="p">}</span> <span class="k">else</span> <span class="p">{</span> <span class="k">return</span> <span class="nb">false</span><span class="p">;</span> <span class="p">}</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l243" href="#l243">243</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "><span class="p">}</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l244" href="#l244">244</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
-    </tr>
-
-    <tr class="source-line">
       <td class="lineno"><a id="l245" href="#l245">245</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkCompactBranch2False</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">}</span></td>
     </tr>
 
     <tr class="source-line">
@@ -3268,11 +3241,96 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l247" href="#l247">247</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkCompactBranch2True</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l248" href="#l248">248</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">{</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l249" href="#l249">249</a></td>
+      <td class="linebranch">
+        <details class="linebranchDetails">
+        <summary class="linebranchSummary">2/4</summary>
+        <div class="linebranchContents">
+          <div class="takenBranch">&check; Branch 0 taken 1 times.</div>
+          <div class="notTakenBranch">&cross; Branch 1 not taken.</div>
+          <div class="takenBranch">&check; Branch 2 taken 1 times.</div>
+          <div class="notTakenBranch">&cross; Branch 3 not taken.</div>
+        </div>
+        </details>
+      </td>
+      <td class="linedecision">
+        <details class="linedecisionDetails">
+          <summary class="linedecisionSummary">0/1</summary>
+          <div class="linedecisionContents">
+            <div class="uncheckedDecision">? Decision couldn't be analyzed.</div>
+          </div>
+        </details>
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="k">if</span> <span class="p">(</span><span class="n">a</span> <span class="o">&gt;</span> <span class="mi">5</span> <span class="o">&amp;&amp;</span> <span class="n">a</span> <span class="o">&lt;</span> <span class="mi">10</span><span class="p">)</span> <span class="p">{</span> <span class="k">return</span> <span class="nb">true</span><span class="p">;</span> <span class="p">}</span> <span class="k">else</span> <span class="p">{</span> <span class="k">return</span> <span class="nb">false</span><span class="p">;</span> <span class="p">}</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l250" href="#l250">250</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">}</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l251" href="#l251">251</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l252" href="#l252">252</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkCompactBranch2False</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l253" href="#l253">253</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">{</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l254" href="#l254">254</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">1/4</summary>
@@ -3297,83 +3355,13 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l248" href="#l248">248</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "><span class="p">}</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l249" href="#l249">249</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l250" href="#l250">250</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkTernary1True</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l251" href="#l251">251</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l252" href="#l252">252</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="k">return</span> <span class="p">(</span><span class="n">a</span> <span class="o">==</span> <span class="mi">5</span><span class="p">)</span> <span class="o">?</span> <span class="nb">true</span> <span class="o">:</span> <span class="nb">false</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l253" href="#l253">253</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "><span class="p">}</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l254" href="#l254">254</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
-    </tr>
-
-    <tr class="source-line">
       <td class="lineno"><a id="l255" href="#l255">255</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkTernary1False</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">}</span></td>
     </tr>
 
     <tr class="source-line">
@@ -3383,7 +3371,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
@@ -3393,7 +3381,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="k">return</span> <span class="p">(</span><span class="n">a</span> <span class="o">==</span> <span class="mi">5</span><span class="p">)</span> <span class="o">?</span> <span class="nb">true</span> <span class="o">:</span> <span class="nb">false</span><span class="p">;</span></td>
+      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkTernary1True</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
     </tr>
 
     <tr class="source-line">
@@ -3403,7 +3391,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "><span class="p">}</span></td>
+      <td class="src "><span class="p">{</span></td>
     </tr>
 
     <tr class="source-line">
@@ -3412,8 +3400,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="k">return</span> <span class="p">(</span><span class="n">a</span> <span class="o">==</span> <span class="mi">5</span><span class="p">)</span> <span class="o">?</span> <span class="nb">true</span> <span class="o">:</span> <span class="nb">false</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -3422,8 +3410,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkTernary2True</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">}</span></td>
     </tr>
 
     <tr class="source-line">
@@ -3433,11 +3421,81 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l262" href="#l262">262</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkTernary1False</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l263" href="#l263">263</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">{</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l264" href="#l264">264</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="k">return</span> <span class="p">(</span><span class="n">a</span> <span class="o">==</span> <span class="mi">5</span><span class="p">)</span> <span class="o">?</span> <span class="nb">true</span> <span class="o">:</span> <span class="nb">false</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l265" href="#l265">265</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">}</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l266" href="#l266">266</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l267" href="#l267">267</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkTernary2True</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l268" href="#l268">268</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">{</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l269" href="#l269">269</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">2/4</summary>
@@ -3456,7 +3514,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l263" href="#l263">263</a></td>
+      <td class="lineno"><a id="l270" href="#l270">270</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3466,7 +3524,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l264" href="#l264">264</a></td>
+      <td class="lineno"><a id="l271" href="#l271">271</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3476,7 +3534,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l265" href="#l265">265</a></td>
+      <td class="lineno"><a id="l272" href="#l272">272</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3486,7 +3544,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l266" href="#l266">266</a></td>
+      <td class="lineno"><a id="l273" href="#l273">273</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3496,7 +3554,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l267" href="#l267">267</a></td>
+      <td class="lineno"><a id="l274" href="#l274">274</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">1/4</summary>
@@ -3515,7 +3573,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l268" href="#l268">268</a></td>
+      <td class="lineno"><a id="l275" href="#l275">275</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3525,7 +3583,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l269" href="#l269">269</a></td>
+      <td class="lineno"><a id="l276" href="#l276">276</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3535,7 +3593,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l270" href="#l270">270</a></td>
+      <td class="lineno"><a id="l277" href="#l277">277</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3545,7 +3603,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l271" href="#l271">271</a></td>
+      <td class="lineno"><a id="l278" href="#l278">278</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3555,7 +3613,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l272" href="#l272">272</a></td>
+      <td class="lineno"><a id="l279" href="#l279">279</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3565,7 +3623,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l273" href="#l273">273</a></td>
+      <td class="lineno"><a id="l280" href="#l280">280</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">2/2</summary>
@@ -3589,7 +3647,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l274" href="#l274">274</a></td>
+      <td class="lineno"><a id="l281" href="#l281">281</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3599,7 +3657,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l275" href="#l275">275</a></td>
+      <td class="lineno"><a id="l282" href="#l282">282</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3609,7 +3667,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l276" href="#l276">276</a></td>
+      <td class="lineno"><a id="l283" href="#l283">283</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3619,7 +3677,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l277" href="#l277">277</a></td>
+      <td class="lineno"><a id="l284" href="#l284">284</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3629,7 +3687,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l278" href="#l278">278</a></td>
+      <td class="lineno"><a id="l285" href="#l285">285</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3639,7 +3697,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l279" href="#l279">279</a></td>
+      <td class="lineno"><a id="l286" href="#l286">286</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3649,7 +3707,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l280" href="#l280">280</a></td>
+      <td class="lineno"><a id="l287" href="#l287">287</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3659,7 +3717,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l281" href="#l281">281</a></td>
+      <td class="lineno"><a id="l288" href="#l288">288</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3669,7 +3727,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l282" href="#l282">282</a></td>
+      <td class="lineno"><a id="l289" href="#l289">289</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3679,7 +3737,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l283" href="#l283">283</a></td>
+      <td class="lineno"><a id="l290" href="#l290">290</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">3/4</summary>
@@ -3704,7 +3762,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l284" href="#l284">284</a></td>
+      <td class="lineno"><a id="l291" href="#l291">291</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3714,7 +3772,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l285" href="#l285">285</a></td>
+      <td class="lineno"><a id="l292" href="#l292">292</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3724,7 +3782,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l286" href="#l286">286</a></td>
+      <td class="lineno"><a id="l293" href="#l293">293</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3734,7 +3792,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l287" href="#l287">287</a></td>
+      <td class="lineno"><a id="l294" href="#l294">294</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3744,7 +3802,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l288" href="#l288">288</a></td>
+      <td class="lineno"><a id="l295" href="#l295">295</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3754,7 +3812,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l289" href="#l289">289</a></td>
+      <td class="lineno"><a id="l296" href="#l296">296</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3764,7 +3822,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l290" href="#l290">290</a></td>
+      <td class="lineno"><a id="l297" href="#l297">297</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3774,7 +3832,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l291" href="#l291">291</a></td>
+      <td class="lineno"><a id="l298" href="#l298">298</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3784,7 +3842,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l292" href="#l292">292</a></td>
+      <td class="lineno"><a id="l299" href="#l299">299</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3794,7 +3852,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l293" href="#l293">293</a></td>
+      <td class="lineno"><a id="l300" href="#l300">300</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3804,7 +3862,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l294" href="#l294">294</a></td>
+      <td class="lineno"><a id="l301" href="#l301">301</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3814,7 +3872,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l295" href="#l295">295</a></td>
+      <td class="lineno"><a id="l302" href="#l302">302</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">2/2</summary>
@@ -3838,7 +3896,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l296" href="#l296">296</a></td>
+      <td class="lineno"><a id="l303" href="#l303">303</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3848,7 +3906,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l297" href="#l297">297</a></td>
+      <td class="lineno"><a id="l304" href="#l304">304</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3858,7 +3916,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l298" href="#l298">298</a></td>
+      <td class="lineno"><a id="l305" href="#l305">305</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3868,7 +3926,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l299" href="#l299">299</a></td>
+      <td class="lineno"><a id="l306" href="#l306">306</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3878,7 +3936,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l300" href="#l300">300</a></td>
+      <td class="lineno"><a id="l307" href="#l307">307</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3888,7 +3946,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l301" href="#l301">301</a></td>
+      <td class="lineno"><a id="l308" href="#l308">308</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3898,7 +3956,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l302" href="#l302">302</a></td>
+      <td class="lineno"><a id="l309" href="#l309">309</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3908,7 +3966,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l303" href="#l303">303</a></td>
+      <td class="lineno"><a id="l310" href="#l310">310</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3918,7 +3976,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l304" href="#l304">304</a></td>
+      <td class="lineno"><a id="l311" href="#l311">311</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3928,7 +3986,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l305" href="#l305">305</a></td>
+      <td class="lineno"><a id="l312" href="#l312">312</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3938,7 +3996,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l306" href="#l306">306</a></td>
+      <td class="lineno"><a id="l313" href="#l313">313</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3948,7 +4006,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l307" href="#l307">307</a></td>
+      <td class="lineno"><a id="l314" href="#l314">314</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3958,7 +4016,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l308" href="#l308">308</a></td>
+      <td class="lineno"><a id="l315" href="#l315">315</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3968,7 +4026,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l309" href="#l309">309</a></td>
+      <td class="lineno"><a id="l316" href="#l316">316</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3978,7 +4036,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l310" href="#l310">310</a></td>
+      <td class="lineno"><a id="l317" href="#l317">317</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3988,7 +4046,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l311" href="#l311">311</a></td>
+      <td class="lineno"><a id="l318" href="#l318">318</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -3998,7 +4056,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l312" href="#l312">312</a></td>
+      <td class="lineno"><a id="l319" href="#l319">319</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4008,7 +4066,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l313" href="#l313">313</a></td>
+      <td class="lineno"><a id="l320" href="#l320">320</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">2/2</summary>
@@ -4032,7 +4090,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l314" href="#l314">314</a></td>
+      <td class="lineno"><a id="l321" href="#l321">321</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4042,7 +4100,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l315" href="#l315">315</a></td>
+      <td class="lineno"><a id="l322" href="#l322">322</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4052,7 +4110,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l316" href="#l316">316</a></td>
+      <td class="lineno"><a id="l323" href="#l323">323</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4062,83 +4120,13 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l317" href="#l317">317</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l318" href="#l318">318</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkInterpreter</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l319" href="#l319">319</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l320" href="#l320">320</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test1</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; while &quot;</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l321" href="#l321">321</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">a</span><span class="o">++</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l322" href="#l322">322</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l323" href="#l323">323</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test2</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; for &quot;</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
       <td class="lineno"><a id="l324" href="#l324">324</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src ">   <span class="p">{</span></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
@@ -4148,7 +4136,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">      <span class="n">a</span><span class="o">++</span><span class="p">;</span></td>
+      <td class="src coveredLine"><span class="kt">bool</span> <span class="nf">checkInterpreter</span><span class="p">(</span><span class="kt">int</span> <span class="n">a</span><span class="p">)</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4158,7 +4146,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src ">   <span class="p">}</span></td>
+      <td class="src "><span class="p">{</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4167,8 +4155,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test1</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; while &quot;</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4178,21 +4166,11 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test3</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; if(&quot;</span><span class="p">;</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l329" href="#l329">329</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
       <td class="src coveredLine">   <span class="n">a</span><span class="o">++</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l330" href="#l330">330</a></td>
+      <td class="lineno"><a id="l329" href="#l329">329</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4202,13 +4180,23 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l331" href="#l331">331</a></td>
+      <td class="lineno"><a id="l330" href="#l330">330</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test4</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; do &quot;</span><span class="p">;</span></td>
+      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test2</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; for &quot;</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l331" href="#l331">331</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src ">   <span class="p">{</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4218,7 +4206,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">a</span><span class="o">++</span><span class="p">;</span></td>
+      <td class="src coveredLine">      <span class="n">a</span><span class="o">++</span><span class="p">;</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4228,11 +4216,81 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="src ">   <span class="p">}</span></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l334" href="#l334">334</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l335" href="#l335">335</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test3</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; if(&quot;</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l336" href="#l336">336</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">a</span><span class="o">++</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l337" href="#l337">337</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l338" href="#l338">338</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="kt">char</span> <span class="n">test4</span><span class="p">[]</span> <span class="o">=</span> <span class="s">&quot; do &quot;</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l339" href="#l339">339</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">a</span><span class="o">++</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l340" href="#l340">340</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l341" href="#l341">341</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">1/2</summary>
@@ -4256,7 +4314,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l335" href="#l335">335</a></td>
+      <td class="lineno"><a id="l342" href="#l342">342</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4266,7 +4324,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l336" href="#l336">336</a></td>
+      <td class="lineno"><a id="l343" href="#l343">343</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4276,7 +4334,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l337" href="#l337">337</a></td>
+      <td class="lineno"><a id="l344" href="#l344">344</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4286,7 +4344,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l338" href="#l338">338</a></td>
+      <td class="lineno"><a id="l345" href="#l345">345</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4296,7 +4354,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l339" href="#l339">339</a></td>
+      <td class="lineno"><a id="l346" href="#l346">346</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4306,7 +4364,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l340" href="#l340">340</a></td>
+      <td class="lineno"><a id="l347" href="#l347">347</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4316,7 +4374,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l341" href="#l341">341</a></td>
+      <td class="lineno"><a id="l348" href="#l348">348</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4326,7 +4384,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l342" href="#l342">342</a></td>
+      <td class="lineno"><a id="l349" href="#l349">349</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4336,7 +4394,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l343" href="#l343">343</a></td>
+      <td class="lineno"><a id="l350" href="#l350">350</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">2/2</summary>
@@ -4360,7 +4418,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l344" href="#l344">344</a></td>
+      <td class="lineno"><a id="l351" href="#l351">351</a></td>
       <td class="linebranch">
         <details class="linebranchDetails">
         <summary class="linebranchSummary">2/2</summary>
@@ -4384,7 +4442,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l345" href="#l345">345</a></td>
+      <td class="lineno"><a id="l352" href="#l352">352</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4394,7 +4452,7 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l346" href="#l346">346</a></td>
+      <td class="lineno"><a id="l353" href="#l353">353</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4404,83 +4462,13 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l347" href="#l347">347</a></td>
+      <td class="lineno"><a id="l354" href="#l354">354</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">2</td>
       <td class="src coveredLine"><span class="p">}</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l348" href="#l348">348</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l349" href="#l349">349</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine"><span class="kt">int</span> <span class="nf">main</span><span class="p">(</span><span class="kt">int</span> <span class="n">argc</span><span class="p">,</span> <span class="kt">char</span> <span class="o">*</span><span class="n">argv</span><span class="p">[])</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l350" href="#l350">350</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount "></td>
-      <td class="src "><span class="p">{</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l351" href="#l351">351</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkBiggerTrue</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l352" href="#l352">352</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkBiggerFalse</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l353" href="#l353">353</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkBiggerBoth</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l354" href="#l354">354</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkBiggerBoth</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4500,7 +4488,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkSmallerTrue</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
+      <td class="src coveredLine"><span class="kt">int</span> <span class="nf">main</span><span class="p">(</span><span class="kt">int</span> <span class="n">argc</span><span class="p">,</span> <span class="kt">char</span> <span class="o">*</span><span class="n">argv</span><span class="p">[])</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4509,8 +4497,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkSmallerFalse</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">{</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4519,8 +4507,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkBiggerTrue</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4530,7 +4518,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkEqualTrue</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkBiggerFalse</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4540,7 +4528,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkEqualFalse</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkBiggerBoth</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4549,8 +4537,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkBiggerBoth</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4559,8 +4547,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkNotEqualTrue</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
+      <td class="linecount "></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
@@ -4570,7 +4558,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkNotEqualFalse</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkSmallerTrue</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4579,8 +4567,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkSmallerFalse</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4589,8 +4577,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkComplexTrue</span><span class="p">(</span><span class="mi">8</span><span class="p">);</span></td>
+      <td class="linecount "></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
@@ -4600,11 +4588,21 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkComplexFalse</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkEqualTrue</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l367" href="#l367">367</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkEqualFalse</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l368" href="#l368">368</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4614,23 +4612,13 @@
     </tr>
 
     <tr class="source-line">
-      <td class="lineno"><a id="l368" href="#l368">368</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkElseIf1</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
-    </tr>
-
-    <tr class="source-line">
       <td class="lineno"><a id="l369" href="#l369">369</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkElseIf2</span><span class="p">(</span><span class="mi">10</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkNotEqualTrue</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4640,7 +4628,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkElseIf3</span><span class="p">(</span><span class="mi">0</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkNotEqualFalse</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4660,7 +4648,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkSwitch1</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkComplexTrue</span><span class="p">(</span><span class="mi">8</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4670,21 +4658,11 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkSwitch2</span><span class="p">(</span><span class="mi">10</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkComplexFalse</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l374" href="#l374">374</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkSwitch3</span><span class="p">(</span><span class="mi">0</span><span class="p">);</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l375" href="#l375">375</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4694,13 +4672,23 @@
     </tr>
 
     <tr class="source-line">
+      <td class="lineno"><a id="l375" href="#l375">375</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkElseIf1</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
+    </tr>
+
+    <tr class="source-line">
       <td class="lineno"><a id="l376" href="#l376">376</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkCompactBranch1True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkElseIf2</span><span class="p">(</span><span class="mi">10</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4710,7 +4698,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkCompactBranch1False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkElseIf3</span><span class="p">(</span><span class="mi">0</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4730,7 +4718,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkCompactBranch2True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkSwitch1</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4740,7 +4728,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkCompactBranch2False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkSwitch2</span><span class="p">(</span><span class="mi">10</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4749,8 +4737,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkSwitch3</span><span class="p">(</span><span class="mi">0</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4759,8 +4747,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkTernary1True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
+      <td class="linecount "></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
@@ -4770,7 +4758,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkTernary1False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkCompactBranch1True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4779,8 +4767,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkCompactBranch1False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4789,8 +4777,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkTernary2True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
+      <td class="linecount "></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
@@ -4800,7 +4788,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkTernary2False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkCompactBranch2True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4809,8 +4797,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkCompactBranch2False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4819,8 +4807,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkForLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
+      <td class="linecount "></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
@@ -4830,7 +4818,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkComplexForLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkTernary1True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4840,21 +4828,11 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkWhileLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkTernary1False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l391" href="#l391">391</a></td>
-      <td class="linebranch">
-      </td>
-      <td class="linedecision">
-      </td>
-      <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkDoWhileLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
-    </tr>
-
-    <tr class="source-line">
-      <td class="lineno"><a id="l392" href="#l392">392</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
@@ -4864,13 +4842,23 @@
     </tr>
 
     <tr class="source-line">
+      <td class="lineno"><a id="l392" href="#l392">392</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkTernary2True</span><span class="p">(</span><span class="mi">6</span><span class="p">);</span></td>
+    </tr>
+
+    <tr class="source-line">
       <td class="lineno"><a id="l393" href="#l393">393</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">checkInterpreter</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkTernary2False</span><span class="p">(</span><span class="mi">4</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4890,7 +4878,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">verify_issue_679</span><span class="p">(</span><span class="nb">false</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkForLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4900,7 +4888,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="n">verify_issue_679</span><span class="p">(</span><span class="nb">true</span><span class="p">);</span></td>
+      <td class="src coveredLine">   <span class="n">checkComplexForLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4909,8 +4897,8 @@
       </td>
       <td class="linedecision">
       </td>
-      <td class="linecount "></td>
-      <td class="src "></td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkWhileLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4920,7 +4908,7 @@
       <td class="linedecision">
       </td>
       <td class="linecount coveredLine">1</td>
-      <td class="src coveredLine">   <span class="k">return</span> <span class="mi">0</span><span class="p">;</span></td>
+      <td class="src coveredLine">   <span class="n">checkDoWhileLoop</span><span class="p">(</span><span class="mi">5</span><span class="p">);</span></td>
     </tr>
 
     <tr class="source-line">
@@ -4930,11 +4918,81 @@
       <td class="linedecision">
       </td>
       <td class="linecount "></td>
-      <td class="src "><span class="p">}</span></td>
+      <td class="src "></td>
     </tr>
 
     <tr class="source-line">
       <td class="lineno"><a id="l400" href="#l400">400</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">checkInterpreter</span><span class="p">(</span><span class="mi">2</span><span class="p">);</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l401" href="#l401">401</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l402" href="#l402">402</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">verify_issue_679</span><span class="p">(</span><span class="nb">false</span><span class="p">);</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l403" href="#l403">403</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="n">verify_issue_679</span><span class="p">(</span><span class="nb">true</span><span class="p">);</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l404" href="#l404">404</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l405" href="#l405">405</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount coveredLine">1</td>
+      <td class="src coveredLine">   <span class="k">return</span> <span class="mi">0</span><span class="p">;</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l406" href="#l406">406</a></td>
+      <td class="linebranch">
+      </td>
+      <td class="linedecision">
+      </td>
+      <td class="linecount "></td>
+      <td class="src "><span class="p">}</span></td>
+    </tr>
+
+    <tr class="source-line">
+      <td class="lineno"><a id="l407" href="#l407">407</a></td>
       <td class="linebranch">
       </td>
       <td class="linedecision">

--- a/gcovr/tests/decisions/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/gcovr/tests/decisions/reference/gcc-8/coverage.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -64,8 +64,8 @@
     <tr>
       <th scope="row">Decisions:</th>
       <td>33</td>
-      <td>63</td>
-      <td class="coverage-low">52.4%</td>
+      <td>65</td>
+      <td class="coverage-low">50.8%</td>
     </tr>
   </table>
 </div>
@@ -2599,6 +2599,12 @@
       <td class="linebranch">
       </td>
       <td class="linedecision">
+        <details class="linedecisionDetails">
+          <summary class="linedecisionSummary">0/1</summary>
+          <div class="linedecisionContents">
+            <div class="notTakenDecision">&cross; Decision 'true' not taken.</div>
+          </div>
+        </details>
       </td>
       <td class="linecount uncoveredLine">&cross;</td>
       <td class="src uncoveredLine">   <span class="k">case</span> <span class="mi">10</span><span class="o">:</span></td>
@@ -2659,6 +2665,12 @@
       <td class="linebranch">
       </td>
       <td class="linedecision">
+        <details class="linedecisionDetails">
+          <summary class="linedecisionSummary">0/1</summary>
+          <div class="linedecisionContents">
+            <div class="notTakenDecision">&cross; Decision 'true' not taken.</div>
+          </div>
+        </details>
       </td>
       <td class="linecount uncoveredLine">&cross;</td>
       <td class="src uncoveredLine">   <span class="k">default</span><span class="o">:</span></td>


### PR DESCRIPTION
Only single line cases are detected by the current decision parser.  This PR extends the decision parser to detect also multi line case statements as suggested in https://github.com/gcovr/gcovr/issues/665#issuecomment-1232581248.

Closes #665