### PR TITLE
Fix filtering wrong path for gcov file

### DIFF
--- a/gcovr/coverage.py
+++ b/gcovr/coverage.py
@@ -91,7 +91,7 @@ def sort_coverage(
 
     def filename(key: str) -> str:
         return (
-            force_unix_separator(os.path.relpath(realpath(key), basedir))
+            force_unix_separator(realpath(key))
             if filename_uses_relative_pathname
             else key
         )

--- a/gcovr/gcov.py
+++ b/gcovr/gcov.py
@@ -124,7 +124,7 @@ def process_gcov_data(
     # Return if the filename does not match the filter
     # Return if the filename matches the exclude pattern
     filtered, excluded = apply_filter_include_exclude(
-        fname, options.filter, options.exclude
+        gcda_fname, options.filter, options.exclude
     )
 
     if filtered:

--- a/gcovr/writer/html/__init__.py
+++ b/gcovr/writer/html/__init__.py
@@ -287,7 +287,7 @@ class RootInfo:
         }
 
         display_filename = force_unix_separator(
-            os.path.relpath(realpath(cdata_fname), self.directory)
+            realpath(cdata_fname)
         )
 
         if link_report is not None:


### PR DESCRIPTION
In Windows, the path include Disk Drive letter in the begining, which was error prone. And thus can not generate any coverage report as described in #769. This changes fix the issue.

* also fix bugs when source file may comes from different Disk Drive.