### PR TITLE
Fix packaging of templates

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,9 +80,12 @@ jobs:
     - name: Test bundle of app
       run: |
         nox --non-interactive --session bundle_app
-    - name: Build
+    - name: Build wheel
       run: |
         nox --non-interactive --session build_wheel
+    - name: Check wheel
+      run: |
+        nox --non-interactive --session check_wheel
     - name: Upload distribution
       if: ${{ success() }}
       uses: actions/upload-artifact@v3

--- a/noxfile.py
+++ b/noxfile.py
@@ -266,11 +266,22 @@ def build_wheel(session: nox.Session) -> None:
 def check_wheel(session: nox.Session) -> None:
     """Check the wheel and do a smoke test, should not be used directly."""
     session.install("wheel", "twine")
-    session.chdir(f"{session.cache_dir}/dist")
-    session.run("twine", "check", "*", external=True)
-    session.install(glob.glob("*.whl")[0])
+    with session.chdir(f"{session.cache_dir}/dist"):
+        session.run("twine", "check", "*", external=True)
+        session.install(glob.glob("*.whl")[0])
     session.run("python", "-m", "gcovr", "--help", external=True)
     session.run("gcovr", "--help", external=True)
+    tmp_dir = session.create_tmp()
+    for format in [
+        "cobertura",
+        "coveralls",
+        "csv",
+        "html-details",
+        "json",
+        "sonarqube",
+        "txt",
+    ]:
+        session.run("gcovr", f"--{format}", f"{tmp_dir}/{format}", external=True)
 
 
 @nox.session

--- a/noxfile.py
+++ b/noxfile.py
@@ -327,14 +327,16 @@ def bundle_app(session: nox.Session) -> None:
 @nox.session
 def check_bundled_app(session: nox.Session) -> None:
     """Run a smoke test with the bundled app, should not be used directly."""
-    session.run("bash", "-c", "./build/gcovr --help", external=True)
-    session.log("Run all transformations to check if all the modules are packed")
-    with session.chdir(session.create_tmp()):
+    with session.chdir("build"):
+        # bash here is needed to be independent from the file extension (Windows).
+        session.run("bash", "-c", "./gcovr --help", external=True)
+        session.log("Run all transformations to check if all the modules are packed")
+        session.create_tmp()
         for format in OUTPUT_FORMATS:
             session.run(
                 "bash",
                 "-c",
-                f"{session.invoked_from}/build/gcovr --{format} out.{format}",
+                f"./gcovr --{format} $TMPDIR/out.{format}",
                 external=True,
             )
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -315,7 +315,7 @@ def bundle_app(session: nox.Session) -> None:
         "./pyinstaller",
         "--onefile",
         "--collect-all",
-        "gcovr",
+        "gcovr.writer",
         "-n",
         executable,
         *session.posargs,

