### PR TITLE
Add macOS to GitHub tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,10 +161,8 @@ jobs:
         if: ${{ startsWith(matrix.os,'macos-') }}
         run: |
           brew update
-          brew install --cask docker
           brew install ninja
           brew install libxml2
-          open -a Docker
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,10 +106,18 @@ jobs:
 
           # Test minimum and maximum Python version on Windows.
           - os: windows-2019
-            gcc: gcc-8
+            gcc: gcc
             python-version: '3.8'
           - os: windows-2019
-            gcc: gcc-8
+            gcc: gcc
+            python-version: '3.11'
+
+          # Test minimum and maximum Python version on Windows.
+          - os: macos-12
+            gcc: gcc
+            python-version: '3.8'
+          - os: macos-12
+            gcc: gcc
             python-version: '3.11'
 
     steps:
@@ -118,14 +126,28 @@ jobs:
         run: |
           # Enable coverage for specific target configurations
           case "${{ matrix.os }}/${{ matrix.gcc }}/${{ matrix.python-version }}" in
-            windows-2019/gcc-8/3.8)   USE_COVERAGE=true ;;
             ubuntu-22.04/gcc-11/3.11) USE_COVERAGE=true ;;
+            windows-2019/gcc-8/3.8)   USE_COVERAGE=true ;;
+            macos-12/gcc-11/3.9)      USE_COVERAGE=true ;;
             *)                        USE_COVERAGE=false ;;
           esac
           echo "USE_COVERAGE=$USE_COVERAGE" >> $GITHUB_ENV
+
+          # Set the CC environment
           echo "CC=${{ matrix.gcc }}" >> $GITHUB_ENV
 
         shell: bash
+      - name: Install build commands, GCC and libxml2 (Linux)
+        if: ${{ startsWith(matrix.os,'ubuntu-') }}
+        run: |
+          sudo apt update
+          sudo apt-get install -y \
+            make \
+            ninja-build \
+            ${{ matrix.gcc }} \
+            $(echo ${{ matrix.gcc }} | sed -e 's/gcc/g\+\+/') \
+            libxml2-utils
+          sudo apt-get clean
       - name: Install msys with GCC (Windows)
         if: ${{ startsWith(matrix.os,'windows-') }}
         uses: msys2/setup-msys2@v2
@@ -135,22 +157,12 @@ jobs:
         if: ${{ startsWith(matrix.os,'windows-') }}
         run: |
           choco install ninja
-      - name: Install build commands and GCC (Linux)
-        if: ${{ startsWith(matrix.os,'ubuntu-') }}
+      - name: Install ninja and libxml2 (MacOs)
+        if: ${{ startsWith(matrix.os,'macos-') }}
         run: |
-          sudo apt update
-          sudo apt-get install -y \
-            make \
-            ninja-build \
-            ${{ matrix.gcc }} \
-            $(echo ${{ matrix.gcc }} | sed -e 's/gcc/g\+\+/')
-          sudo apt-get clean
-      - name: Install libxml2
-        if: ${{ startsWith(matrix.os,'ubuntu-') }}
-        run: |
-          sudo apt-get install -y \
-            libxml2-utils
-          sudo apt-get clean
+          brew update
+          brew install ninja
+          brew install libxml2
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -157,12 +157,14 @@ jobs:
         if: ${{ startsWith(matrix.os,'windows-') }}
         run: |
           choco install ninja
-      - name: Install ninja and libxml2 (MacOs)
+      - name: Install docker, ninja and libxml2 (MacOs)
         if: ${{ startsWith(matrix.os,'macos-') }}
         run: |
           brew update
+          brew install --cask docker
           brew install ninja
           brew install libxml2
+          open -a Docker
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,7 +117,7 @@ jobs:
             gcc: gcc
             python-version: '3.8'
           - os: macos-12
-            gcc: gcc
+            gcc: gcc-13
             python-version: '3.11'
 
     steps:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Documentation:
 Internal changes:
 
 - Move tests to directory in the root. (:issue:`897`)
+- Add MacOs to the GitHub test workflow. (:issue:`901`)
 
 7.2 (24 February 2024)
 ----------------------

--- a/noxfile.py
+++ b/noxfile.py
@@ -206,7 +206,9 @@ def doc(session: nox.Session) -> None:
     session.install("-r", "doc/requirements.txt", "docutils")
     session.install("-e", ".")
 
-    if not GCOVR_ISOLATED_TEST:
+    if not GCOVR_ISOLATED_TEST and not (
+        platform.system() == "Darwin" and "GITHUB_ACTION" in os.environ
+    ):
         docker_build_compiler(session, "gcc-8")
         session._runner.posargs = ["-s", "tests", "--", "-k", "test_example"]
         docker_run_compiler(session, "gcc-8")

--- a/noxfile.py
+++ b/noxfile.py
@@ -24,6 +24,7 @@ import platform
 import re
 import socket
 from time import sleep
+from typing import Tuple
 import requests
 import shutil
 import subprocess
