### PR TITLE
Do not trigger pipeline twice for new PR

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, synchronize, reopened, edited]
+    types: [synchronize, reopened, edited]  # opened: If PR is created a 'opened' and a 'edited' is triggered
 
 jobs:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, synchronize, reopened, edited]
+    types: [synchronize, reopened, edited]  # opened: If PR is created a 'opened' and a 'edited' is triggered
 
 jobs:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,7 +38,8 @@ Internal changes:
 - Add test with Python 3.12. (:issue:`924`)
 - Add gcc-14 to the test suite. (:issue:`923`)
 - Skip coverage upload if executed in a fork. (:issue:`930`)
-- Only execute on pipeline if pushed on main and add button to execute workflow manual. (:issue:`930`)
+- Only execute pipeline if pushed on main and add button to execute workflow manual. (:issue:`930`)
+- Do not trigger pipeline twice for new PR. (:issue:`931`)
 
 7.2 (24 February 2024)
 ----------------------


### PR DESCRIPTION
For the PR the `opened` and the `edited` is triggered. Since we need the `edited` to be triggered on comment changes we remove the `opened` trigger.