### PR TITLE
Do not update dependencies on MacOs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,9 +158,11 @@ jobs:
         if: ${{ startsWith(matrix.os,'windows-') }}
         run: |
           choco install ninja
-      - name: Install docker, ninja and libxml2 (MacOs)
+      - name: Install ninja and libxml2 (MacOs)
         if: ${{ startsWith(matrix.os,'macos-') }}
         run: |
+          export HOMEBREW_NO_AUTO_UPDATE=1
+          export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
           brew update
           brew install ninja
           brew install libxml2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,7 @@ Documentation:
 Internal changes:
 
 - Move tests to directory in the root. (:issue:`897`)
-- Add MacOs to the GitHub test workflow. (:issue:`901`)
+- Add MacOs to the GitHub test workflow. (:issue:`901`, :issue:`905`)
 - Remove test exclusions for MacOs and adapt tests and reference data. (:issue:`902`)
 
 7.2 (24 February 2024)


### PR DESCRIPTION
The update of the installed packages takes quite long and is failing.