### PR TITLE
Improve coverage and generate report locally

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ Internal changes:
 - Improve Dockerfile for faster rebuilds by using cache. (:issue:`878`)
 - Fix deprecation warnings from GitHub actions. (:issue:`880`) 
 - Add pipeline job to apply tag if new version is bumped. (:issue:`879`)
+- Improve test coverage and generate coverage report if executed in local environment. (:issue:`890`) 
 
 7.0 (25 January 2024)
 ---------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,7 +29,7 @@ Internal changes:
 - Improve Dockerfile for faster rebuilds by using cache. (:issue:`878`)
 - Fix deprecation warnings from GitHub actions. (:issue:`880`) 
 - Add pipeline job to apply tag if new version is bumped. (:issue:`879`)
-- Improve test coverage and generate coverage report if executed in local environment. (:issue:`890`) 
+- Improve test coverage and generate coverage report if executed in local environment. (:issue:`891`) 
 
 7.0 (25 January 2024)
 ---------------------

--- a/gcovr/__main__.py
+++ b/gcovr/__main__.py
@@ -110,7 +110,7 @@ def fail_under(
 
     function_nok = False
     if threshold_function > 0.0:
-        # Allow data with no decisions.
+        # Allow data with no functions.
         percent_function = stats.function.percent_or(100.0)
         if percent_function < threshold_function:
             function_nok = True
@@ -329,7 +329,7 @@ def main(args=None):
         # but is used to turn absolute paths into relative paths
         options.root_filter = re.compile("^" + re.escape(options.root_dir + os.sep))
 
-        if options.gcov_exclude_dirs is not None:
+        if options.gcov_exclude_dirs:
             options.gcov_exclude_dirs = [
                 f.build_filter() for f in options.gcov_exclude_dirs
             ]

--- a/gcovr/__main__.py
+++ b/gcovr/__main__.py
@@ -324,38 +324,41 @@ def main(args=None):
     #
     # Setup filters
     #
+    try:
+        # The root filter isn't technically a filter,
+        # but is used to turn absolute paths into relative paths
+        options.root_filter = re.compile("^" + re.escape(options.root_dir + os.sep))
 
-    # The root filter isn't technically a filter,
-    # but is used to turn absolute paths into relative paths
-    options.root_filter = re.compile("^" + re.escape(options.root_dir + os.sep))
+        if options.gcov_exclude_dirs is not None:
+            options.gcov_exclude_dirs = [
+                f.build_filter() for f in options.gcov_exclude_dirs
+            ]
 
-    if options.gcov_exclude_dirs is not None:
-        options.gcov_exclude_dirs = [
-            f.build_filter() for f in options.gcov_exclude_dirs
-        ]
+        options.exclude = [f.build_filter() for f in options.exclude]
+        options.filter = [f.build_filter() for f in options.filter]
+        if not options.filter:
+            options.filter = [DirectoryPrefixFilter(options.root_dir)]
 
-    options.exclude = [f.build_filter() for f in options.exclude]
-    options.filter = [f.build_filter() for f in options.filter]
-    if not options.filter:
-        options.filter = [DirectoryPrefixFilter(options.root_dir)]
+        options.gcov_exclude = [f.build_filter() for f in options.gcov_exclude]
+        options.gcov_filter = [f.build_filter() for f in options.gcov_filter]
+        if not options.gcov_filter:
+            options.gcov_filter = [AlwaysMatchFilter()]
 
-    options.gcov_exclude = [f.build_filter() for f in options.gcov_exclude]
-    options.gcov_filter = [f.build_filter() for f in options.gcov_filter]
-    if not options.gcov_filter:
-        options.gcov_filter = [AlwaysMatchFilter()]
-
-    # Output the filters for debugging
-    for name, filters in [
-        ("--root", [options.root_filter]),
-        ("--filter", options.filter),
-        ("--exclude", options.exclude),
-        ("--gcov-filter", options.gcov_filter),
-        ("--gcov-exclude", options.gcov_exclude),
-        ("--gcov-exclude-directories", options.gcov_exclude_dirs),
-    ]:
-        LOGGER.debug(f"Filters for {name}: ({len(filters)})")
-        for f in filters:
-            LOGGER.debug(f" - {f}")
+        # Output the filters for debugging
+        for name, filters in [
+            ("--root", [options.root_filter]),
+            ("--filter", options.filter),
+            ("--exclude", options.exclude),
+            ("--gcov-filter", options.gcov_filter),
+            ("--gcov-exclude", options.gcov_exclude),
+            ("--gcov-exclude-directories", options.gcov_exclude_dirs),
+        ]:
+            LOGGER.debug(f"Filters for {name}: ({len(filters)})")
+            for f in filters:
+                LOGGER.debug(f" - {f}")
+    except re.error as e:
+        LOGGER.error(f"Error setting up filter '{e.pattern}': {e}")
+        sys.exit(EXIT_CMDLINE_ERROR)
 
     if options.exclude_lines_by_pattern:
         try:

--- a/gcovr/tests/gcov-exclude/Makefile
+++ b/gcovr/tests/gcov-exclude/Makefile
@@ -1,0 +1,31 @@
+CFLAGS= -fprofile-arcs -ftest-coverage -fPIC
+
+all:
+	$(CXX) $(CFLAGS) -c subdir/A/file1.cpp -o subdir/A/file1.o
+	$(CXX) $(CFLAGS) -c subdir/A/File2.cpp -o subdir/A/File2.o
+	$(CXX) $(CFLAGS) -c subdir/A/file3.cpp -o subdir/A/file3.o
+	$(CXX) $(CFLAGS) -c subdir/A/File4.cpp -o subdir/A/File4.o
+	$(CXX) $(CFLAGS) -c subdir/A/file7.cpp -o subdir/A/file7.o
+	$(CXX) $(CFLAGS) -c subdir/A/C/file5.cpp -o subdir/A/C/file5.o
+	$(CXX) $(CFLAGS) -c subdir/A/C/D/File6.cpp -o subdir/A/C/D/File6.o
+	$(CXX) $(CFLAGS) -c subdir/B/main.cpp -o subdir/B/main.o
+	$(CXX) $(CFLAGS) subdir/A/file1.o subdir/A/File2.o subdir/A/file3.o subdir/A/File4.o subdir/A/C/file5.o subdir/A/C/D/File6.o subdir/A/file7.o subdir/B/main.o -o subdir/testcase
+
+run: json lcov
+
+coverage.json:
+	./subdir/testcase
+	# First exclude file pattern is for GCC, second one for clang output filenames
+	$(GCOVR) -r subdir --verbose --gcov-exclude-directories '.*/A/C(?:/.*)?' --gcov-filter '.*' --gcov-exclude 'subdir#A#[Ff]ile.\.cpp\.gcov' --gcov-exclude '[Ff]ile.\.cpp##.*' --json-pretty --json $@
+
+json: coverage.json
+	echo Dummy
+
+lcov: coverage.json
+	$(GCOVR) -r subdir -a $< --lcov coverage.lcov
+
+clean:
+	rm -f ./subdir/testcase
+	rm -f *.gc* */*.gc* */*/*.gc* */*/*/*.gc* */*/*/*/*.gc*
+	rm -f *.o */*.o */*/*.o */*/*/*.o */*/*/*/*.o
+	rm -f coverage*.*

--- a/gcovr/tests/gcov-exclude/reference/clang-10/coverage.lcov
+++ b/gcovr/tests/gcov-exclude/reference/clang-10/coverage.lcov
@@ -1,0 +1,20 @@
+TN:GCOVR report
+SF:gcovr/tests/gcov-exclude/subdir/B/main.cpp
+VER:8051e1c52cab743a41a6bbe9822a917a
+FN:12,main
+FNDA:1,main
+FNF:1
+FNH:1
+BRF:0
+BRH:0
+DA:12,1,2a787a1309f19379bb0e3d8434d2a18d
+DA:13,1,c18608b3fe9a00042c41d97d382d1e07
+DA:14,1,a16b1758a01395f320d0ffe89a85defc
+DA:15,1,86e212ad9e6f4e2f6aeed5ebd8f2d4b2
+DA:16,1,50ff38672dfb3881235944c1cbc313ff
+DA:17,1,537738ff9ea76bce1fbf48f1f7ec6a56
+DA:18,1,1e069fab499b18f31b84dea8d0b9f13d
+DA:20,1,c26ba559a5f34d46a49fafed87946fb7
+LH:8
+LF:8
+end_of_record

--- a/gcovr/tests/gcov-exclude/reference/clang-10/coveralls.json
+++ b/gcovr/tests/gcov-exclude/reference/clang-10/coveralls.json
@@ -1,0 +1,141 @@
+{
+    "run_at": "",
+    "service_job_id": "id",
+    "service_name": "gcovr-test-suite",
+    "service_number": "number",
+    "service_pull_request": "pr",
+    "source_files": [
+        {
+            "coverage": [
+                1,
+                null,
+                1,
+                0,
+                null,
+                1,
+                null,
+                1
+            ],
+            "name": "A/C/D/File6.cpp",
+            "source_digest": "51c81752202f160b25ffc07fb9134018"
+        },
+        {
+            "coverage": [
+                1,
+                null,
+                1,
+                0,
+                null,
+                1,
+                null,
+                1
+            ],
+            "name": "A/C/file5.cpp",
+            "source_digest": "994904d7cb6f33c4235bc1f132c029f9"
+        },
+        {
+            "coverage": [
+                1,
+                null,
+                1,
+                1,
+                1,
+                null,
+                null,
+                0,
+                null,
+                0,
+                0,
+                null
+            ],
+            "name": "A/File2.cpp",
+            "source_digest": "44683de2597fa27a9410e0f65f71fde0"
+        },
+        {
+            "coverage": [
+                1,
+                null,
+                1,
+                1,
+                null,
+                0,
+                null,
+                1
+            ],
+            "name": "A/File4.cpp",
+            "source_digest": "7451828cfb58f0fefc6e5fbf44d9a6f4"
+        },
+        {
+            "coverage": [
+                1,
+                null,
+                1,
+                0,
+                null,
+                1,
+                null,
+                1
+            ],
+            "name": "A/file1.cpp",
+            "source_digest": "cf6b72cbb3c9c004a97684f1495332fd"
+        },
+        {
+            "coverage": [
+                1,
+                null,
+                1,
+                1,
+                1,
+                null,
+                null,
+                0,
+                null,
+                0,
+                0,
+                0,
+                null,
+                0,
+                0
+            ],
+            "name": "A/file3.cpp",
+            "source_digest": "2676d9d3e59bfb8cf028df06bf1cc9fe"
+        },
+        {
+            "coverage": [
+                0,
+                null,
+                0,
+                null
+            ],
+            "name": "A/file7.cpp",
+            "source_digest": "cbd3974ad5ed983ce0a47c7a7d8b5725"
+        },
+        {
+            "coverage": [
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                null,
+                1,
+                null
+            ],
+            "name": "B/main.cpp",
+            "source_digest": "8051e1c52cab743a41a6bbe9822a917a"
+        }
+    ]
+}

--- a/gcovr/tests/gcov-exclude/reference/gcc-5/coverage.lcov
+++ b/gcovr/tests/gcov-exclude/reference/gcc-5/coverage.lcov
@@ -1,0 +1,25 @@
+TN:GCOVR report
+SF:gcovr/tests/gcov-exclude/subdir/B/main.cpp
+VER:8051e1c52cab743a41a6bbe9822a917a
+FN:12,main
+FNDA:1,main
+FNF:1
+FNH:1
+BRDA:21,3,0,1
+BRDA:21,3,1,-
+BRDA:21,4,2,1
+BRDA:21,4,3,-
+BRF:4
+BRH:2
+DA:12,1,2a787a1309f19379bb0e3d8434d2a18d
+DA:13,1,c18608b3fe9a00042c41d97d382d1e07
+DA:14,1,a16b1758a01395f320d0ffe89a85defc
+DA:15,1,86e212ad9e6f4e2f6aeed5ebd8f2d4b2
+DA:16,1,50ff38672dfb3881235944c1cbc313ff
+DA:17,1,537738ff9ea76bce1fbf48f1f7ec6a56
+DA:18,1,1e069fab499b18f31b84dea8d0b9f13d
+DA:20,1,c26ba559a5f34d46a49fafed87946fb7
+DA:21,4,cbb184dd8e05c9709e5dcaedaa0495cf
+LH:9
+LF:9
+end_of_record

--- a/gcovr/tests/gcov-exclude/reference/gcc-5/coveralls.json
+++ b/gcovr/tests/gcov-exclude/reference/gcc-5/coveralls.json
@@ -1,0 +1,141 @@
+{
+    "run_at": "",
+    "service_job_id": "id",
+    "service_name": "gcovr-test-suite",
+    "service_number": "number",
+    "service_pull_request": "pr",
+    "source_files": [
+        {
+            "coverage": [
+                1,
+                null,
+                1,
+                0,
+                null,
+                1,
+                null,
+                null
+            ],
+            "name": "A/C/D/File6.cpp",
+            "source_digest": "51c81752202f160b25ffc07fb9134018"
+        },
+        {
+            "coverage": [
+                1,
+                null,
+                1,
+                0,
+                null,
+                1,
+                null,
+                null
+            ],
+            "name": "A/C/file5.cpp",
+            "source_digest": "994904d7cb6f33c4235bc1f132c029f9"
+        },
+        {
+            "coverage": [
+                1,
+                null,
+                1,
+                1,
+                1,
+                null,
+                null,
+                0,
+                null,
+                0,
+                0,
+                null
+            ],
+            "name": "A/File2.cpp",
+            "source_digest": "44683de2597fa27a9410e0f65f71fde0"
+        },
+        {
+            "coverage": [
+                1,
+                null,
+                1,
+                1,
+                null,
+                0,
+                null,
+                null
+            ],
+            "name": "A/File4.cpp",
+            "source_digest": "7451828cfb58f0fefc6e5fbf44d9a6f4"
+        },
+        {
+            "coverage": [
+                1,
+                null,
+                1,
+                0,
+                null,
+                1,
+                null,
+                null
+            ],
+            "name": "A/file1.cpp",
+            "source_digest": "cf6b72cbb3c9c004a97684f1495332fd"
+        },
+        {
+            "coverage": [
+                1,
+                null,
+                1,
+                1,
+                1,
+                null,
+                null,
+                0,
+                null,
+                0,
+                0,
+                0,
+                null,
+                0,
+                null
+            ],
+            "name": "A/file3.cpp",
+            "source_digest": "2676d9d3e59bfb8cf028df06bf1cc9fe"
+        },
+        {
+            "coverage": [
+                0,
+                null,
+                0,
+                null
+            ],
+            "name": "A/file7.cpp",
+            "source_digest": "cbd3974ad5ed983ce0a47c7a7d8b5725"
+        },
+        {
+            "coverage": [
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                null,
+                1,
+                4
+            ],
+            "name": "B/main.cpp",
+            "source_digest": "8051e1c52cab743a41a6bbe9822a917a"
+        }
+    ]
+}

--- a/gcovr/tests/gcov-exclude/reference/gcc-8/coverage.lcov
+++ b/gcovr/tests/gcov-exclude/reference/gcc-8/coverage.lcov
@@ -1,0 +1,20 @@
+TN:GCOVR report
+SF:gcovr/tests/gcov-exclude/subdir/B/main.cpp
+VER:8051e1c52cab743a41a6bbe9822a917a
+FN:12,main
+FNDA:1,main
+FNF:1
+FNH:1
+BRF:0
+BRH:0
+DA:12,1,2a787a1309f19379bb0e3d8434d2a18d
+DA:13,1,c18608b3fe9a00042c41d97d382d1e07
+DA:14,1,a16b1758a01395f320d0ffe89a85defc
+DA:15,1,86e212ad9e6f4e2f6aeed5ebd8f2d4b2
+DA:16,1,50ff38672dfb3881235944c1cbc313ff
+DA:17,1,537738ff9ea76bce1fbf48f1f7ec6a56
+DA:18,1,1e069fab499b18f31b84dea8d0b9f13d
+DA:20,1,c26ba559a5f34d46a49fafed87946fb7
+LH:8
+LF:8
+end_of_record

--- a/gcovr/tests/gcov-exclude/subdir/A/C/D/File6.cpp
+++ b/gcovr/tests/gcov-exclude/subdir/A/C/D/File6.cpp
@@ -1,0 +1,8 @@
+int foo6(int param)
+{
+  if (param) {
+     return 1;
+  } else {
+     return 0;
+  }
+}

--- a/gcovr/tests/gcov-exclude/subdir/A/C/file5.cpp
+++ b/gcovr/tests/gcov-exclude/subdir/A/C/file5.cpp
@@ -1,0 +1,8 @@
+int foo5(int param)
+{
+  if (param) {
+     return 1;
+  } else {
+     return 0;
+  }
+}

--- a/gcovr/tests/gcov-exclude/subdir/A/File2.cpp
+++ b/gcovr/tests/gcov-exclude/subdir/A/File2.cpp
@@ -1,0 +1,12 @@
+int bar()
+{
+int x=1;
+int y=2;
+return x+y;
+}
+
+int bar_()
+{
+int x=1;
+return 2*x;
+}

--- a/gcovr/tests/gcov-exclude/subdir/A/File4.cpp
+++ b/gcovr/tests/gcov-exclude/subdir/A/File4.cpp
@@ -1,0 +1,8 @@
+int foobar(int param)
+{
+  if (param) {
+     return 1;
+  } else {
+     return 0;
+  }
+}

--- a/gcovr/tests/gcov-exclude/subdir/A/file1.cpp
+++ b/gcovr/tests/gcov-exclude/subdir/A/file1.cpp
@@ -1,0 +1,8 @@
+int foo(int param)
+{
+  if (param) {
+     return 1;
+  } else {
+     return 0;
+  }
+}

--- a/gcovr/tests/gcov-exclude/subdir/A/file3.cpp
+++ b/gcovr/tests/gcov-exclude/subdir/A/file3.cpp
@@ -1,0 +1,15 @@
+int fourbar()
+{
+int x=1;
+int y=2;
+return x+y;
+}
+
+int fourbar_()
+{
+int x=1;
+if (x)
+    return 2*x;     /* This is a really long comment that confirms whether gcovr colors lines that exceed normal expectations. */
+else
+    return x;
+}

--- a/gcovr/tests/gcov-exclude/subdir/A/file7.cpp
+++ b/gcovr/tests/gcov-exclude/subdir/A/file7.cpp
@@ -1,0 +1,4 @@
+int uncovered()
+{
+return 0;
+}

--- a/gcovr/tests/gcov-exclude/subdir/B/main.cpp
+++ b/gcovr/tests/gcov-exclude/subdir/B/main.cpp
@@ -1,0 +1,21 @@
+#include <iostream>
+
+extern int foo(int param);
+extern int foobar(int param);
+extern int bar();
+extern int fourbar();
+extern int foo5(int param);
+extern int foo6(int param);
+extern int uncovered();
+
+
+int main(int argc, char* argv[]) {
+  foo(0);
+  foobar(1);
+  bar();
+  fourbar();
+  foo5(0);
+  foo6(0);
+
+  return 0;
+}

--- a/gcovr/tests/simple1/Makefile
+++ b/gcovr/tests/simple1/Makefile
@@ -20,12 +20,12 @@ txt:
 	grep -F "failed minimum decision coverage" fail_under.stderr
 	$(GCOVR) --fail-under-function 100 --print-summary 2>fail_under.stderr; test $$? -eq 16 || ( cat fail_under.stderr & exit 1 )
 	grep -F "failed minimum function coverage" fail_under.stderr
-	$(GCOVR) --fail-under-line 80.1 --fail-under-branch 50.1 --decision --fail-under-decision 50.1 --fail-under-function 100 --print-summary 2>fail_under.stderr; test $$? -eq 30 || ( cat fail_under.stderr & exit 1 )
+	$(GCOVR) --fail-under-line 80.1 --fail-under-branch 50.1 --decision --fail-under-decision 50.1 --fail-under-function 66.8 --print-summary 2>fail_under.stderr; test $$? -eq 30 || ( cat fail_under.stderr & exit 1 )
 	grep -F "failed minimum line coverage" fail_under.stderr
 	grep -F "failed minimum branch coverage" fail_under.stderr
 	grep -F "failed minimum decision coverage" fail_under.stderr
 	grep -F "failed minimum function coverage" fail_under.stderr
-	$(GCOVR) --fail-under-line $(FAIL_UNDER_LINE) --fail-under-branch 49.9 --print-summary 2>fail_under.stderr; test $$? -eq 0 || ( cat fail_under.stderr & exit 1 )
+	$(GCOVR) --fail-under-line $(FAIL_UNDER_LINE) --fail-under-branch 50.0 --decision --fail-under-decision 50.0 --fail-under-function 66.7 --print-summary 2>fail_under.stderr; test $$? -eq 0 || ( cat fail_under.stderr & exit 1 )
 	grep -F "failed minimum line coverage" fail_under.stderr; test $$? -eq 1
 	grep -F "failed minimum branch coverage" fail_under.stderr; test $$? -eq 1
 	grep -F "failed minimum decision coverage" fail_under.stderr; test $$? -eq 1

--- a/gcovr/tests/test_args.py
+++ b/gcovr/tests/test_args.py
@@ -368,7 +368,7 @@ def test_filter_backslashes_are_detected(caplog):
     message = c.record_tuples[3]
     assert message[1] == logging.ERROR
     assert message[2].startswith(
-        "Error setting up filter 'C:\\\\foo\\moo': bad escape \m at position 7"
+        "Error setting up filter 'C:\\\\foo\\moo': bad escape \\m at position 7"
     )
 
 

--- a/gcovr/tests/test_args.py
+++ b/gcovr/tests/test_args.py
@@ -286,6 +286,17 @@ def test_no_output_html_nested(caplog):
     assert c.exception.code != 0
 
 
+def test_html_details_and_html_nested(caplog):
+    c = log_capture(caplog, ["--output", "x", "--html-details", "--html-nested"])
+    message = c.record_tuples[0]
+    assert message[1] == logging.ERROR
+    assert (
+        message[2]
+        == "--html-details and --html-nested can not be used together."
+    )
+    assert c.exception.code != 0
+
+
 @pytest.mark.parametrize(
     "option",
     [

--- a/gcovr/tests/test_args.py
+++ b/gcovr/tests/test_args.py
@@ -290,10 +290,7 @@ def test_html_details_and_html_nested(caplog):
     c = log_capture(caplog, ["--output", "x", "--html-details", "--html-nested"])
     message = c.record_tuples[0]
     assert message[1] == logging.ERROR
-    assert (
-        message[2]
-        == "--html-details and --html-nested can not be used together."
-    )
+    assert message[2] == "--html-details and --html-nested can not be used together."
     assert c.exception.code != 0
 
 
@@ -370,7 +367,9 @@ def test_filter_backslashes_are_detected(caplog):
     assert message[2].startswith("did you mean: C:/foo/moo")
     message = c.record_tuples[3]
     assert message[1] == logging.ERROR
-    assert message[2].startswith("Error setting up filter 'C:\\\\foo\\moo': bad escape \m at position 7")
+    assert message[2].startswith(
+        "Error setting up filter 'C:\\\\foo\\moo': bad escape \m at position 7"
+    )
 
 
 def test_html_css_not_exists(capsys):

--- a/gcovr/tests/test_args.py
+++ b/gcovr/tests/test_args.py
@@ -39,7 +39,7 @@ class CaptureObject:
         self.exception = exception
 
 
-def capture(capsys, args, other_ex=()):
+def capture(capsys, args):
     """The capture method calls the main method and captures its output/error
     streams and exit code."""
     e = None
@@ -48,8 +48,6 @@ def capture(capsys, args, other_ex=()):
         # Explicit SystemExit exception in case main() returns normally
         sys.exit(0)
     except SystemExit as exception:
-        e = exception
-    except other_ex as exception:
         e = exception
     out, err = capsys.readouterr()
     return CaptureObject(out, err, e)
@@ -62,7 +60,7 @@ class LogCaptureObject:
         self.exception = exception
 
 
-def log_capture(caplog, args, other_ex=()):
+def log_capture(caplog, args):
     """The capture method calls the main method and captures its output/error
     streams and exit code."""
     e = None
@@ -71,8 +69,6 @@ def log_capture(caplog, args, other_ex=()):
         # Explicit SystemExit exception in case main() returns normally
         sys.exit(0)
     except SystemExit as exception:
-        e = exception
-    except other_ex as exception:
         e = exception
     return LogCaptureObject(caplog.record_tuples, e)
 
@@ -351,7 +347,6 @@ def test_filter_backslashes_are_detected(caplog):
     c = log_capture(
         caplog,
         args=["--filter", r"C:\\foo\moo", "--gcov-exclude", ""],
-        other_ex=re.error,
     )
     message0 = c.record_tuples[0]
     assert message0[1] == logging.WARNING
@@ -362,7 +357,9 @@ def test_filter_backslashes_are_detected(caplog):
     message = c.record_tuples[2]
     assert message[1] == logging.WARNING
     assert message[2].startswith("did you mean: C:/foo/moo")
-    assert isinstance(c.exception, re.error) or c.exception.code == 0
+    message = c.record_tuples[3]
+    assert message[1] == logging.ERROR
+    assert message[2].startswith("Error setting up filter 'C:\\\\foo\\moo': bad escape \m at position 7")
 
 
 def test_html_css_not_exists(capsys):

--- a/gcovr/tests/test_gcovr.py
+++ b/gcovr/tests/test_gcovr.py
@@ -64,7 +64,8 @@ CC = os.path.split(env["CC"])[1]
 
 IS_MACOS = platform.system() == "Darwin"
 IS_WINDOWS = platform.system() == "Windows"
-if IS_WINDOWS:
+if IS_WINDOWS:  # pragma: no cover
+    # This is only covered on Windows
     import win32api
     import string
 
@@ -85,7 +86,7 @@ REFERENCE_DIR_VERSION_LIST = (
     if "gcc" in CC_REFERENCE
     else ["clang-10", "clang-13", "clang-14", "clang-15"]
 )
-for ref in REFERENCE_DIR_VERSION_LIST:
+for ref in REFERENCE_DIR_VERSION_LIST:  # pragma: no cover
     REFERENCE_DIRS.append(os.path.join("reference", ref))
     if platform.system() != "Linux":
         REFERENCE_DIRS.append(f"{REFERENCE_DIRS[-1]}-{platform.system()}")
@@ -237,7 +238,8 @@ def compiled(request, name):
     assert run(["make", "clean"], cwd=path)
     assert run(["make", "all"], cwd=path)
     yield name
-    if not skip_clean:
+    if not skip_clean:  # pragma: no cover
+        # In the automated tests skip_clean is always False.
         assert run(["make", "clean"], cwd=path)
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -306,9 +306,11 @@ def tests_compiler(session: nox.Session, version: str) -> None:
     args += session.posargs
     if "--" not in args:
         args += ["--"] + DEFAULT_TEST_DIRECTORIES
-    session.run("python", *args)
-    if os.environ.get("USE_COVERAGE") == "true":
-        session.run("coverage", "xml")
+
+    running_locally = os.environ.get("GITHUB_ACTIONS") is None
+    session.run("python", *args, success_codes=[0, 1] if running_locally and coverage_args else [0])
+    if coverage_args:
+        session.run("coverage", "html" if running_locally else "xml")
 
 
 @nox.session

--- a/noxfile.py
+++ b/noxfile.py
@@ -308,7 +308,11 @@ def tests_compiler(session: nox.Session, version: str) -> None:
         args += ["--"] + DEFAULT_TEST_DIRECTORIES
 
     running_locally = os.environ.get("GITHUB_ACTIONS") is None
-    session.run("python", *args, success_codes=[0, 1] if running_locally and coverage_args else [0])
+    session.run(
+        "python",
+        *args,
+        success_codes=[0, 1] if running_locally and coverage_args else [0],
+    )
     if coverage_args:
         session.run("coverage", "html" if running_locally else "xml")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -313,7 +313,7 @@ def tests_compiler(session: nox.Session, version: str) -> None:
         *args,
         success_codes=[0, 1] if running_locally and coverage_args else [0],
     )
-    
+
     if os.environ.get("USE_COVERAGE") == "true":
         session.run("coverage", "xml")
         if running_locally:

--- a/noxfile.py
+++ b/noxfile.py
@@ -313,8 +313,11 @@ def tests_compiler(session: nox.Session, version: str) -> None:
         *args,
         success_codes=[0, 1] if running_locally and coverage_args else [0],
     )
-    if coverage_args:
-        session.run("coverage", "html" if running_locally else "xml")
+    
+    if os.environ.get("USE_COVERAGE") == "true":
+        session.run("coverage", "xml")
+        if running_locally:
+            session.run("coverage", "html")
 
 
 @nox.session


### PR DESCRIPTION
If theist is executed locally and the environment `USE_COVERAGE=true`  HTML coverage report is generated after executing the tests.