### PR TITLE
Use `build` instead of calling `setup.py` directly.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -58,6 +58,7 @@ Internal changes:
 - Replace the deprecated codecov python uploader with the binary uploader. (:issue:`770`)
 - Add gcc-12 and gcc-13 to the test suite. (:issue:`780`)
 - Add sessions to run the targets for all versions of ``gcc`` or ``clang``. (:issue:`782`)
+- Use ``build`` instead of calling ``setup.py`` directly. (:issue:`819`)
 
 6.0 (08 March 2023)
 -------------------

--- a/admin/Dockerfile.qa
+++ b/admin/Dockerfile.qa
@@ -28,7 +28,7 @@ RUN \
                           python3-setuptools \
                           $(if [ "$DOCKER_OS" != "ubuntu:23.04"  ]; then echo "python3-dev"; fi) \
                           $(if [ "$DOCKER_OS" = "ubuntu:23.04"  ]; then echo "python3-full python3-pip python3-nox"; fi) \
-                          python3-venv \
+                          $(if [ "$DOCKER_OS" = "ubuntu:18.04" ]; then echo "python3.7-venv"; else echo "python3-venv"; fi)  \
                           $(if [ "$DOCKER_OS" = "ubuntu:18.04" -o "$DOCKER_OS" = "ubuntu:20.04" ]; then echo "python3.7"; fi) \
                           ninja-build \
                           curl \

--- a/noxfile.py
+++ b/noxfile.py
@@ -301,8 +301,8 @@ def tests_compiler(session: nox.Session, version: str) -> None:
 @nox.session
 def build_wheel(session: nox.Session) -> None:
     """Build a wheel."""
-    session.install("wheel")
-    session.run("python", "setup.py", "sdist", "bdist_wheel")
+    session.install("build")
+    session.run("python", "-m", "build")
     dist_cache = f"{session.cache_dir}/dist"
     if os.path.isdir(dist_cache):
         shutil.rmtree(dist_cache)


### PR DESCRIPTION
When running `setup.py` directly following message is printed:

Please avoid running ``setup.py`` directly.
Instead, use pypa/build, pypa/installer or other
standards-based tools.

See https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html for details.