### PR TITLE
Fix building executable with python 3.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,7 +91,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         gcc: [gcc-8]
-        python-version: ['3.8', '3.9', '3.10', '3.11', 'pypy-3.8']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy-3.8']
 
         include:
 
@@ -110,15 +110,15 @@ jobs:
             python-version: '3.8'
           - os: windows-2019
             gcc: gcc
-            python-version: '3.11'
+            python-version: '3.12'
 
-          # Test minimum and maximum Python version on Windows.
+          # Test minimum and maximum Python version on Mac OS.
           - os: macos-12
             gcc: gcc
             python-version: '3.8'
           - os: macos-12
             gcc: gcc-13
-            python-version: '3.11'
+            python-version: '3.12'
 
     steps:
       - uses: actions/checkout@v4
@@ -127,8 +127,8 @@ jobs:
           # Enable coverage for specific target configurations
           case "${{ matrix.os }}/${{ matrix.gcc }}/${{ matrix.python-version }}" in
             ubuntu-22.04/gcc-11/3.11) USE_COVERAGE=true ;;
-            windows-2019/gcc-8/3.8)   USE_COVERAGE=true ;;
-            macos-12/gcc-13/3.11)     USE_COVERAGE=true ;;
+            windows-2019/gcc-8/3.12)   USE_COVERAGE=true ;;
+            macos-12/gcc-13/3.12)     USE_COVERAGE=true ;;
             macos-12/gcc/3.8)         USE_COVERAGE=true ;;
             *)                        USE_COVERAGE=false ;;
           esac

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Bug fixes and small improvements:
 - Use replacement value of 0 for function call count ``NAN %``. (:issue:`910`)
 - Fix erroneous deprecation warning. (:issue:`912`)
 - Fix display filename in HTML report. (:issue:`920`)
+- Fix bundle of standalone executable with Python 3.12. (:issue:`924`)
 
 Documentation:
 
@@ -32,6 +33,8 @@ Internal changes:
 - Link correct documentation version in copyright header. (:issue:`907`)
 - Move tag creation before publish the distribution because tag from pipeline doesn't trigger additional runs. (:issue:`899`)
 - Fix scrubber for date in HTML test data. (:issue:`919`)
+- Add test with Python 3.12. (:issue:`924`)
+
 
 7.2 (24 February 2024)
 ----------------------

--- a/gcovr/merging.py
+++ b/gcovr/merging.py
@@ -293,7 +293,7 @@ def merge_function(
         if left.count.keys() != right.count.keys():
             lines = sorted(set([*left.count.keys(), *right.count.keys()]))
             raise AssertionError(
-                f"Got function {right.name} on multiple lines: {', '.join([str(l) for l in lines])}.\n"
+                f"Got function {right.name} on multiple lines: {', '.join([str(line) for line in lines])}.\n"
                 "\tYou can run gcovr with --merge-mode-functions=MERGE_MODE.\n"
                 "\tThe available values for MERGE_MODE are described in the documentation."
             )

--- a/noxfile.py
+++ b/noxfile.py
@@ -320,30 +320,34 @@ def upload_wheel(session: nox.Session) -> None:
 def bundle_app(session: nox.Session) -> None:
     """Bundle a standalone executable."""
     session.install("pyinstaller~=5.13.2")
-    session.install("-e", ".")
+    # This is needed if the virtual env is reused
+    session.run("pip", "uninstall", "gcovr")
+    # Do not install interactive to get the module resolved
+    # with the needed data
+    session.install(".")
     os.makedirs("build", exist_ok=True)
-    session.chdir("build")
-    if platform.system() == "Windows":
-        executable = "gcovr.exe"
-    else:
-        executable = "gcovr"
-    session.run(
-        "pyinstaller",
-        "--distpath",
-        ".",
-        "--workpath",
-        "./pyinstaller",
-        "--specpath",
-        "./pyinstaller",
-        "--onefile",
-        "--collect-all",
-        "gcovr.formats",
-        "-n",
-        executable,
-        *session.posargs,
-        "../scripts/pyinstaller_entrypoint.py",
-    )
-    session.notify("check_bundled_app")
+    with session.chdir("build"):
+        if platform.system() == "Windows":
+            executable = "gcovr.exe"
+        else:
+            executable = "gcovr"
+        session.run(
+            "pyinstaller",
+            "--distpath",
+            ".",
+            "--workpath",
+            "./pyinstaller",
+            "--specpath",
+            "./pyinstaller",
+            "--onefile",
+            "--collect-all",
+            "gcovr",
+            "-n",
+            executable,
+            *session.posargs,
+            "../scripts/pyinstaller_entrypoint.py",
+        )
+        session.notify("check_bundled_app")
 
 
 @nox.session(python=False)


### PR DESCRIPTION
#923 pointed out that there is a problem building the standalone executable with Python 3.12.

The application aborts with following message: 

```
Traceback (most recent call last):
  File "pyinstaller_entrypoint.py", line 22, in <module>
ModuleNotFoundError: No module named 'gcovr.__main__'
[267] Failed to execute script 'pyinstaller_entrypoint' due to unhandled exception!
```