### PR TITLE
Fix cache in pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -223,6 +223,9 @@ jobs:
           verbose: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Expose GitHub Runtime for Docker cache
+        if: ${{ (! startsWith(matrix.python-version,'pypy')) && (! startsWith(matrix.os,'windows-'))}}
+        uses: crazy-max/ghaction-github-runtime@v3
       - name: Generate documentation
         if: ${{ (! startsWith(matrix.python-version,'pypy')) && (! startsWith(matrix.os,'windows-'))}}
         run: |
@@ -276,6 +279,8 @@ jobs:
           python -m pip install --upgrade pip
           python3 -m pip install nox requests
       - uses: actions/checkout@v4
+      - name: Expose GitHub Runtime for Docker cache
+        uses: crazy-max/ghaction-github-runtime@v3
       - name: Build Docker
         run: |
           python3 -m nox --non-interactive --session "docker_build_compiler(${{ matrix.gcc }})"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,12 +122,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
       - name: Setup environment
         run: |
           # Enable coverage for specific target configurations
           case "${{ matrix.os }}/${{ matrix.gcc }}/${{ matrix.python-version }}" in
             ubuntu-22.04/gcc-11/3.11) USE_COVERAGE=true ;;
-            windows-2019/gcc-8/3.12)   USE_COVERAGE=true ;;
+            windows-2019/gcc-8/3.12)  USE_COVERAGE=true ;;
             macos-12/gcc-13/3.12)     USE_COVERAGE=true ;;
             macos-12/gcc/3.8)         USE_COVERAGE=true ;;
             *)                        USE_COVERAGE=false ;;
@@ -138,6 +139,8 @@ jobs:
           echo "CC=${{ matrix.gcc }}" >> $GITHUB_ENV
 
         shell: bash
+
+      # Setup Ubuntu
       - name: Install build commands, GCC and libxml2 (Linux)
         if: ${{ startsWith(matrix.os,'ubuntu-') }}
         run: |
@@ -148,16 +151,20 @@ jobs:
             ${{ matrix.gcc }} \
             $(echo ${{ matrix.gcc }} | sed -e 's/gcc/g\+\+/') \
             libxml2-utils
-          sudo apt-get clean
+
+      # Setup Windows
       - name: Install msys with GCC (Windows)
         if: ${{ startsWith(matrix.os,'windows-') }}
         uses: msys2/setup-msys2@v2
         with:
           install: gcc make
+          cache: true
       - name: Install ninja (Windows)
         if: ${{ startsWith(matrix.os,'windows-') }}
         run: |
           choco install ninja
+
+      # Setup MacOS
       - name: Install ninja and libxml2 (MacOs)
         if: ${{ startsWith(matrix.os,'macos-') }}
         run: |
@@ -166,23 +173,31 @@ jobs:
           brew update
           brew install ninja
           brew install libxml2
+
+      # Setup python
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Get pip cache dir
+        id: pip-cache
+        run: |
+          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+        shell: bash
       - name: Cache pip
         uses: actions/cache@v4
         with:
-          # This path is specific to Ubuntu
-          path: ~/.cache/pip
+          path: ${{ steps.pip-cache.outputs.dir }}
           # Look to see if there is a cache hit for the corresponding requirements file
-          key: ${{ runner.os }}-pip-${{ hashFiles('noxfile.py', 'doc/requirements.txt') }}
+          key: ${{ matrix.os }}-python${{ matrix.python-version }}-pip-${{ hashFiles('noxfile.py', 'doc/requirements.txt') }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            ${{ matrix.os }}-pip-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           python3 -m pip install nox requests
+
+      # Run tests
       - name: Lint files
         run: |
           nox --non-interactive --session lint

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ __pycache__
 
 # nox virtual environments
 /.nox*/
+# User virtual environment
+/.venv/
 
 # Packages
 /gcovr.egg

--- a/noxfile.py
+++ b/noxfile.py
@@ -530,11 +530,35 @@ def docker_build_compiler_clang(session: nox.Session) -> None:
 def docker_build_compiler(session: nox.Session, version: str) -> None:
     """Build the docker container for a specific GCC version."""
     set_environment(session, version)
+    container_id = docker_container_id(session, version)
+    cache_options = []
+    if "GITHUB_ACTIONS" in os.environ:
+        session.log(
+            "Create a builder because the default on doesn't support the gha cache"
+        )
+        session.run(
+            "docker",
+            "buildx",
+            "create",
+            "--name",
+            "gha-container",
+            "--driver=docker-container",
+            "--driver-opt=default-load=true",
+            external=True,
+        )
+        cache_options += [
+            "--builder=gha-container",
+            "--cache-to",
+            f"type=gha,mode=max,scope={container_id}",
+            "--cache-from",
+            f"type=gha,scope={container_id}",
+        ]
     session.run(
         "docker",
         "build",
+        *cache_options,
         "--tag",
-        docker_container_id(session, version),
+        container_id,
         "--build-arg",
         f"DOCKER_OS={docker_container_os(session)}",
         "--build-arg",

--- a/noxfile.py
+++ b/noxfile.py
@@ -320,7 +320,9 @@ def upload_wheel(session: nox.Session) -> None:
 @nox.session
 def bundle_app(session: nox.Session) -> None:
     """Bundle a standalone executable."""
-    session.install("pyinstaller~=5.13.2")
+    session.install(
+        "pyinstaller~=6.8.0" if platform.system() == "Darwin" else "pyinstaller~=5.13.2"
+    )
     # This is needed if the virtual env is reused
     session.run("pip", "uninstall", "gcovr")
     # Do not install interactive to get the module resolved


### PR DESCRIPTION
Fix the pip cache directory to cache the data on all OS.

Activate beta feature of Docker to cache the builds on GitHub. This improves the time needed to build the docker image, e.g. a second run for `gcc-10` image needs 17s instead of 1m 22s.

[no changelog]