### PR TITLE
Fix summary report

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ New features and notable changes:
 
 Bug fixes and small improvements:
 
+- Print calls and decision statistics in summary only if values are gathered. (:issue:`749`)
+
 Documentation:
 
 Internal changes:

--- a/gcovr/__main__.py
+++ b/gcovr/__main__.py
@@ -537,7 +537,7 @@ def print_reports(covdata: CovData, options):
         )
 
     if options.print_summary:
-        print_summary(covdata)
+        print_summary(covdata, options)
 
     return generator_error_occurred
 

--- a/gcovr/configuration.py
+++ b/gcovr/configuration.py
@@ -807,7 +807,7 @@ GCOVR_CONFIG_OPTIONS = [
         "show_decision",
         ["--decisions"],
         group="output_options",
-        help="Report the decision coverage. For HTML, JSON  and the summary report.",
+        help="Report the decision coverage. For HTML, JSON, and the summary report.",
         action="store_true",
     ),
     GcovrConfigOption(

--- a/gcovr/configuration.py
+++ b/gcovr/configuration.py
@@ -807,14 +807,14 @@ GCOVR_CONFIG_OPTIONS = [
         "show_decision",
         ["--decisions"],
         group="output_options",
-        help="Report the decision coverage. For HTML and JSON report.",
+        help="Report the decision coverage. For HTML, JSON  and the summary report.",
         action="store_true",
     ),
     GcovrConfigOption(
         "exclude_calls",
         ["--calls"],
         group="output_options",
-        help="Report the calls coverage. For HTML report.",
+        help="Report the calls coverage. For HTML and the summary report.",
         action="store_false",
     ),
     GcovrConfigOption(

--- a/gcovr/tests/print-summary-full/Makefile
+++ b/gcovr/tests/print-summary-full/Makefile
@@ -1,0 +1,17 @@
+CFLAGS = -fprofile-arcs -ftest-coverage -fPIC
+
+all:
+	$(CXX) $(CFLAGS) main.cpp -o testcase
+
+run: txt
+
+GCOVR_TEST_OPTIONS = --print-summary --calls --decision
+
+txt:
+	./testcase
+	$(GCOVR) $(GCOVR_TEST_OPTIONS) -d -o coverage-output.txt > coverage.txt
+
+clean:
+	rm -f testcase
+	rm -f *.gc*
+	rm -f coverage*.txt

--- a/gcovr/tests/print-summary-full/README
+++ b/gcovr/tests/print-summary-full/README
@@ -1,0 +1,1 @@
+A simple test that verifies generated summary with all optional parts.

--- a/gcovr/tests/print-summary-full/main.cpp
+++ b/gcovr/tests/print-summary-full/main.cpp
@@ -1,0 +1,26 @@
+#include <iostream>
+
+
+int foo(int param) {
+  if (param) {
+     return 1; //std::cout << "param not null." << std::endl;
+  } else {
+     return 0; //std::cout << "param is null." << std::endl;
+  }
+}
+
+
+int main(int argc, char* argv[]) {
+  foo(
+     0
+     )
+     ;
+  if (argc > 1) {
+     foo(
+        1
+        )
+        ;
+     }
+
+  return 0;
+}

--- a/gcovr/tests/print-summary-full/reference/clang-10/coverage.txt
+++ b/gcovr/tests/print-summary-full/reference/clang-10/coverage.txt
@@ -1,0 +1,5 @@
+lines: 72.7% (8 out of 11)
+functions: 100.0% (2 out of 2)
+branches: 50.0% (2 out of 4)
+decisions: 50.0% (2 out of 4)
+calls: 0.0% (0 out of 0)

--- a/gcovr/tests/print-summary-full/reference/gcc-5/coverage.txt
+++ b/gcovr/tests/print-summary-full/reference/gcc-5/coverage.txt
@@ -1,0 +1,5 @@
+lines: 80.0% (8 out of 10)
+functions: 100.0% (2 out of 2)
+branches: 50.0% (4 out of 8)
+decisions: 50.0% (2 out of 4)
+calls: 66.7% (2 out of 3)

--- a/gcovr/tests/print-summary-full/reference/gcc-8/coverage.txt
+++ b/gcovr/tests/print-summary-full/reference/gcc-8/coverage.txt
@@ -1,0 +1,5 @@
+lines: 77.8% (7 out of 9)
+functions: 100.0% (2 out of 2)
+branches: 50.0% (2 out of 4)
+decisions: 50.0% (2 out of 4)
+calls: 50.0% (1 out of 2)

--- a/gcovr/tests/print-summary/reference/clang-10/coverage.txt
+++ b/gcovr/tests/print-summary/reference/clang-10/coverage.txt
@@ -1,4 +1,3 @@
 lines: 72.7% (8 out of 11)
 functions: 100.0% (2 out of 2)
 branches: 50.0% (2 out of 4)
-calls: 0.0% (0 out of 0)

--- a/gcovr/tests/print-summary/reference/gcc-5/coverage.txt
+++ b/gcovr/tests/print-summary/reference/gcc-5/coverage.txt
@@ -1,4 +1,3 @@
 lines: 80.0% (8 out of 10)
 functions: 100.0% (2 out of 2)
 branches: 50.0% (4 out of 8)
-calls: 0.0% (0 out of 0)

--- a/gcovr/tests/print-summary/reference/gcc-8/coverage.txt
+++ b/gcovr/tests/print-summary/reference/gcc-8/coverage.txt
@@ -1,4 +1,3 @@
 lines: 77.8% (7 out of 9)
 functions: 100.0% (2 out of 2)
 branches: 50.0% (2 out of 4)
-calls: 0.0% (0 out of 0)

--- a/gcovr/writer/summary.py
+++ b/gcovr/writer/summary.py
@@ -22,7 +22,7 @@ import sys
 from ..coverage import CovData, CoverageStat, SummarizedStats
 
 
-def print_summary(covdata: CovData):
+def print_summary(covdata: CovData, options):
     """Print a small report to the standard output.
     Output the percentage, covered and total lines and branches.
     """
@@ -38,5 +38,8 @@ def print_summary(covdata: CovData):
     print_stat("lines", stats.line)
     print_stat("functions", stats.function)
     print_stat("branches", stats.branch)
-    print_stat("calls", stats.call)
+    if options.show_decision:
+        print_stat("decisions", stats.decision)
+    if not options.exclude_calls:
+        print_stat("calls", stats.call)
     sys.stdout.flush()


### PR DESCRIPTION
The decission summary is missing and the calls summary is printed even if the values aren't gathered.

This PR fixes the summary report by:

- Only print call coverage summary if option `--calls` is given.
- Print decision summary coverage if option `--decisions` is given.

Closes #745 