### PR TITLE
Turn off coexisting_object_directories tests for MacOs with gcc

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -275,7 +275,8 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           env_vars: OS,PYTHON
-          fail_ci_if_error: true
+          # The upload process is often failing on MacOs.
+          fail_ci_if_error: ${{ ! startsWith(matrix.os, 'macos-') }}
           disable_search: true
           plugins: pycoverage
           files: ./coverage.xml

--- a/tests/test_gcovr.py
+++ b/tests/test_gcovr.py
@@ -364,6 +364,12 @@ def pytest_generate_tests(metafunc):
                     name == "gcc-abspath" and (IS_CLANG or CC_REFERENCE_VERSION < 8),
                     reason="Option -fprofile-abs-path is supported since gcc-8",
                 ),
+                pytest.mark.xfail(
+                    name == "coexisting_object_directories"
+                    and IS_MACOS
+                    and not IS_CLANG,
+                    reason="There are compiler errors from include of iostream",
+                ),
             ]
 
             collected_params.append(

--- a/tests/test_gcovr.py
+++ b/tests/test_gcovr.py
@@ -365,7 +365,17 @@ def pytest_generate_tests(metafunc):
                     reason="Option -fprofile-abs-path is supported since gcc-8",
                 ),
                 pytest.mark.xfail(
-                    name in ["coexisting_object_directories", "cmake_oos"]
+                    name
+                    in [
+                        "cmake_oos",
+                        "cmake_oos_ninja",
+                        "coexisting_object_directories-from_build_dir",
+                        "coexisting_object_directories-from_build_dir-without_search_dir",
+                        "coexisting_object_directories-from_build_dir-without_object_dir",
+                        "coexisting_object_directories-from_root_dir",
+                        "coexisting_object_directories-from_root_dir-without_search_dir",
+                        "coexisting_object_directories-from_root_dir-without_object_dir",
+                    ]
                     and IS_MACOS
                     and CC_REFERENCE == "gcc-13",
                     reason="There are compiler errors from include of iostream",

--- a/tests/test_gcovr.py
+++ b/tests/test_gcovr.py
@@ -365,9 +365,9 @@ def pytest_generate_tests(metafunc):
                     reason="Option -fprofile-abs-path is supported since gcc-8",
                 ),
                 pytest.mark.xfail(
-                    name == "coexisting_object_directories"
+                    name in ["coexisting_object_directories", "cmake_oos"]
                     and IS_MACOS
-                    and not IS_CLANG,
+                    and CC_REFERENCE == "gcc-13",
                     reason="There are compiler errors from include of iostream",
                 ),
             ]


### PR DESCRIPTION
The test is not compilable with gcc on MacOs. The native compiler is working

[no changelog]