### PR TITLE
Use development version instead of local ones

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ Script to generate the installer for gcovr.
 """
 
 from runpy import run_path
+import time
 from setuptools import setup, find_packages
 from os import path
 import re
@@ -35,7 +36,7 @@ with open(path.join(this_directory, "README.rst"), encoding="utf-8") as f:
 
 long_description = re.sub(
     r"^\.\. image:: \./",
-    r".. image:: https://raw.githubusercontent.com/gcovr/gcovr/{}/".format(version),
+    rf".. image:: https://raw.githubusercontent.com/gcovr/gcovr/{version}/",
     long_description,
     flags=re.MULTILINE,
 )
@@ -45,7 +46,11 @@ long_description = re.sub(
 
 setup(
     name="gcovr",
-    version=version,
+    version=(
+        version.replace("+main", f".dev{int(time.time())}+main")
+        if version.endswith("+main")
+        else version
+    ),
     long_description=long_description,
     long_description_content_type="text/x-rst",
     platforms=["any"],


### PR DESCRIPTION
According to https://packaging.python.org/en/latest/specifications/version-specifiers/#developmental-releases the used local version identifier is described as:
   Local version identifiers are used to denote fully API (and, if
   applicable, ABI) compatible patched versions of upstream projects.
According to https://packaging.python.org/en/latest/specifications/version-specifiers/#developmental-releases we should use a development version specifier. The version identifier is extended by the build time.

[no changelog]