### PR TITLE
Add thread information to logging

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ New features and notable changes:
 Bug fixes and small improvements:
 
 - Print calls and decision statistics in summary only if values are gathered. (:issue:`749`)
+- Log the thread name if :option:`-j` is used. (:issue:`752`)
 
 Documentation:
 

--- a/gcovr/__main__.py
+++ b/gcovr/__main__.py
@@ -45,6 +45,7 @@ from .utils import (
     AlwaysMatchFilter,
     DirectoryPrefixFilter,
     configure_logging,
+    switch_to_logging_format_with_threads,
 )
 from .version import __version__
 from .workers import Workers
@@ -177,6 +178,9 @@ def main(args=None):
 
     options_dict = merge_options_and_set_defaults([cfg_options, cli_options.__dict__])
     options = Options(**options_dict)
+    # Reconfigure the logging.
+    if options.gcov_parallel > 1:
+        switch_to_logging_format_with_threads()
 
     if options.verbose:
         logger.setLevel(logging.DEBUG)

--- a/gcovr/utils.py
+++ b/gcovr/utils.py
@@ -30,6 +30,10 @@ from contextlib import contextmanager
 logger = logging.getLogger("gcovr")
 
 
+LOG_FORMAT = "(%(levelname)s) %(message)s"
+LOG_FORMAT_THREADS = "(%(levelname)s) - %(threadName)s - %(message)s"
+
+
 class LoopChecker(object):
     def __init__(self):
         self._seen = set()
@@ -290,9 +294,11 @@ class DirectoryPrefixFilter(Filter):
 
 
 def configure_logging() -> None:
+    stream_handler = logging.StreamHandler(sys.stderr)
+    stream_handler.setFormatter(logging.Formatter(LOG_FORMAT))
+
     logging.basicConfig(
-        format="(%(levelname)s) %(message)s",
-        stream=sys.stderr,
+        handlers=[stream_handler],
         level=logging.INFO,
     )
 
@@ -302,6 +308,16 @@ def configure_logging() -> None:
         )
 
     sys.excepthook = exception_hook
+
+
+def switch_to_logging_format_with_threads() -> None:
+    # The one and only logger was configured from ourselve.
+    if len(logging.getLogger().handlers) == 1 and (
+        logging.getLogger().handlers[0].formatter._fmt == LOG_FORMAT
+    ):
+        logging.getLogger().handlers[0].setFormatter(
+            logging.Formatter(LOG_FORMAT_THREADS)
+        )
 
 
 @contextmanager


### PR DESCRIPTION
Without threads the logging isn't changed. If more than one thread is used the message looks like this:

```
(DEBUG) - Thread-2 - Parsing coverage data for file /Users/Shared/Informatik/GitHub/gcovr/gcovr/tests/nested/subdir/A/file2.cpp
(DEBUG) - MainThread - Gathered coveraged data for 8 files
```

Closes #751