### PR TITLE
Update version of pipeline actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
     env:
       FORCE_COLOR: "1"
       PYTHON_VERSION: "3.8"
-      CC: "gcc-8"
+      CC: "gcc-11"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ on:
 jobs:
 
   release-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     continue-on-error: ${{ startsWith(github.event.ref,'refs/heads/') }}
 
@@ -29,7 +29,7 @@ jobs:
           admin/release_checklist $EXTRA_CHECKLIST_ARGS 7.0+main
 
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: release-check
 
     env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,11 +40,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Cache pip
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           # This path is specific to Ubuntu
           path: ~/.cache/pip

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
     continue-on-error: ${{ startsWith(github.event.ref,'refs/heads/') }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: fetch all tags  # need annotated tags for release checklist
         run: |
           git fetch --force --tags --depth=1
@@ -38,7 +38,7 @@ jobs:
       CC: "gcc-8"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,11 +150,11 @@ jobs:
             libxml2-utils
           sudo apt-get clean
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Cache pip
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           # This path is specific to Ubuntu
           path: ~/.cache/pip
@@ -180,7 +180,7 @@ jobs:
           path: gcovr/tests/diff.zip
       - name: Upload coverage to Codecov
         if: ${{ env.USE_COVERAGE == 'true' }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           env_vars: OS,PYTHON
@@ -241,7 +241,7 @@ jobs:
           python3 -m nox --non-interactive --session "docker_run_compiler(${{ matrix.gcc }})" -- --session tests
       - name: Upload coverage to Codecov
         if: ${{ env.USE_COVERAGE == 'true' }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           env_vars: OS,PYTHON
@@ -251,7 +251,7 @@ jobs:
           verbose: true
       - name: Upload LCOV coverage to Codecov
         if: ${{ matrix.gcc == 'clang-13' }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           env_vars: OS,PYTHON

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       PR_MILESTONE: "${{ github.event.pull_request.milestone.number }}"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Check if PR is assigned to a milestone
         if: ${{ github.event_name == 'pull_request' }}
         run: |
@@ -37,7 +37,7 @@ jobs:
       CHANGELOG_ISSUE: ":issue:`${{ github.event.pull_request.number }}`"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Check if PR is mentioned in changelog
         if: ${{ always() }}
         run: |
@@ -113,7 +113,7 @@ jobs:
             python-version: '3.11'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup environment
         run: |
           # Enable coverage for specific target configurations
@@ -229,7 +229,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python3 -m pip install nox
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build Docker
         run: |
           python3 -m nox --non-interactive --session "docker_build_compiler(${{ matrix.gcc }})"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -185,6 +185,8 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           env_vars: OS,PYTHON
           fail_ci_if_error: true
+          disable_search: true
+          plugins: pycoverage
           files: ./coverage.xml
           name: ${{ matrix.os }}-${{ matrix.gcc }}
           verbose: true
@@ -246,16 +248,19 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           env_vars: OS,PYTHON
           fail_ci_if_error: true
+          disable_search: true
+          plugins: pycoverage
           files: ./coverage.xml
           name: docker-${{ matrix.gcc }}
           verbose: true
       - name: Upload LCOV coverage to Codecov
-        if: ${{ matrix.gcc == 'clang-13' }}
+        if: ${{ (matrix.gcc == 'gcc-5') || (matrix.gcc == 'clang-10') }}
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           env_vars: OS,PYTHON
           fail_ci_if_error: true
+          disable_search: true
           files: ./gcovr/tests/nested/reference/${{ matrix.gcc }}/coverage.lcov
           name: docker-${{ matrix.gcc }}-lcov
           verbose: true

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Documentation:
 Internal changes:
 
 - Improve Dockerfile for faster rebuilds by using cache. (:issue:`878`) 
+- Fix deprecation warnings from GitHub actions. (:issue:`880`) 
 
 7.0 (25 January 2024)
 ---------------------


### PR DESCRIPTION
Fix the warnings in the pipeline:

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```