### PR TITLE
Fix code scanning alert

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,8 @@ Bug fixes and small improvements:
 - Fix display filename in HTML report. (:issue:`920`)
 - Fix bundle of standalone executable with Python 3.12. (:issue:`924`)
 - Fix merging of function coverage data. (:issue:`925`)
+- Fix inefficient regular expression. (:issue:`933`)
+
 
 Documentation:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,7 +24,7 @@ Bug fixes and small improvements:
 - Fix display filename in HTML report. (:issue:`920`)
 - Fix bundle of standalone executable with Python 3.12. (:issue:`924`)
 - Fix merging of function coverage data. (:issue:`925`)
-- Fix inefficient regular expression. (:issue:`933`)
+- Fix inefficient regular expression. (:issue:`933`, :security_issue:`1`)
 
 
 Documentation:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -191,4 +191,10 @@ todo_include_todos = True
 # -- Options for extlinks extension ------------------------------------------
 
 # see http://www.sphinx-doc.org/en/master/ext/extlinks.html
-extlinks = {"issue": ("https://github.com/gcovr/gcovr/issues/%s", "#%s")}
+extlinks = {
+    "issue": ("https://github.com/gcovr/gcovr/issues/%s", "#%s"),
+    "security_issue": (
+        "https://github.com/gcovr/gcovr/security/code-scanning/%s",
+        "Code scanning alert #%s",
+    ),
+}

--- a/gcovr/decision_analysis.py
+++ b/gcovr/decision_analysis.py
@@ -37,7 +37,7 @@ _C_STYLE_COMMENT_PATTERN = re.compile(r"/\*.*?\*/")
 _CPP_STYLE_COMMENT_PATTERN = re.compile(r"//.*?$")
 _WHITESPACE_PATTERN = re.compile(r"\s+")
 
-_ONE_LINE_BRANCH = re.compile(r"^[^;]+{(?:.*;)*.*}$")
+_ONE_LINE_BRANCH = re.compile(r"^[^;]+{(?:[^;]+;)*.*}$")
 
 # helper functions
 


### PR DESCRIPTION
https://github.com/gcovr/gcovr/security/code-scanning/1: Changed to be less greedy.

Also extended Spynx configuration with role to shorten security links.