--- a/noxfile.py
+++ b/noxfile.py
@@ -59,6 +59,16 @@ DEFAULT_LINT_ARGUMENTS = [
 
 BLACK_PINNED_VERSION = "black==22.3.0"
 
+OUTPUT_FORMATS = [
+        "cobertura",
+        "coveralls",
+        "csv",
+        "html-details",
+        "json",
+        "sonarqube",
+        "txt",
+    ]
+
 nox.options.sessions = ["qa"]
 
 
@@ -271,17 +281,10 @@ def check_wheel(session: nox.Session) -> None:
         session.install(glob.glob("*.whl")[0])
     session.run("python", "-m", "gcovr", "--help", external=True)
     session.run("gcovr", "--help", external=True)
+    session.log("Run all transformations to check if all the modules are packed")
     tmp_dir = session.create_tmp()
-    for format in [
-        "cobertura",
-        "coveralls",
-        "csv",
-        "html-details",
-        "json",
-        "sonarqube",
-        "txt",
-    ]:
-        session.run("gcovr", f"--{format}", f"{tmp_dir}/{format}", external=True)
+    for format in OUTPUT_FORMATS:
+        session.run("gcovr", f"--{format}", f"{tmp_dir}/out.{format}", external=True)
 
 
 @nox.session
@@ -324,11 +327,11 @@ def bundle_app(session: nox.Session) -> None:
 @nox.session
 def check_bundled_app(session: nox.Session) -> None:
     """Run a smoke test with the bundled app, should not be used directly."""
-    session.chdir("build")
-    session.run("bash", "-c", "./gcovr --help", external=True)
-    session.log("Run HTML all transformations to check if all the modules are packed")
-    for format in ["txt", "html", "cobertura", "sonarqube", "csv", "coveralls"]:
-        session.run("bash", "-c", f"./gcovr --{format} out.{format}", external=True)
+    session.run("./build/gcovr", "--help", external=True)
+    session.log("Run all transformations to check if all the modules are packed")
+    tmp_dir = session.create_tmp()
+    for format in OUTPUT_FORMATS:
+        session.run("./build/gcovr", f"--{format}", f"{tmp_dir}/out.{format}", external=True)
 
 
 def docker_container_os(session: nox.Session) -> str:

--- a/noxfile.py
+++ b/noxfile.py
@@ -327,14 +327,14 @@ def bundle_app(session: nox.Session) -> None:
 @nox.session
 def check_bundled_app(session: nox.Session) -> None:
     """Run a smoke test with the bundled app, should not be used directly."""
-    session.run("./build/gcovr", "--help", external=True)
+    session.run("bash", "-c", "./build/gcovr --help", external=True)
     session.log("Run all transformations to check if all the modules are packed")
     with session.chdir(session.create_tmp()):
         for format in OUTPUT_FORMATS:
             session.run(
-                f"{session.invoked_from}/build/gcovr",
-                f"--{format}",
-                f"out.{format}",
+                "bash",
+                "-c",
+                f"{session.invoked_from}/build/gcovr --{format} out.{format}",
                 external=True,
             )
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -60,14 +60,14 @@ DEFAULT_LINT_ARGUMENTS = [
 BLACK_PINNED_VERSION = "black==22.3.0"
 
 OUTPUT_FORMATS = [
-        "cobertura",
-        "coveralls",
-        "csv",
-        "html-details",
-        "json",
-        "sonarqube",
-        "txt",
-    ]
+    "cobertura",
+    "coveralls",
+    "csv",
+    "html-details",
+    "json",
+    "sonarqube",
+    "txt",
+]
 
 nox.options.sessions = ["qa"]
 
@@ -331,7 +331,9 @@ def check_bundled_app(session: nox.Session) -> None:
     session.log("Run all transformations to check if all the modules are packed")
     tmp_dir = session.create_tmp()
     for format in OUTPUT_FORMATS:
-        session.run("./build/gcovr", f"--{format}", f"{tmp_dir}/out.{format}", external=True)
+        session.run(
+            "./build/gcovr", f"--{format}", f"{tmp_dir}/out.{format}", external=True
+        )
 
 
 def docker_container_os(session: nox.Session) -> str:

--- a/noxfile.py
+++ b/noxfile.py
@@ -282,9 +282,9 @@ def check_wheel(session: nox.Session) -> None:
     session.run("python", "-m", "gcovr", "--help", external=True)
     session.run("gcovr", "--help", external=True)
     session.log("Run all transformations to check if all the modules are packed")
-    tmp_dir = session.create_tmp()
-    for format in OUTPUT_FORMATS:
-        session.run("gcovr", f"--{format}", f"{tmp_dir}/out.{format}", external=True)
+    with session.chdir(session.create_tmp()):
+        for format in OUTPUT_FORMATS:
+            session.run("gcovr", f"--{format}", f"out.{format}", external=True)
 
 
 @nox.session
@@ -329,11 +329,14 @@ def check_bundled_app(session: nox.Session) -> None:
     """Run a smoke test with the bundled app, should not be used directly."""
     session.run("./build/gcovr", "--help", external=True)
     session.log("Run all transformations to check if all the modules are packed")
-    tmp_dir = session.create_tmp()
-    for format in OUTPUT_FORMATS:
-        session.run(
-            "./build/gcovr", f"--{format}", f"{tmp_dir}/out.{format}", external=True
-        )
+    with session.chdir(session.create_tmp()):
+        for format in OUTPUT_FORMATS:
+            session.run(
+                f"{session.invoked_from}/build/gcovr",
+                f"--{format}",
+                f"out.{format}",
+                external=True,
+            )
 
 
 def docker_container_os(session: nox.Session) -> str:

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     packages=find_packages(include=["gcovr*"], exclude=["gcovr.tests"]),
     install_requires=["jinja2", "lxml", "pygments"],
     package_data={
-        "gcovr": ["templates/*.css", "templates/*.html"],
+        "gcovr": ["writer/html/templates/*.css", "writer/html/templates/*.html"],
     },
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
When moving the templates the writer the paths were not updated in `setup.py`. This PR updates the paths and extends the session `check_wheel` to create a empty report for each output format. Without the adaption of the paths the check is failing for HTML format.

[no changelog]