### PR TITLE
Pin pyinstaller version

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -336,7 +336,7 @@ def upload_wheel(session: nox.Session) -> None:
 @nox.session
 def bundle_app(session: nox.Session) -> None:
     """Bundle a standalone executable."""
-    session.install("pyinstaller")
+    session.install("pyinstaller~=5.13.2")
     session.install("-e", ".")
     os.makedirs("build", exist_ok=True)
     session.chdir("build")


### PR DESCRIPTION
With the latest version 6.0.0 we get following error:
```
9459 INFO: Including run-time hook '/gcovr/.nox-containerized.gcc-8.uid_1001/bundle_app/lib/python3.8/site-packages/PyInstaller/hooks/rthooks/pyi_rth_pkgres.py'
9476 INFO: Looking for dynamic libraries
Traceback (most recent call last):
...
  File "/usr/lib/python3.8/pathlib.py", line 1198, in stat
    return self._accessor.stat(self)
PermissionError: [Errno 13] Permission denied: '/root/.local/lib/python3.8/site-packages'
nox > Command pyinstaller --distpath . --workpath ./pyinstaller --specpath ./pyinstaller --onefile --collect-all gcovr.formats -n gcovr ../scripts/pyinstaller_entrypoint.py failed with exit code 1
```

[no changelog]