### PR TITLE
Increase timeout of pytest because of MacOs runner

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,4 +52,4 @@ ignore = E203, E501, W503
 exclude = .git, __pycache__, tests/cmake_gtest/build/_deps
 
 [tool:pytest]
-addopts = -v --timeout=60 --doctest-modules --ignore-glob=*/linked/subdir/*
+addopts = -v --timeout=90 --doctest-modules --ignore-glob=*/linked/subdir/*


### PR DESCRIPTION
The timeout of 60 seconds seems to be too less for some tests on MacOs.

[no changelog]