### PR TITLE
Use interactive terminal for docker if stdin is a tty.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,8 @@ Internal changes:
   - :option:`--gcov-exclude-directories` in addition to :option:`--exclude-directories`
   - :option:`--gcov-use-existing-files` in addition to :option:`--use-gcov-files`
 
+- Use interactive terminal for docker (support of Ctrl-C to interrupt). (:issue:`767`)
+
 6.0 (08 March 2023)
 -------------------
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -439,7 +439,7 @@ def docker_run_compiler(session: nox.Session, version: str) -> None:
         "docker",
         "run",
         "--rm",
-        "-t",
+        "-it" if sys.__stdin__.isatty() else "-t",
         "-e",
         "CC",
         "-v",

--- a/noxfile.py
+++ b/noxfile.py
@@ -439,7 +439,7 @@ def docker_run_compiler(session: nox.Session, version: str) -> None:
         "docker",
         "run",
         "--rm",
-        "-it" if sys.__stdin__.isatty() else "-t",
+        "-it" if session.interactive else "-t",
         "-e",
         "CC",
         "-v",


### PR DESCRIPTION
With a interactive shell you can use Ctrl-C to interrupt the docker call.