### PR TITLE
Add tagging to pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -110,6 +110,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - name: fetch all tags  # need to prevent creation of an existing tag
+        run: |
+          git fetch --force --tags --depth=1
       - name: Apply new tag if version is bumped
         run: |
           set -e

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,3 +100,36 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           python -m nox --session upload_wheel
+
+  tagging:
+    runs-on: ubuntu-20.04
+    needs: deploy
+    permissions:
+      contents: write  # Needed for pushing the tag
+    if: ${{ success() && (github.event.ref == 'refs/heads/main') }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Apply new tag if version is bumped
+        run: |
+          set -e
+          
+          # Set git user info
+          git config --global user.email "noreply@gcovr.com"
+          git config --global user.name "gcovr authors"
+
+          # Get the version
+          Version="$(sed -n 's/__version__.*"\(.*\)"/\1/ p' gcovr/version.py)"
+
+          # Try to create the tag and print the output. It's only pushed if it's a real release
+          git tag -a "$Version" -m "$Version ($(date -I))"
+          git tag --list -n "$Version"
+          
+          # Check if it is a new release
+          VersionPostfix="$(echo "$Version" | sed -n 's/^[0-9]*\.[0-9]*// p')"
+          if [ -z "$VersionPostfix" ]; then
+            echo "New version bumped"
+            git push origin "refs/tags/$Version"
+          else
+            echo "Skip pushing tag for development build"
+          fi

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,8 @@ Documentation:
 
 Internal changes:
 
-- Improve Dockerfile for faster rebuilds by using cache. (:issue:`878`) 
+- Improve Dockerfile for faster rebuilds by using cache. (:issue:`878`)
+- Add pipeline job to apply tag if new version is bumped. (:issue:`879`)
 
 7.0 (25 January 2024)
 ---------------------


### PR DESCRIPTION
Add pipeline job to apply tag if new version is bumped to main branch.
A tag is always created but only pushed if there is no suffix after the version number.