### PR TITLE
Use the rst2html.py again to be able to run the doc for all compilers.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -182,7 +182,7 @@ jobs:
       run: |
         codecov --flags ${{ matrix.os }} -X gcov search
     - name: Generate documentation
-      if: ${{ (!startsWith(matrix.python-version,'pypy')) && (matrix.python-version != '3.7') }}
+      if: ${{ (! startsWith(matrix.python-version,'pypy')) && (! startsWith(matrix.os,'windows-'))}}
       run: |
         nox --non-interactive --session doc
     - name: Test bundle of app
@@ -220,7 +220,6 @@ jobs:
       run: |
         python3 -m nox --non-interactive --session "docker_run_compiler(${{ matrix.gcc }})" -- --session tests
     - name: Generate documentation (in container)
-      if: ${{ (matrix.gcc != 'gcc-5') && (matrix.gcc != 'gcc-6') }} # Uses Ubuntu 18.04
       run: |
         python3 -m nox --non-interactive --session "docker_run_compiler(${{ matrix.gcc }})" -- --session doc
     - name: Test bundle of app (in container)

--- a/noxfile.py
+++ b/noxfile.py
@@ -192,7 +192,7 @@ def doc(session: nox.Session) -> None:
 
     # Ensure that the README builds fine as a standalone document.
     readme_html = session.create_tmp() + "/README.html"
-    session.run("rst2html5", "--strict", "README.rst", readme_html)
+    session.run("rst2html5.py", "--strict", "README.rst", readme_html)
 
 
 @nox.session(python=False)


### PR DESCRIPTION
The `qa` session in the docker container for `gcc-5` and `gcc-6` wasn't working anymore. Therefore switch back to the python script.

[no changelog]