### PR TITLE
Add log messages which are captured by the CI

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,8 @@ Breaking changes:
 
 New features and notable changes:
 
+- In Azure pipelines or GitHub actions errors and warnings are printed in an additional format captured by the CI. (:issue:`904`)
+
 Bug fixes and small improvements:
 
 Documentation:

--- a/gcovr/__main__.py
+++ b/gcovr/__main__.py
@@ -43,7 +43,7 @@ from .utils import (
     AlwaysMatchFilter,
     DirectoryPrefixFilter,
     configure_logging,
-    update_logging_formatter,
+    update_logging,
 )
 from .version import __version__
 from .coverage import CovData, SummarizedStats
@@ -221,10 +221,7 @@ def main(args=None):
     options = merge_options_and_set_defaults([cfg_options, cli_options.__dict__])
 
     # Reconfigure the logging.
-    update_logging_formatter(options)
-
-    if options.verbose:
-        LOGGER.setLevel(logging.DEBUG)
+    update_logging(options)
 
     if options.sort_branches and options.sort_key not in [
         "uncovered-number",

--- a/gcovr/utils.py
+++ b/gcovr/utils.py
@@ -32,10 +32,13 @@ from colorlog import ColoredFormatter
 from gcovr.options import Options
 
 LOGGER = logging.getLogger("gcovr")
+DEFAULT_LOGGING_HANDLER = logging.StreamHandler(sys.stderr)
 
 
-LOG_FORMAT = "%(log_color)s(%(levelname)s) %(message)s"
-LOG_FORMAT_THREADS = "%(log_color)s(%(levelname)s) - %(threadName)s - %(message)s"
+LOG_FORMAT = "(%(levelname)s) %(message)s"
+LOG_FORMAT_THREADS = "(%(levelname)s) - %(threadName)s - %(message)s"
+COLOR_LOG_FORMAT = f"%(log_color)s{LOG_FORMAT}"
+COLOR_LOG_FORMAT_THREADS = f"%(log_color)s{LOG_FORMAT_THREADS}"
 
 
 class LoopChecker(object):
@@ -280,13 +283,13 @@ class DirectoryPrefixFilter(Filter):
         return super().match(path)
 
 
-def __colored_formatter(options: Options) -> ColoredFormatter:
+def __colored_formatter(options: Options = None) -> ColoredFormatter:
     if options is not None:
-        log_format = LOG_FORMAT_THREADS if options.gcov_parallel > 1 else LOG_FORMAT
+        log_format = COLOR_LOG_FORMAT_THREADS if options.gcov_parallel > 1 else COLOR_LOG_FORMAT
         force_color = getattr(options, "force_color", False)
         no_color = getattr(options, "no_color", False)
     else:
-        log_format = LOG_FORMAT
+        log_format = COLOR_LOG_FORMAT
         force_color = False
         no_color = False
 
@@ -309,14 +312,39 @@ def __colored_formatter(options: Options) -> ColoredFormatter:
     )
 
 
-def configure_logging(options: Options = None) -> None:
-    stream_handler = logging.StreamHandler(sys.stderr)
-    stream_handler.setFormatter(__colored_formatter(options))
+def configure_logging() -> None:
+    logging.basicConfig(level=logging.INFO)
+    DEFAULT_LOGGING_HANDLER.setFormatter(__colored_formatter())
+    logging.getLogger().addHandler(DEFAULT_LOGGING_HANDLER)
+    ci_logging_prefixes = None
+    if "TF_BUILD" in os.environ:
+        ci_logging_prefixes = {
+            logging.WARNING: "##vso[task.logissue type=warning]",
+            logging.ERROR: "##vso[task.logissue type=error]",
+        }
+    elif "GITHUB_ACTIONS" in os.environ:
+        ci_logging_prefixes = {
+            logging.WARNING: "::warning::",
+            logging.ERROR: "::error::",
+        }
 
