### PR TITLE
Use coloured logging in a TTY

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,8 @@ Breaking changes:
 
 New features and notable changes:
 
+- Add support for colored logging. (:issue:`887`)
+
 Bug fixes and small improvements:
 
 - Add support for files with more than 9999 lines. (:issue:`883`, fixes :issue:`882``) 

--- a/gcovr/__main__.py
+++ b/gcovr/__main__.py
@@ -36,7 +36,7 @@ from .utils import (
     AlwaysMatchFilter,
     DirectoryPrefixFilter,
     configure_logging,
-    switch_to_logging_format_with_threads,
+    update_logging_formatter,
 )
 from .version import __version__
 from .coverage import CovData, SummarizedStats
@@ -195,9 +195,9 @@ def main(args=None):
                 parse_config_file(cfg_file, filename=cfg_name)
             )
     options = merge_options_and_set_defaults([cfg_options, cli_options.__dict__])
+
     # Reconfigure the logging.
-    if options.gcov_parallel > 1:
-        switch_to_logging_format_with_threads()
+    update_logging_formatter(options)
 
     if options.verbose:
         LOGGER.setLevel(logging.DEBUG)

--- a/gcovr/configuration.py
+++ b/gcovr/configuration.py
@@ -386,6 +386,26 @@ GCOVR_CONFIG_OPTIONS = [
         action="store_true",
     ),
     GcovrConfigOption(
+        "no_color",
+        ["--no-color"],
+        help=(
+            "Turn off colored logging."
+            " Is also set if environment variable NO_COLOR is present."
+            " Ignored if --force-color is used."
+        ),
+        action="store_true",
+    ),
+    GcovrConfigOption(
+        "force_color",
+        ["--force-color"],
+        help=(
+            "Force colored logging, this is the default for a terminal."
+            " Is also set if environment variable FORCE_COLOR is present."
+            " Has presedence over --no-color."
+        ),
+        action="store_true",
+    ),
+    GcovrConfigOption(
         "root",
         ["-r", "--root"],
         help=(

--- a/gcovr/utils.py
+++ b/gcovr/utils.py
@@ -28,12 +28,14 @@ import platform
 import re
 import sys
 from contextlib import contextmanager
+from colorlog import ColoredFormatter
+from gcovr.options import Options
 
 LOGGER = logging.getLogger("gcovr")
 
 
-LOG_FORMAT = "(%(levelname)s) %(message)s"
-LOG_FORMAT_THREADS = "(%(levelname)s) - %(threadName)s - %(message)s"
+LOG_FORMAT = "%(log_color)s(%(levelname)s) %(message)s"
+LOG_FORMAT_THREADS = "%(log_color)s(%(levelname)s) - %(threadName)s - %(message)s"
 
 
 class LoopChecker(object):
@@ -278,9 +280,38 @@ class DirectoryPrefixFilter(Filter):
         return super().match(path)
 
 
-def configure_logging() -> None:
+def __colored_formatter(options: Options) -> ColoredFormatter:
+    if options is not None:
+        log_format = LOG_FORMAT_THREADS if options.gcov_parallel > 1 else LOG_FORMAT
+        force_color = getattr(options, "force_color", False)
+        no_color = getattr(options, "no_color", False)
+    else:
+        log_format = LOG_FORMAT
+        force_color = False
+        no_color = False
+
+    return ColoredFormatter(
+        log_format,
+        datefmt=None,
+        reset=True,
+        log_colors={
+            "DEBUG": "cyan",
+            "INFO": "blue",
+            "WARNING": "yellow",
+            "ERROR": "red",
+            "CRITICAL": "red,bg_white",
+        },
+        secondary_log_colors={},
+        style="%",
+        force_color=force_color,
+        no_color=no_color,
+        stream=sys.stderr,
+    )
+
+
+def configure_logging(options: Options = None) -> None:
     stream_handler = logging.StreamHandler(sys.stderr)
-    stream_handler.setFormatter(logging.Formatter(LOG_FORMAT))
+    stream_handler.setFormatter(__colored_formatter(options))
 
     logging.basicConfig(
         handlers=[stream_handler],
@@ -295,13 +326,13 @@ def configure_logging() -> None:
     sys.excepthook = exception_hook
 
 
-def switch_to_logging_format_with_threads() -> None:
+def update_logging_formatter(options: Options) -> None:
     # The one and only LOGGER was configured from ourselve.
     if len(logging.getLogger().handlers) == 1 and (
         logging.getLogger().handlers[0].formatter._fmt == LOG_FORMAT
     ):
         logging.getLogger().handlers[0].setFormatter(
-            logging.Formatter(LOG_FORMAT_THREADS)
+            __colored_formatter(options)
         )
 
 

--- a/gcovr/utils.py
+++ b/gcovr/utils.py
@@ -331,9 +331,7 @@ def update_logging_formatter(options: Options) -> None:
     if len(logging.getLogger().handlers) == 1 and (
         logging.getLogger().handlers[0].formatter._fmt == LOG_FORMAT
     ):
-        logging.getLogger().handlers[0].setFormatter(
-            __colored_formatter(options)
-        )
+        logging.getLogger().handlers[0].setFormatter(__colored_formatter(options))
 
 
 @contextmanager

--- a/noxfile.py
+++ b/noxfile.py
@@ -621,6 +621,8 @@ def docker_run_compiler(session: nox.Session, version: str) -> None:
         "-e",
         "USE_COVERAGE",
         "-e",
+        "FORCE_COLOR",
+        "-e",
         f"HOST_OS={platform.system()}",
         "-v",
         f"{os.getcwd()}:/gcovr",

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     platforms=["any"],
     python_requires=">=3.8",
     packages=find_packages(include=["gcovr*"], exclude=["gcovr.tests"]),
-    install_requires=["jinja2", "lxml", "pygments>=2.13.0"],
+    install_requires=["jinja2", "lxml", "pygments>=2.13.0", "colorlog"],
     package_data={
         "gcovr": [
             "formats/html/*/*.css",


### PR DESCRIPTION
Update the logging to use a coloured output if running in a TTY or the user forced it by setting `--force-color` in the CLI or by defining the environment variable `FORCE_COLOR` as described in http://force-color.org.
In the pipeline the color is forced (introduced for nox by #698). If a test is failing we get now a coloured output of gcovr execution.