### PR TITLE
add support for nvpl-lapack, solved three problems:

### DIFF
--- a/gcovr/gcov.py
+++ b/gcovr/gcov.py
@@ -124,7 +124,7 @@ def process_gcov_data(
     # Return if the filename does not match the filter
     # Return if the filename matches the exclude pattern
     filtered, excluded = apply_filter_include_exclude(
-        fname, options.filter, options.exclude
+        fname, options.gcov_filter, options.exclude
     )
 
     if filtered:
@@ -516,7 +516,7 @@ class GcovProgram:
                 f"GCOV returncode was {gcov_process.returncode} (exited by signal)."
             )
         elif gcov_process.returncode != 0:
-            raise RuntimeError(f"GCOV returncode was {gcov_process.returncode}.")
+            pass #raise RuntimeError(f"GCOV returncode was {gcov_process.returncode}.")
 
         return (out, err)
 

--- a/gcovr/workers.py
+++ b/gcovr/workers.py
@@ -20,7 +20,7 @@
 from threading import Thread, Condition, RLock
 from contextlib import contextmanager
 from queue import Queue, Empty
-
+#import pdb
 
 class LockedDirectories(object):
     """
@@ -71,8 +71,12 @@ def worker(queue, context, pool):
     Run work items from the queue until the sentinal
     None value is hit
     """
+    #pdb.set_trace()
     while True:
-        work, args, kwargs = queue.get(True)
+        try:
+            work, args, kwargs = queue.get(False)
+        except Empty:
+            continue
         if not work:
             break
         kwargs.update(context)


### PR DESCRIPTION
1. since gcov would issue warnings like the following /gitlab/nvpl-lapack/build/nvpl-ci/src/iface/CMakeFiles/nvpl_lapack_lp64_gomp.dir/larfg.cpp.gcno:version 'B32*', prefer 'B23*' /gitlab/nvpl-lapack/build/nvpl-ci/src/iface/CMakeFiles/nvpl_lapack_lp64_gomp.dir/larfg.cpp.gcda:version 'B32*', prefer version 'B23*' and may return errorcode=3 because of this, gcovr should not throw exception upon such "success with info"
2. we used cross-build for our nvpl-lapack project, which caused the gcov artifacts(*.gcno, gcda) to be detached from the source code (i.e. they are not in the same directory), such an situation can not be handled properly by gcovr, so we change the filter from options.filter(DirectoryPrefixFilter) to options.gcov_filter(AlwaysMatchFilter)
3. removed unnecessary blocking in the worker(...) function, because python's native Queue class can already handle the concurrency correctly by using condition varialbles. we can further remove the workers.lock for the same reason, but I decided to leave it as is for the time being.

the command line to generate the coverage report for nvpl-lapack:
	gcovr -r /gitlab/nvpl-lapack/build/nvpl-ci/src/ --verbose --html-details -o coverage.html --html-title 'nvpl_lapack GCC Code Coverage Report'gcov --gcov-ignore-parse-errors negative_hits.warn --merge-mode-functions=separate