@@ -85,57 +86,64 @@ OUTPUT_FORMATS = [
 nox.options.sessions = ["qa"]
 
 
-def get_gcc_version_to_use():
+def get_gcc_versions() -> Tuple[str]:
     # If the user explicitly set CC variable, use that directly without checks.
     cc = os.environ.get("CC")
-    if cc:
-        return os.path.split(cc)[1]
+    if cc is None:
+        # Find the first installed compiler version we support
+        for command in ALL_COMPILER_VERSIONS_NEWEST_FIRST:
+            if shutil.which(command):
+                return (command, command)
+    elif cc_reference := os.environ.get("CC_REFERENCE"):
+        return (cc, cc_reference)
 
-    # Find the first insalled compiler version we suport
-    for cc in ALL_COMPILER_VERSIONS_NEWEST_FIRST:
-        if shutil.which(cc):
-            return cc
+    commands = ["gcc", "clang"] if cc is None else [cc]
 
-    for cc in ["gcc", "clang"]:
-        output = subprocess.check_output([cc, "--version"]).decode()
-        # Ignore error code since we want to find a valid executable
+    for command in commands:
+        if shutil.which(command):
+            output = subprocess.check_output([command, "--version"]).decode()
 
-        # look for a line "gcc WHATEVER VERSION.WHATEVER" in output like:
-        #    gcc (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0
-        #    Copyright (C) 2019 Free Software Foundation, Inc.
-        #    This is free software; see the source for copying conditions.  There is NO
-        #    warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-        search_gcc_version = re.search(r"^gcc\b.* ([0-9]+)\.\S+$", output, re.M)
+            # look for a line "gcc WHATEVER VERSION.WHATEVER" in output like:
+            #   gcc-5 (Ubuntu/Linaro 5.5.0-12ubuntu1) 5.5.0 20171010
+            #   Copyright (C) 2015 Free Software Foundation, Inc.
+            #   This is free software; see the source for copying conditions.  There is NO
+            #   warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+            search_gcc_version = re.search(r"^gcc\b.* ([0-9]+)\..+$", output, re.M)
 
-        # look for a line "WHATEVER clang version VERSION.WHATEVER" in output like:
-        #    Apple clang version 13.1.6 (clang-1316.0.21.2.5)
-        #    Target: arm64-apple-darwin21.5.0
-        #    Thread model: posix
-        #    InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
-        search_clang_version = re.search(r"\bclang version ([0-9]+)\.", output, re.M)
+            # look for a line "WHATEVER clang version VERSION.WHATEVER" in output like:
+            #    Apple clang version 13.1.6 (clang-1316.0.21.2.5)
+            #    Target: arm64-apple-darwin21.5.0
+            #    Thread model: posix
+            #    InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
+            search_clang_version = re.search(
+                r"\bclang version ([0-9]+)\.", output, re.M
+            )
 
-        if search_gcc_version:
-            major_version = search_gcc_version.group(1)
-            return f"gcc-{major_version}"
-        elif search_clang_version:
-            major_version = search_clang_version.group(1)
-            return f"clang-{major_version}"
+            if search_gcc_version:
+                major_version = search_gcc_version.group(1)
+                return (command, f"gcc-{major_version}")
+            elif search_clang_version:
+                major_version = search_clang_version.group(1)
+                return (command, f"clang-{major_version}")
 
     raise RuntimeError(
-        "Could not detect a valid compiler, you can defin one by setting the environment CC"
+        "Could not detect a valid compiler, you can define one by setting the environment CC"
     )
 
 
-def set_environment(session: nox.Session, cc: str, check: bool = True) -> None:
-    if check and (shutil.which(cc) is None):
-        session.env["CC_REFERENCE"] = cc
-        cc = "gcc"
-    cxx = cc.replace("clang", "clang++").replace("gcc", "g++")
+def set_environment(session: nox.Session, cc: str = None) -> None:
+    """Set the environment variables"""
+    if cc is None:
+        cc, cc_reference = get_gcc_versions()
+    else:
+        cc_reference = cc
     session.env["GCOVR_TEST_SUITE"] = "1"
     session.env["CC"] = cc
     session.env["CFLAGS"] = "--this_flag_does_not_exist"
-    session.env["CXX"] = cxx
+    session.env["CXX"] = cc.replace("clang", "clang++").replace("gcc", "g++")
     session.env["CXXFLAGS"] = "--this_flag_does_not_exist"
+    if cc_reference is not None:
+        session.env["CC_REFERENCE"] = cc_reference
 
 
 @nox.session
@@ -233,7 +241,7 @@ def tests(session: nox.Session) -> None:
         session.install("coverage", "pytest-cov")
         coverage_args = ["--cov=gcovr", "--cov-branch"]
     session.install("-e", ".")
-    set_environment(session, get_gcc_version_to_use())
+    set_environment(session)
     session.log("Print tool versions")
     session.run("python", "--version")
     # Use full path to executable
@@ -247,6 +255,7 @@ def tests(session: nox.Session) -> None:
     session.run(session.env["GCOV"], "--version", external=True)
     if "llvm-cov" in session.env["GCOV"]:
         session.env["GCOV"] += " gcov"
+    session.log(f"Using reference data for {session.env['CC_REFERENCE']}")
 
     with session.chdir("tests"):
         session.run("make", "--silent", "clean", external=True)
@@ -507,7 +516,7 @@ def docker_build_compiler_clang(session: nox.Session) -> None:
 @nox.parametrize("version", [nox.param(v, id=v) for v in ALL_COMPILER_VERSIONS])
 def docker_build_compiler(session: nox.Session, version: str) -> None:
     """Build the docker container for a specific GCC version."""
-    set_environment(session, version, False)
+    set_environment(session, version)
     session.run(
         "docker",
         "build",
@@ -567,7 +576,7 @@ def docker_run_compiler_clang(session: nox.Session) -> None:
 @nox.parametrize("version", [nox.param(v, id=v) for v in ALL_COMPILER_VERSIONS])
 def docker_run_compiler(session: nox.Session, version: str) -> None:
     """Run the docker container for a specific GCC version."""
-    set_environment(session, version, False)
+    set_environment(session, version)
 
     nox_options = session.posargs if session.posargs else ["-s", "qa"]
     if not session.interactive:

--- a/tests/decisions/reference/gcc-13-Darwin/coverage.json
+++ b/tests/decisions/reference/gcc-13-Darwin/coverage.json
@@ -1,0 +1,2193 @@
+{
+    "files": [
+        {
+            "file": "main.cpp",
+            "functions": [
+                {
+                    "blocks_percent": 100.0,
+                    "execution_count": 2,
+                    "lineno": 32,
+                    "name": "checkBiggerBoth(int)",
+                    "returned_count": 2
+                },
+                {
+                    "blocks_percent": 75.0,
+                    "execution_count": 1,
+                    "lineno": 20,
+                    "name": "checkBiggerFalse(int)",
+                    "returned_count": 1
+                },
+                {
+                    "blocks_percent": 75.0,
+                    "execution_count": 1,
+                    "lineno": 8,
+                    "name": "checkBiggerTrue(int)",
+                    "returned_count": 1
+                },
+                {
+                    "blocks_percent": 75.0,
+                    "execution_count": 1,
+                    "lineno": 246,
+                    "name": "checkCompactBranch1False(int)",
+                    "returned_count": 1
+                },
+                {
+                    "blocks_percent": 75.0,
+                    "execution_count": 1,
+                    "lineno": 241,
+                    "name": "checkCompactBranch1True(int)",
+                    "returned_count": 1
+                },
+                {
+                    "blocks_percent": 60.0,
+                    "execution_count": 1,
+                    "lineno": 256,
+                    "name": "checkCompactBranch2False(int)",
+                    "returned_count": 1
+                },
+                {
+                    "blocks_percent": 80.0,
+                    "execution_count": 1,
+                    "lineno": 251,
+                    "name": "checkCompactBranch2True(int)",
+                    "returned_count": 1
+                },
+                {
+                    "blocks_percent": 67.0,
+                    "execution_count": 1,
+                    "lineno": 128,
+                    "name": "checkComplexFalse(int)",
+                    "returned_count": 1
+                },
+                {
+                    "blocks_percent": 100.0,
+                    "execution_count": 1,
+                    "lineno": 291,
+                    "name": "checkComplexForLoop(int)",
+                    "returned_count": 1
+                },
+                {
+                    "blocks_percent": 83.0,
+                    "execution_count": 1,
+                    "lineno": 116,
+                    "name": "checkComplexTrue(int)",
+                    "returned_count": 1
+                },
+                {
+                    "blocks_percent": 100.0,
+                    "execution_count": 1,
+                    "lineno": 315,
+                    "name": "checkDoWhileLoop(int)",
+                    "returned_count": 1
+                },
+                {
+                    "blocks_percent": 50.0,
+                    "execution_count": 1,
+                    "lineno": 140,
+                    "name": "checkElseIf1(int)",
+                    "returned_count": 1
+                },
+                {
+                    "blocks_percent": 67.0,
+                    "execution_count": 1,
+                    "lineno": 156,
+                    "name": "checkElseIf2(int)",
+                    "returned_count": 1
+                },
+                {
+                    "blocks_percent": 67.0,
+                    "execution_count": 1,
+                    "lineno": 172,
+                    "name": "checkElseIf3(int)",
+                    "returned_count": 1
+                },
+                {
+                    "blocks_percent": 75.0,
+                    "execution_count": 1,
+                    "lineno": 80,
+                    "name": "checkEqualFalse(int)",
+                    "returned_count": 1
+                },
+                {
+                    "blocks_percent": 75.0,
+                    "execution_count": 1,
+                    "lineno": 68,
+                    "name": "checkEqualTrue(int)",
+                    "returned_count": 1
+                },
+                {
+                    "blocks_percent": 100.0,
+                    "execution_count": 1,
+                    "lineno": 281,
+                    "name": "checkForLoop(int)",
+                    "returned_count": 1
+                },
+                {
+                    "blocks_percent": 80.0,
+                    "execution_count": 1,
+                    "lineno": 329,
+                    "name": "checkInterpreter(int)",
+                    "returned_count": 1
+                },
+                {
+                    "blocks_percent": 75.0,
+                    "execution_count": 1,
+                    "lineno": 104,
+                    "name": "checkNotEqualFalse(int)",
+                    "returned_count": 1
+                },
+                {
+                    "blocks_percent": 75.0,
+                    "execution_count": 1,
+                    "lineno": 92,
+                    "name": "checkNotEqualTrue(int)",
+                    "returned_count": 1
+                },
+                {
+                    "blocks_percent": 75.0,
+                    "execution_count": 1,
+                    "lineno": 56,
+                    "name": "checkSmallerFalse(int)",
+                    "returned_count": 1
+                },
+                {
+                    "blocks_percent": 75.0,
+                    "execution_count": 1,
+                    "lineno": 44,
+                    "name": "checkSmallerTrue(int)",
+                    "returned_count": 1
+                },
+                {
+                    "blocks_percent": 60.0,
+                    "execution_count": 1,
+                    "lineno": 188,
+                    "name": "checkSwitch1(int)",
+                    "returned_count": 1
+                },
+                {
+                    "blocks_percent": 60.0,
+                    "execution_count": 1,
+                    "lineno": 209,
+                    "name": "checkSwitch2(int)",
+                    "returned_count": 1
+                },
+                {
+                    "blocks_percent": 60.0,
+                    "execution_count": 1,
+                    "lineno": 225,
+                    "name": "checkSwitch3(int)",
+                    "returned_count": 1
+                },
+                {
+                    "blocks_percent": 100.0,
+                    "execution_count": 1,
+                    "lineno": 266,
+                    "name": "checkTernary1False(int)",
+                    "returned_count": 1
+                },
+                {
+                    "blocks_percent": 100.0,
+                    "execution_count": 1,
+                    "lineno": 261,
+                    "name": "checkTernary1True(int)",
+                    "returned_count": 1
+                },
+                {
+                    "blocks_percent": 67.0,
+                    "execution_count": 1,
+                    "lineno": 276,
+                    "name": "checkTernary2False(int)",
+                    "returned_count": 1
+                },
+                {
+                    "blocks_percent": 83.0,
+                    "execution_count": 1,
+                    "lineno": 271,
+                    "name": "checkTernary2True(int)",
+                    "returned_count": 1
+                },
+                {
+                    "blocks_percent": 100.0,
+                    "execution_count": 1,
+                    "lineno": 301,
+                    "name": "checkWhileLoop(int)",
+                    "returned_count": 1
+                },
+                {
+                    "blocks_percent": 95.0,
+                    "execution_count": 1,
+                    "lineno": 360,
+                    "name": "main",
+                    "returned_count": 1
+                },
+                {
+                    "blocks_percent": 100.0,
+                    "execution_count": 2,
+                    "lineno": 353,
+                    "name": "verify_issue_679(bool)",
+                    "returned_count": 2
+                }
+            ],
+            "lines": [
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "6787aacdd04e18ff50f22cb09af64959",
+                    "line_number": 8
+                },
+                {
+                    "branches": [
+                        {
+                            "blockno": 0,
+                            "count": 1,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 0,
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
+                    "count": 1,
+                    "gcovr/decision": {
+                        "count_false": 0,
+                        "count_true": 1,
+                        "type": "conditional"
+                    },
+                    "gcovr/md5": "9eb017aa338d065a39a9c50252dd0884",
+                    "line_number": 10
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "62a065f25d3a698c626b4544d33c875d",
+                    "line_number": 12
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "gcovr/md5": "235ad08b96dfe43e66fbcdb9a2ffc171",
+                    "line_number": 16
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "260f9a095d49eb9dd2c2fa021674d079",
+                    "line_number": 20
+                },
+                {
+                    "branches": [
+                        {
+                            "blockno": 0,
+                            "count": 0,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 0,
+                            "count": 1,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
+                    "count": 1,
+                    "gcovr/decision": {
+                        "count_false": 1,
+                        "count_true": 0,
+                        "type": "conditional"
+                    },
+                    "gcovr/md5": "9eb017aa338d065a39a9c50252dd0884",
+                    "line_number": 22
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "gcovr/md5": "62a065f25d3a698c626b4544d33c875d",
+                    "line_number": 24
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "235ad08b96dfe43e66fbcdb9a2ffc171",
+                    "line_number": 28
+                },
+                {
+                    "branches": [],
+                    "count": 2,
+                    "gcovr/md5": "b848ba6f16ad8e8b5c12256d5aecd684",
+                    "line_number": 32
+                },
+                {
+                    "branches": [
+                        {
+                            "blockno": 0,
+                            "count": 1,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 0,
+                            "count": 1,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
+                    "count": 2,
+                    "gcovr/decision": {
+                        "count_false": 1,
+                        "count_true": 1,
+                        "type": "conditional"
+                    },
+                    "gcovr/md5": "9eb017aa338d065a39a9c50252dd0884",
+                    "line_number": 34
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "62a065f25d3a698c626b4544d33c875d",
+                    "line_number": 36
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "235ad08b96dfe43e66fbcdb9a2ffc171",
+                    "line_number": 40
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "37d231dfe6f9f10d7281467eacbd00ed",
+                    "line_number": 44
+                },
+                {
+                    "branches": [
+                        {
+                            "blockno": 0,
+                            "count": 1,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 0,
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
+                    "count": 1,
+                    "gcovr/decision": {
+                        "count_false": 0,
+                        "count_true": 1,
+                        "type": "conditional"
+                    },
+                    "gcovr/md5": "aefaa176c8639c64cebe2afde4bc42af",
+                    "line_number": 46
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "62a065f25d3a698c626b4544d33c875d",
+                    "line_number": 48
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "gcovr/md5": "235ad08b96dfe43e66fbcdb9a2ffc171",
+                    "line_number": 52
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "e308518e2f82e0e2d7b68dfafb8d005f",
+                    "line_number": 56
+                },
+                {
+                    "branches": [
+                        {
+                            "blockno": 0,
+                            "count": 0,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 0,
+                            "count": 1,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
+                    "count": 1,
+                    "gcovr/decision": {
+                        "count_false": 1,
+                        "count_true": 0,
+                        "type": "conditional"
+                    },
+                    "gcovr/md5": "aefaa176c8639c64cebe2afde4bc42af",
+                    "line_number": 58
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "gcovr/md5": "62a065f25d3a698c626b4544d33c875d",
+                    "line_number": 60
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "235ad08b96dfe43e66fbcdb9a2ffc171",
+                    "line_number": 64
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "e877d9ef2d646c713eb69df3d1ae1b87",
+                    "line_number": 68
+                },
+                {
+                    "branches": [
+                        {
+                            "blockno": 0,
+                            "count": 1,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 0,
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
+                    "count": 1,
+                    "gcovr/decision": {
+                        "count_false": 0,
+                        "count_true": 1,
+                        "type": "conditional"
+                    },
+                    "gcovr/md5": "f00aa9ee0a7a2963e5ed28c3d5f411ba",
+                    "line_number": 70
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "62a065f25d3a698c626b4544d33c875d",
+                    "line_number": 72
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "gcovr/md5": "235ad08b96dfe43e66fbcdb9a2ffc171",
+                    "line_number": 76
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "32156227fa301e21b7798267f1d41fe9",
+                    "line_number": 80
+                },
+                {
+                    "branches": [
+                        {
+                            "blockno": 0,
+                            "count": 0,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 0,
+                            "count": 1,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
+                    "count": 1,
+                    "gcovr/decision": {
+                        "count_false": 1,
+                        "count_true": 0,
+                        "type": "conditional"
+                    },
+                    "gcovr/md5": "f00aa9ee0a7a2963e5ed28c3d5f411ba",
+                    "line_number": 82
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "gcovr/md5": "62a065f25d3a698c626b4544d33c875d",
+                    "line_number": 84
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "235ad08b96dfe43e66fbcdb9a2ffc171",
+                    "line_number": 88
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "1b839eefb1c215aed886395e851c20db",
+                    "line_number": 92
+                },
+                {
+                    "branches": [
+                        {
+                            "blockno": 0,
+                            "count": 1,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 0,
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
+                    "count": 1,
+                    "gcovr/decision": {
+                        "count_false": 0,
+                        "count_true": 1,
+                        "type": "conditional"
+                    },
+                    "gcovr/md5": "f1b4991cba9c51e1b01479bf5a3f8107",
+                    "line_number": 94
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "62a065f25d3a698c626b4544d33c875d",
+                    "line_number": 96
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "gcovr/md5": "235ad08b96dfe43e66fbcdb9a2ffc171",
+                    "line_number": 100
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "aedcd800a4eccc0d565b3361b4b7a4fe",
+                    "line_number": 104
+                },
+                {
+                    "branches": [
+                        {
+                            "blockno": 0,
+                            "count": 0,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 0,
+                            "count": 1,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
+                    "count": 1,
+                    "gcovr/decision": {
+                        "count_false": 1,
+                        "count_true": 0,
+                        "type": "conditional"
+                    },
+                    "gcovr/md5": "f1b4991cba9c51e1b01479bf5a3f8107",
+                    "line_number": 106
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "gcovr/md5": "62a065f25d3a698c626b4544d33c875d",
+                    "line_number": 108
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "235ad08b96dfe43e66fbcdb9a2ffc171",
+                    "line_number": 112
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "42e96b0366090f26436c9bf59b01660b",
+                    "line_number": 116
+                },
+                {
+                    "branches": [
+                        {
+                            "blockno": 0,
+                            "count": 1,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 0,
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 1,
+                            "count": 1,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 1,
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 2,
+                            "count": 1,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 2,
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
+                    "count": 1,
+                    "gcovr/decision": {
+                        "count_false": 0,
+                        "count_true": 1,
+                        "type": "conditional"
+                    },
+                    "gcovr/md5": "488462d327ca243033ac1a4eebc24b42",
+                    "line_number": 118
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "62a065f25d3a698c626b4544d33c875d",
+                    "line_number": 120
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "gcovr/md5": "235ad08b96dfe43e66fbcdb9a2ffc171",
+                    "line_number": 124
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "afc37d67b5def9e06b8c1ba2a081c0b9",
+                    "line_number": 128
+                },
+                {
+                    "branches": [
+                        {
+                            "blockno": 0,
+                            "count": 1,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 0,
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 1,
+                            "count": 0,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 1,
+                            "count": 1,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 2,
+                            "count": 0,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 2,
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
+                    "count": 1,
+                    "gcovr/decision": {
+                        "count_false": 1,
+                        "count_true": 0,
+                        "type": "conditional"
+                    },
+                    "gcovr/md5": "488462d327ca243033ac1a4eebc24b42",
+                    "line_number": 130
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "gcovr/md5": "62a065f25d3a698c626b4544d33c875d",
+                    "line_number": 132
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "235ad08b96dfe43e66fbcdb9a2ffc171",
+                    "line_number": 136
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "9cca3668005168d0e054caf95cd8948c",
+                    "line_number": 140
+                },
+                {
+                    "branches": [
+                        {
+                            "blockno": 0,
+                            "count": 1,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 0,
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
+                    "count": 1,
+                    "gcovr/decision": {
+                        "count_false": 0,
+                        "count_true": 1,
+                        "type": "conditional"
+                    },
+                    "gcovr/md5": "f00aa9ee0a7a2963e5ed28c3d5f411ba",
+                    "line_number": 142
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "62a065f25d3a698c626b4544d33c875d",
+                    "line_number": 144
+                },
+                {
+                    "branches": [
+                        {
+                            "blockno": 0,
+                            "count": 0,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 0,
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
+                    "count": 0,
+                    "gcovr/decision": {
+                        "count_false": 0,
+                        "count_true": 0,
+                        "type": "conditional"
+                    },
+                    "gcovr/md5": "49b898f9974955f74f69f174b54a6668",
+                    "line_number": 146
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "gcovr/md5": "62a065f25d3a698c626b4544d33c875d",
+                    "line_number": 148
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "gcovr/md5": "235ad08b96dfe43e66fbcdb9a2ffc171",
+                    "line_number": 152
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "ef8de72a20f145f62aca999f152f0034",
+                    "line_number": 156
+                },
+                {
+                    "branches": [
+                        {
+                            "blockno": 0,
+                            "count": 0,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 0,
+                            "count": 1,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
+                    "count": 1,
+                    "gcovr/decision": {
+                        "count_false": 1,
+                        "count_true": 0,
+                        "type": "conditional"
+                    },
+                    "gcovr/md5": "f00aa9ee0a7a2963e5ed28c3d5f411ba",
+                    "line_number": 158
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "gcovr/md5": "62a065f25d3a698c626b4544d33c875d",
+                    "line_number": 160
+                },
+                {
+                    "branches": [
+                        {
+                            "blockno": 0,
+                            "count": 1,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 0,
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
+                    "count": 1,
+                    "gcovr/decision": {
+                        "count_false": 0,
+                        "count_true": 1,
+                        "type": "conditional"
+                    },
+                    "gcovr/md5": "b428569a14d78c85b2215dd962d9c82c",
+                    "line_number": 162
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "62a065f25d3a698c626b4544d33c875d",
+                    "line_number": 164
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "gcovr/md5": "235ad08b96dfe43e66fbcdb9a2ffc171",
+                    "line_number": 168
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "ef28e06cf701eb5dee133164631e1de5",
+                    "line_number": 172
+                },
+                {
+                    "branches": [
+                        {
+                            "blockno": 0,
+                            "count": 0,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 0,
+                            "count": 1,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
+                    "count": 1,
+                    "gcovr/decision": {
+                        "count_false": 1,
+                        "count_true": 0,
+                        "type": "conditional"
+                    },
+                    "gcovr/md5": "f00aa9ee0a7a2963e5ed28c3d5f411ba",
+                    "line_number": 174
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "gcovr/md5": "62a065f25d3a698c626b4544d33c875d",
+                    "line_number": 176
+                },
+                {
+                    "branches": [
+                        {
+                            "blockno": 0,
+                            "count": 0,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 0,
+                            "count": 1,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
+                    "count": 1,
+                    "gcovr/decision": {
+                        "count_false": 1,
+                        "count_true": 0,
+                        "type": "conditional"
+                    },
+                    "gcovr/md5": "b428569a14d78c85b2215dd962d9c82c",
+                    "line_number": 178
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "gcovr/md5": "62a065f25d3a698c626b4544d33c875d",
+                    "line_number": 180
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "235ad08b96dfe43e66fbcdb9a2ffc171",
+                    "line_number": 184
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "779fed7d2f7ce06627a9f4f67dedfe5f",
+                    "line_number": 188
+                },
+                {
+                    "branches": [
+                        {
+                            "blockno": 0,
+                            "count": 1,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 0,
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 0,
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
+                    "count": 1,
+                    "gcovr/md5": "a942ed799094287b927e24b1b7d47d5d",
+                    "line_number": 190
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/decision": {
+                        "count": 1,
+                        "type": "switch"
+                    },
+                    "gcovr/md5": "c55ac16d79ecde6ccafa6981a9351947",
+                    "line_number": 192
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "gcovr/decision": {
+                        "count": 0,
+                        "type": "switch"
+                    },
+                    "gcovr/md5": "5192495be2208d8d390eeb8bfd5a50e9",
+                    "line_number": 194
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "gcovr/md5": "62a065f25d3a698c626b4544d33c875d",
+                    "line_number": 196
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "gcovr/decision": {
+                        "count": 0,
+                        "type": "switch"
+                    },
+                    "gcovr/md5": "8f556dc5bac889fb0d6b398cc5f1d1a2",
+                    "line_number": 200
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "gcovr/md5": "235ad08b96dfe43e66fbcdb9a2ffc171",
+                    "line_number": 202
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "b27839bf103fdd94b8d5f7c0fec7d676",
+                    "line_number": 209
+                },
+                {
+                    "branches": [
+                        {
+                            "blockno": 0,
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 0,
+                            "count": 1,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 0,
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
+                    "count": 1,
+                    "gcovr/md5": "a942ed799094287b927e24b1b7d47d5d",
+                    "line_number": 211
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "gcovr/decision": {
+                        "count": 0,
+                        "type": "switch"
+                    },
+                    "gcovr/md5": "4e16c5488167f241ab1487a55fdbe6d1",
+                    "line_number": 213
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "gcovr/md5": "62a065f25d3a698c626b4544d33c875d",
+                    "line_number": 214
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/decision": {
+                        "count": 1,
+                        "type": "switch"
+                    },
+                    "gcovr/md5": "5192495be2208d8d390eeb8bfd5a50e9",
+                    "line_number": 216
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "62a065f25d3a698c626b4544d33c875d",
+                    "line_number": 217
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "gcovr/decision": {
+                        "count": 0,
+                        "type": "switch"
+                    },
+                    "gcovr/md5": "8f556dc5bac889fb0d6b398cc5f1d1a2",
+                    "line_number": 219
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "gcovr/md5": "235ad08b96dfe43e66fbcdb9a2ffc171",
+                    "line_number": 220
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "e1b1c7d843f820d35f09c2df667c15ef",
+                    "line_number": 225
+                },
+                {
+                    "branches": [
+                        {
+                            "blockno": 0,
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 0,
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 0,
+                            "count": 1,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
+                    "count": 1,
+                    "gcovr/md5": "a942ed799094287b927e24b1b7d47d5d",
+                    "line_number": 227
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "gcovr/decision": {
+                        "count": 0,
+                        "type": "switch"
+                    },
+                    "gcovr/md5": "4e16c5488167f241ab1487a55fdbe6d1",
+                    "line_number": 229
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "gcovr/md5": "62a065f25d3a698c626b4544d33c875d",
+                    "line_number": 230
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "gcovr/decision": {
+                        "count": 0,
+                        "type": "switch"
+                    },
+                    "gcovr/md5": "5192495be2208d8d390eeb8bfd5a50e9",
+                    "line_number": 232
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "gcovr/md5": "62a065f25d3a698c626b4544d33c875d",
+                    "line_number": 233
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/decision": {
+                        "count": 1,
+                        "type": "switch"
+                    },
+                    "gcovr/md5": "8f556dc5bac889fb0d6b398cc5f1d1a2",
+                    "line_number": 235
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "235ad08b96dfe43e66fbcdb9a2ffc171",
+                    "line_number": 236
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "dbdb1200cd98fca90a93dfb7f426bfa6",
+                    "line_number": 241
+                },
+                {
+                    "branches": [
+                        {
+                            "blockno": 0,
+                            "count": 1,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 0,
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
+                    "count": 1,
+                    "gcovr/decision": {
+                        "count_false": 0,
+                        "count_true": 1,
+                        "type": "conditional"
+                    },
+                    "gcovr/md5": "e749733f42b89caef9a0026be7b83b75",
+                    "line_number": 243
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "880e53e4a12d09f7cd28d27076b2e586",
+                    "line_number": 246
+                },
+                {
+                    "branches": [
+                        {
+                            "blockno": 0,
+                            "count": 0,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 0,
+                            "count": 1,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
+                    "count": 1,
+                    "gcovr/decision": {
+                        "count_false": 1,
+                        "count_true": 0,
+                        "type": "conditional"
+                    },
+                    "gcovr/md5": "e749733f42b89caef9a0026be7b83b75",
+                    "line_number": 248
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "768bcd7c52e4ebd1157dc298740c4c75",
+                    "line_number": 251
+                },
+                {
+                    "branches": [
+                        {
+                            "blockno": 0,
+                            "count": 1,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 0,
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 1,
+                            "count": 1,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 1,
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
+                    "count": 1,
+                    "gcovr/decision": {
+                        "type": "uncheckable"
+                    },
+                    "gcovr/md5": "f10e70f8cd7ef7ef1645378b8571e499",
+                    "line_number": 253
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "04774800e109bfa6463950e63def9f9b",
+                    "line_number": 256
+                },
+                {
+                    "branches": [
+                        {
+                            "blockno": 0,
+                            "count": 0,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 0,
+                            "count": 1,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 1,
+                            "count": 0,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 1,
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
+                    "count": 1,
+                    "gcovr/decision": {
+                        "type": "uncheckable"
+                    },
+                    "gcovr/md5": "f10e70f8cd7ef7ef1645378b8571e499",
+                    "line_number": 258
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "b2ce0dd6c936dc2090ed5fce103cab77",
+                    "line_number": 261
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "e5687ce2bfb55e6b964d04780a002b51",
+                    "line_number": 263
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "50d4f07d1fecada716d18177c9a504a1",
+                    "line_number": 266
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "e5687ce2bfb55e6b964d04780a002b51",
+                    "line_number": 268
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "38133a7c12b812e2590432cbc63041c5",
+                    "line_number": 271
+                },
+                {
+                    "branches": [
+                        {
+                            "blockno": 0,
+                            "count": 1,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 0,
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 1,
+                            "count": 1,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 1,
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
+                    "count": 1,
+                    "gcovr/md5": "cc459c18ce48cc663bdc4a760ec410f6",
+                    "line_number": 273
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "a3e296dc69cd28202a38f73b2d4b57a9",
+                    "line_number": 276
+                },
+                {
+                    "branches": [
+                        {
+                            "blockno": 0,
+                            "count": 0,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 0,
+                            "count": 1,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 1,
+                            "count": 0,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 1,
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
+                    "count": 1,
+                    "gcovr/md5": "cc459c18ce48cc663bdc4a760ec410f6",
+                    "line_number": 278
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "a5ed42af8f8896d1af443379712e5a5f",
+                    "line_number": 281
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "4060985ba945597cd1f528d1880b4999",
+                    "line_number": 283
+                },
+                {
+                    "branches": [
+                        {
+                            "blockno": 1,
+                            "count": 5,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 1,
+                            "count": 1,
+                            "fallthrough": true,
+                            "throw": false
+                        }
+                    ],
+                    "count": 6,
+                    "gcovr/decision": {
+                        "count_false": 1,
+                        "count_true": 5,
+                        "type": "conditional"
+                    },
+                    "gcovr/md5": "3acfab0519f3428bd6e85b610574acac",
+                    "line_number": 284
+                },
+                {
+                    "branches": [],
+                    "count": 5,
+                    "gcovr/md5": "55d711b351fb023f321f67130eacc2e8",
+                    "line_number": 286
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "043b84861b98adf987e1231784d5af52",
+                    "line_number": 288
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "6452493326f1adb6dbb8e661240f0725",
+                    "line_number": 291
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "4060985ba945597cd1f528d1880b4999",
+                    "line_number": 293
+                },
+                {
+                    "branches": [
+                        {
+                            "blockno": 1,
+                            "count": 5,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 1,
+                            "count": 1,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 2,
+                            "count": 5,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 2,
+                            "count": 0,
+                            "fallthrough": true,
+                            "throw": false
+                        }
+                    ],
+                    "count": 6,
+                    "gcovr/decision": {
+                        "type": "uncheckable"
+                    },
+                    "gcovr/md5": "f045ba8b7bbb82cb14b97f844c17a868",
+                    "line_number": 294
+                },
+                {
+                    "branches": [],
+                    "count": 5,
+                    "gcovr/md5": "55d711b351fb023f321f67130eacc2e8",
+                    "line_number": 296
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "043b84861b98adf987e1231784d5af52",
+                    "line_number": 298
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "f4b8e72891cf996cb8da3195b075336a",
+                    "line_number": 301
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "4060985ba945597cd1f528d1880b4999",
+                    "line_number": 303
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "d0a5dc4bd59ad4730f939048c07e34b3",
+                    "line_number": 304
+                },
+                {
+                    "branches": [
+                        {
+                            "blockno": 1,
+                            "count": 5,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 1,
+                            "count": 1,
+                            "fallthrough": true,
+                            "throw": false
+                        }
+                    ],
+                    "count": 6,
+                    "gcovr/decision": {
+                        "count_false": 1,
+                        "count_true": 5,
+                        "type": "conditional"
+                    },
+                    "gcovr/md5": "670ed65f1c3b23a11afd3746e0865ce4",
+                    "line_number": 306
+                },
+                {
+                    "branches": [],
+                    "count": 5,
+                    "gcovr/md5": "ff85af6301d128a7daa567a0a0390e91",
+                    "line_number": 308
+                },
+                {
+                    "branches": [],
+                    "count": 5,
+                    "gcovr/md5": "55d711b351fb023f321f67130eacc2e8",
+                    "line_number": 309
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "043b84861b98adf987e1231784d5af52",
+                    "line_number": 312
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "cbafffe2e47d8b1805f93607e5a668c0",
+                    "line_number": 315
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "4060985ba945597cd1f528d1880b4999",
+                    "line_number": 317
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "d0a5dc4bd59ad4730f939048c07e34b3",
+                    "line_number": 318
+                },
+                {
+                    "branches": [],
+                    "count": 5,
+                    "gcovr/md5": "ff85af6301d128a7daa567a0a0390e91",
+                    "line_number": 322
+                },
+                {
+                    "branches": [],
+                    "count": 5,
+                    "gcovr/md5": "55d711b351fb023f321f67130eacc2e8",
+                    "line_number": 323
+                },
+                {
+                    "branches": [
+                        {
+                            "blockno": 0,
+                            "count": 4,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 0,
+                            "count": 1,
+                            "fallthrough": true,
+                            "throw": false
+                        }
+                    ],
+                    "count": 5,
+                    "gcovr/decision": {
+                        "count_false": 1,
+                        "count_true": 4,
+                        "type": "conditional"
+                    },
+                    "gcovr/md5": "3e8434067cc44c9640dd8a6d237d800a",
+                    "line_number": 324
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "043b84861b98adf987e1231784d5af52",
+                    "line_number": 326
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "f8b4513731a14f4d9805082c72c433f7",
+                    "line_number": 329
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "928c0e79786bd7f4e271f1b810308475",
+                    "line_number": 331
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "527a8f31bcf6609350fead60576d6bce",
+                    "line_number": 332
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "0e9387f55399ceee62583ce672cc1370",
+                    "line_number": 334
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "9c196756bc02433fb578f76c2e8ca85f",
+                    "line_number": 336
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "9aaae14be89d538995df72937d38b87e",
+                    "line_number": 339
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "527a8f31bcf6609350fead60576d6bce",
+                    "line_number": 340
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "3a8920632809f93dd1e65c2c9dc778ef",
+                    "line_number": 342
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "527a8f31bcf6609350fead60576d6bce",
+                    "line_number": 343
+                },
+                {
+                    "branches": [
+                        {
+                            "blockno": 0,
+                            "count": 1,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 0,
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
+                    "count": 1,
+                    "gcovr/decision": {
+                        "count_false": 0,
+                        "count_true": 1,
+                        "type": "conditional"
+                    },
+                    "gcovr/md5": "9eb017aa338d065a39a9c50252dd0884",
+                    "line_number": 345
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "62a065f25d3a698c626b4544d33c875d",
+                    "line_number": 347
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "gcovr/md5": "645924eb3b07dbb34295edeaa6442673",
+                    "line_number": 350
+                },
+                {
+                    "branches": [],
+                    "count": 2,
+                    "gcovr/md5": "78cbf5dc7f0e6f7d02476603c791b3fd",
+                    "line_number": 353
+                },
+                {
+                    "branches": [
+                        {
+                            "blockno": 0,
+                            "count": 1,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 0,
+                            "count": 1,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
+                    "count": 2,
+                    "gcovr/decision": {
+                        "count_false": 1,
+                        "count_true": 1,
+                        "type": "conditional"
+                    },
+                    "gcovr/md5": "ea7f2e78805e85d9aa20a2bec77cee2e",
+                    "line_number": 354
+                },
+                {
+                    "branches": [
+                        {
+                            "blockno": 2,
+                            "count": 10,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 2,
+                            "count": 1,
+                            "fallthrough": true,
+                            "throw": false
+                        }
+                    ],
+                    "count": 11,
+                    "gcovr/decision": {
+                        "count_false": 1,
+                        "count_true": 10,
+                        "type": "conditional"
+                    },
+                    "gcovr/md5": "3e2cc082cb7c4086fe2acf4d52b8819b",
+                    "line_number": 355
+                },
+                {
+                    "branches": [],
+                    "count": 2,
+                    "gcovr/md5": "cbb184dd8e05c9709e5dcaedaa0495cf",
+                    "line_number": 358
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "8e855b46bd5f3510eb5ca2bf348886b1",
+                    "line_number": 360
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "3cc5c7379c991f20593f9e60cdff92e3",
+                    "line_number": 362
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "b3aee9744dd3c8c21ee7958a20c812b8",
+                    "line_number": 363
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "92645afa29c10f35a9cff34bb1055444",
+                    "line_number": 364
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "a01db9b27704d7c9d491dc2c4f8f9eb3",
+                    "line_number": 365
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "15d893e7d4568dd18290c2ad0f4bf4bb",
+                    "line_number": 367
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "a9f40f5247afa5eafcf9d73780a49d14",
+                    "line_number": 368
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "ab7cc9c5a6a1b8bacbce76dc0b953556",
+                    "line_number": 370
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "4637d80dd004526f2eff906696f203ee",
+                    "line_number": 371
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "d0539d8a5f62a39e677f88e292e9596f",
+                    "line_number": 373
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "435dd23a0ad476b42e5e97c11ee07c59",
+                    "line_number": 374
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "c5422996dc66f19290c22c6f15ce9975",
+                    "line_number": 376
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "e7110dd34c53922142313c2e26ddc0ac",
+                    "line_number": 377
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "92007538956d002a31e280c7b6484fd3",
+                    "line_number": 379
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "3a5aa177c25976ed9a7fef7147852155",
+                    "line_number": 380
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "3ca06b2d4a93036239b05f0ec57838e2",
+                    "line_number": 381
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "90e3bdbd267998fffc247854eafb7fab",
+                    "line_number": 383
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "2218abcab99d7f157fb8a725c709eff8",
+                    "line_number": 384
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "b47672a79f6c622ed3f76d76eca245b0",
+                    "line_number": 385
+                },
+                {
+                    "branches": [
+                        {
+                            "blockno": 0,
+                            "count": 1,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 0,
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": true
+                        },
+                        {
+                            "blockno": 0,
+                            "count": 1,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 0,
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": true
+                        }
+                    ],
+                    "count": 1,
+                    "gcovr/md5": "9aef5fe9108e3cbc13c6552674316763",
+                    "line_number": 388
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "bf47c01ac22ec690a031557d2549af78",
+                    "line_number": 391
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "5c2e91ce4cb9f01e5d9c593325852c79",
+                    "line_number": 392
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "98a7a749633438d8c3fbce5f6e0e4dbe",
+                    "line_number": 394
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "3d07f757c579cdcb84199581ac590035",
+                    "line_number": 395
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "417d286a6a330312ff021a41177652df",
+                    "line_number": 397
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "6fca1b917c3eb34dafaf42c5b2fba108",
+                    "line_number": 398
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "a07e47adac4b00d46e8d03e1b3b4f074",
+                    "line_number": 400
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "5c4ad7fb65100111dee2989629b891db",
+                    "line_number": 401
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "9267e0de8997916348249ed2da14f25b",
+                    "line_number": 403
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "33cef5a3aa96b6891c77909242530dca",
+                    "line_number": 404
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "5f8093ff079edf5092bf9c7103ea702b",
+                    "line_number": 405
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "dafda76cddea8476c38f1d88673abb9d",
+                    "line_number": 406
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "2df255f12bacc5d1208535956b261df8",
+                    "line_number": 408
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "3f3d124026146a196f8bbd3d3b64601c",
+                    "line_number": 410
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "8ca7cc4fbe5ff42bfbc97665e2fd738d",
+                    "line_number": 411
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "7483dc5d2ba8642b2a3fed7915b6f508",
+                    "line_number": 413
+                }
+            ]
+        },
+        {
+            "file": "switch_test.cpp",
+            "functions": [
+                {
+                    "blocks_percent": 75.0,
+                    "execution_count": 1,
+                    "lineno": 5,
+                    "name": "SwitchTestIssue783::SwitchTestIssue783()",
+                    "returned_count": 1
+                },
+                {
+                    "blocks_percent": 100.0,
+                    "execution_count": 1,
+                    "lineno": 7,
+                    "name": "SwitchTestIssue783::checkSwitch()",
+                    "returned_count": 1
+                }
+            ],
+            "lines": [
+                {
+                    "branches": [
+                        {
+                            "blockno": 1,
+                            "count": 1,
+                            "fallthrough": true,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 1,
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": true
+                        }
+                    ],
+                    "count": 6,
+                    "gcovr/md5": "daaee5f922cdfe45cf6519c84a4de5b0",
+                    "line_number": 5
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "8047128d0af317bb6db2334074f87249",
+                    "line_number": 7
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "fa6d8aa38011d7d76109ffc5e615ffeb",
+                    "line_number": 8
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "cbb184dd8e05c9709e5dcaedaa0495cf",
+                    "line_number": 9
+                }
+            ]
+        },
+        {
+            "file": "switch_test.h",
+            "functions": [
+                {
+                    "blocks_percent": 50.0,
+                    "execution_count": 1,
+                    "lineno": 15,
+                    "name": "SwitchTestIssue783::doSomething(SwitchTestIssue783::SomeEnum)",
+                    "returned_count": 1
+                }
+            ],
+            "lines": [
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/md5": "af21e6405cc1226c39e994ba8233ef61",
+                    "line_number": 15
+                },
+                {
+                    "branches": [
+                        {
+                            "blockno": 0,
+                            "count": 1,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 0,
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 0,
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        },
+                        {
+                            "blockno": 0,
+                            "count": 0,
+                            "fallthrough": false,
+                            "throw": false
+                        }
+                    ],
+                    "count": 1,
+                    "gcovr/md5": "fcb068fee0ede6857cdd1a834d4da42f",
+                    "line_number": 16
+                },
+                {
+                    "branches": [],
+                    "count": 1,
+                    "gcovr/decision": {
+                        "count": 1,
+                        "type": "switch"
+                    },
+                    "gcovr/md5": "6cf38b6f666597bfe088a84dea6fe22b",
+                    "line_number": 17
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "gcovr/decision": {
+                        "count": 0,
+                        "type": "switch"
+                    },
+                    "gcovr/md5": "e442aca3482ae01847a8e3624a553ba3",
+                    "line_number": 18
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "gcovr/decision": {
+                        "count": 0,
+                        "type": "switch"
+                    },
+                    "gcovr/md5": "648cebceec88bee865d519f95c2f386c",
+                    "line_number": 19
+                },
+                {
+                    "branches": [],
+                    "count": 0,
+                    "gcovr/md5": "10768d314ff01a06ad913aa6ed6ece64",
+                    "line_number": 21
+                }
+            ]
+        }
+    ],
+    "gcovr/format_version": "0.6"
+}

--- a/tests/gcc-abspath/Makefile
+++ b/tests/gcc-abspath/Makefile
@@ -5,7 +5,7 @@ run: json
 
 json:
 	cd subfolder&& ./testcase
-	mv -f --target-directory . subfolder/*.gc??
+	mv -f subfolder/*.gc?? ./
 	$(GCOVR) -d --json-pretty --json coverage.json
 
 clean:

--- a/tests/test_gcovr.py
+++ b/tests/test_gcovr.py
@@ -365,7 +365,7 @@ def pytest_generate_tests(metafunc):
                 ),
                 pytest.mark.xfail(
                     name == "decisions"
-                    and (IS_CLANG and CC_REFERENCE_VERSION == 15 and IS_MACOS),
+                    and (IS_CLANG and CC_REFERENCE_VERSION in [14, 15] and IS_MACOS),
                     reason="On MacOS with clang 15 the file decision/switch_test.h throws compiler errors",
                 ),
                 pytest.mark.xfail(

--- a/tests/test_gcovr.py
+++ b/tests/test_gcovr.py
@@ -366,7 +366,7 @@ def pytest_generate_tests(metafunc):
                 pytest.mark.xfail(
                     name == "decisions"
                     and (IS_CLANG and CC_REFERENCE_VERSION in [14, 15] and IS_MACOS),
-                    reason="On MacOS with clang 15 the file decision/switch_test.h throws compiler errors",
+                    reason="On MacOS with clang 14 and 15 the file decision/switch_test.h throws compiler errors",
                 ),
                 pytest.mark.xfail(
                     name in ["decisions-neg-delta"] and IS_MACOS,


### PR DESCRIPTION
Add MacOs to the test matrix on GitHub.

To get the tests working the selection of the compiler and the reference data which is done in the noxfile needs to be improved. Now you need to set CC to the name of the executable which shall be used and from this executable the version is selected.

The docker test pointed out that the detection of the gcc version wasn't correct. There can be a number after the version:
```
 gcc-5 (Ubuntu/Linaro 5.5.0-12ubuntu1) 5.5.0 20171010
```