### PR TITLE
Use options when merging coverage data (#841)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -49,7 +49,7 @@ Bug fixes and small improvements:
 - Fix reading of choices options from configuration files (e.g. ``gcov-ignore-parse-errors``). (:issue:`816`)
 - Fix ``TypeError`` during decision analysis. (:issue:`784`)
 - Use relative paths if possible when running ``gcov``. (:issue:`820`)
-- Respect :option`--merge-mode-functions`when merging coverage data. (:issue:`841`)
+- Respect :option`--merge-mode-functions`when merging coverage data. (:issue:`844`)
 
 Documentation:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -49,6 +49,7 @@ Bug fixes and small improvements:
 - Fix reading of choices options from configuration files (e.g. ``gcov-ignore-parse-errors``). (:issue:`816`)
 - Fix ``TypeError`` during decision analysis. (:issue:`784`)
 - Use relative paths if possible when running ``gcov``. (:issue:`820`)
+- Use options when merging coverage data. (:issue:`841`)
 
 Documentation:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -49,7 +49,7 @@ Bug fixes and small improvements:
 - Fix reading of choices options from configuration files (e.g. ``gcov-ignore-parse-errors``). (:issue:`816`)
 - Fix ``TypeError`` during decision analysis. (:issue:`784`)
 - Use relative paths if possible when running ``gcov``. (:issue:`820`)
-- Use options when merging coverage data. (:issue:`841`)
+- Respect :option`--merge-mode-functions`when merging coverage data. (:issue:`841`)
 
 Documentation:
 

--- a/gcovr/formats/gcov/read.py
+++ b/gcovr/formats/gcov/read.py
@@ -88,7 +88,9 @@ def read_report(options: Options) -> CovData:
     toerase = set()
     covdata = dict()
     for context in contexts:
-        covdata = merge_covdata(covdata, context["covdata"])
+        covdata = merge_covdata(
+            covdata, context["covdata"], get_merge_mode_from_options(options)
+        )
         toerase.update(context["toerase"])
 
     for filepath in toerase:
@@ -305,7 +307,6 @@ def guess_source_file_name_heuristics(
     starting_dir: str,
     obj_dir: str,
 ) -> str:
-
     # 0. Try using the path to the gcov file
     fname = os.path.join(os.path.dirname(data_fname), source_from_gcov)
     if os.path.exists(fname):

--- a/gcovr/merging.py
+++ b/gcovr/merging.py
@@ -179,9 +179,7 @@ def _insert_coverage_item(
     return merged_item
 
 
-def merge_covdata(
-    left: CovData, right: CovData, options: MergeOptions = DEFAULT_MERGE_OPTIONS
-) -> CovData:
+def merge_covdata(left: CovData, right: CovData, options: MergeOptions) -> CovData:
     """
     Merge CovData information.
 
@@ -202,7 +200,7 @@ def insert_file_coverage(
 def merge_file(
     left: FileCoverage,
     right: FileCoverage,
-    options: MergeOptions = DEFAULT_MERGE_OPTIONS,
+    options: MergeOptions,
 ) -> FileCoverage:
     """
     Merge FileCoverage information.
@@ -234,7 +232,7 @@ def insert_line_coverage(
 def merge_line(
     left: LineCoverage,
     right: LineCoverage,
-    options: MergeOptions = DEFAULT_MERGE_OPTIONS,
+    options: MergeOptions,
 ) -> LineCoverage:
     """
     Merge LineCoverage information.
@@ -273,7 +271,7 @@ def insert_function_coverage(
 def merge_function(
     left: FunctionCoverage,
     right: FunctionCoverage,
-    options: MergeOptions = DEFAULT_MERGE_OPTIONS,
+    options: MergeOptions,
 ) -> FunctionCoverage:
     """
     Merge FunctionCoverage information.
@@ -364,7 +362,7 @@ def insert_branch_coverage(
 def merge_branch(
     left: BranchCoverage,
     right: BranchCoverage,
-    options: MergeOptions = DEFAULT_MERGE_OPTIONS,
+    options: MergeOptions,
 ) -> BranchCoverage:
     """
     Merge BranchCoverage information.
@@ -391,7 +389,7 @@ def insert_call_coverage(
 def merge_call(
     left: CallCoverage,
     right: CallCoverage,
-    options: MergeOptions = DEFAULT_MERGE_OPTIONS,
+    options: MergeOptions,
 ) -> BranchCoverage:
     """
     Merge CallCoverage information.
@@ -409,14 +407,14 @@ def insert_decision_coverage(
     options: MergeOptions = DEFAULT_MERGE_OPTIONS,
 ) -> Optional[DecisionCoverage]:
     """Insert DecisionCoverage into LineCoverage."""
-    target.decision = merge_decision(target.decision, decision)
+    target.decision = merge_decision(target.decision, decision, options)
     return target.decision
 
 
 def merge_decision(
     left: Optional[DecisionCoverage],
     right: Optional[DecisionCoverage],
-    options: MergeOptions = DEFAULT_MERGE_OPTIONS,
+    options: MergeOptions,
 ) -> Optional[DecisionCoverage]:
     """
     Merge DecisionCoverage information.


### PR DESCRIPTION
Use option `--merge-mode-functions` also when merging coverage data. The default value for the merge option is removed from the functions making it now a required argument.

Closes #841