-    logging.basicConfig(
-        handlers=[stream_handler],
-        level=logging.INFO,
-    )
+    if ci_logging_prefixes is not None:
+        class CiFormatter(logging.Formatter):
+            """Formatter to format messages to be captured in Azure"""
+            def __init__(self):
+                super(CiFormatter, self).__init__(fmt=LOG_FORMAT)
+
+            def format(self, record):
+                if record.levelno in ci_logging_prefixes:
+                    result = f"{ci_logging_prefixes[record.levelno]}{super().format(record)}"
+                else:
+                    result = ""
+
+                return result
+
+        handler = logging.StreamHandler(sys.stderr)
+        handler.setFormatter(CiFormatter())
+        logging.getLogger().addHandler(handler)
 
     def exception_hook(exc_type, exc_value, exc_traceback) -> None:
         logging.exception(
@@ -326,12 +354,12 @@ def configure_logging(options: Options = None) -> None:
     sys.excepthook = exception_hook
 
 
-def update_logging_formatter(options: Options) -> None:
-    # The one and only LOGGER was configured from ourselve.
-    if len(logging.getLogger().handlers) == 1 and (
-        logging.getLogger().handlers[0].formatter._fmt == LOG_FORMAT
-    ):
-        logging.getLogger().handlers[0].setFormatter(__colored_formatter(options))
+def update_logging(options: Options) -> None:
+    if options.verbose:
+        LOGGER.setLevel(logging.DEBUG)
+
+    # Update the formatter of the default logger depending on options
+    DEFAULT_LOGGING_HANDLER.setFormatter(__colored_formatter(options))
 
 
 @contextmanager

--- a/gcovr/utils.py
+++ b/gcovr/utils.py
@@ -285,7 +285,9 @@ class DirectoryPrefixFilter(Filter):
 
 def __colored_formatter(options: Options = None) -> ColoredFormatter:
     if options is not None:
-        log_format = COLOR_LOG_FORMAT_THREADS if options.gcov_parallel > 1 else COLOR_LOG_FORMAT
+        log_format = (
+            COLOR_LOG_FORMAT_THREADS if options.gcov_parallel > 1 else COLOR_LOG_FORMAT
+        )
         force_color = getattr(options, "force_color", False)
         no_color = getattr(options, "no_color", False)
     else:
@@ -329,14 +331,18 @@ def configure_logging() -> None:
         }
 
     if ci_logging_prefixes is not None:
+
         class CiFormatter(logging.Formatter):
             """Formatter to format messages to be captured in Azure"""
+
             def __init__(self):
                 super(CiFormatter, self).__init__(fmt=LOG_FORMAT)
 
             def format(self, record):
                 if record.levelno in ci_logging_prefixes:
-                    result = f"{ci_logging_prefixes[record.levelno]}{super().format(record)}"
+                    result = (
+                        f"{ci_logging_prefixes[record.levelno]}{super().format(record)}"
+                    )
                 else:
                     result = ""
 

--- a/tests/simple1/Makefile
+++ b/tests/simple1/Makefile
@@ -12,10 +12,10 @@ run: txt clover cobertura html sonarqube jacoco json json_summary coveralls
 txt:
 	./testcase
 	# a couple of tests about failure thresholds
-	$(GCOVR) --fail-under-line 80.1 --print-summary 2>fail_under.stderr; test $$? -eq 2 || ( cat fail_under.stderr & exit 1 )
-	grep -F "failed minimum line coverage" fail_under.stderr
-	$(GCOVR) --fail-under-branch 50.1 --print-summary 2>fail_under.stderr; test $$? -eq 4 || ( cat fail_under.stderr & exit 1 )
-	grep -F "failed minimum branch coverage" fail_under.stderr
+	TF_BUILD=true $(GCOVR) --fail-under-line 80.1 --print-summary 2>fail_under.stderr; test $$? -eq 2 || ( cat fail_under.stderr & exit 1 )
+	grep -F "##vso[task.logissue type=error](ERROR) failed minimum line coverage" fail_under.stderr
+	GITHUB_ACTIONS=true $(GCOVR) --fail-under-branch 50.1 --print-summary 2>fail_under.stderr; test $$? -eq 4 || ( cat fail_under.stderr & exit 1 )
+	grep -F "::error::(ERROR) failed minimum branch coverage" fail_under.stderr
 	$(GCOVR) --decision --fail-under-decision 50.1 --print-summary 2>fail_under.stderr; test $$? -eq 8 || ( cat fail_under.stderr & exit 1 )
 	grep -F "failed minimum decision coverage" fail_under.stderr
 	$(GCOVR) --fail-under-function 100 --print-summary 2>fail_under.stderr; test $$? -eq 16 || ( cat fail_under.stderr & exit 1 )


### PR DESCRIPTION
If gcovr is executed in Azure pipeline or GitHub actions a additional
logging handler is installed which prints warning and error  message
in a format detected by the CI system.