### PR TITLE
Fix Windows test

### DIFF
--- a/gcovr/tests/test_args.py
+++ b/gcovr/tests/test_args.py
@@ -579,6 +579,7 @@ def test_import_valid_cobertura_file(tmp_path):
   </packages>
 </coverage>
     """
+    testfile = os.path.abspath(testfile)
     tempfile = tmp_path / "valid_cobertura.xml"
     with tempfile.open("w+") as fp:
         fp.write(xmldata)


### PR DESCRIPTION
Due to some change on the runner one test is failing:

```
FAILED gcovr/tests/test_args.py::test_import_valid_cobertura_file - AssertionError: assert '/path/to/source/code.cpp' in {'D:\\path\\to\\source\\code.cpp': <gcovr.coverage.FileCoverage object at 0x000001AB762D9300>}
```

This PR makes the path absolute before checking the dict.

[no changelog]