### PR TITLE
Use replacement value for NAN %

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,8 @@ New features and notable changes:
 
 Bug fixes and small improvements:
 
+- Use replacement value of 0 for function call count ``NAN %``. (:issue:`910`)
+
 Documentation:
 
 Internal changes:

--- a/gcovr/formats/gcov/parser.py
+++ b/gcovr/formats/gcov/parser.py
@@ -847,12 +847,18 @@ def _parse_tag_line(
         if match is not None:
             name, count, returned, blocks = match.groups()
             count = _int_from_gcov_unit(count)
+            if returned[-1] == "%":
+                if returned == "NAN %":
+                    returned = 0
+                else:
+                    returned = int(_float_from_gcov_percent(returned) * count / 100)
+            else:
+                returned = int(returned)
+
             return _FunctionLine(
                 name,
                 count,
-                int(_float_from_gcov_percent(returned) * count / 100)
-                if returned[-1] == "%"
-                else int(returned),
+                returned,
                 _float_from_gcov_percent(blocks),
             )
 


### PR DESCRIPTION
A function returned value of `NAN %`is replaced by 0.

Fixes #908 