### PR TITLE
Update Sphinx config

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,8 @@ Bug fixes and small improvements:
 
 Documentation:
 
+- Update Sphinx config because of deprecated context injection from Read The Docs. (:issue:`936`)
+
 Internal changes:
 
 - Move tests to directory in the root. (:issue:`897`)

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -46,6 +46,8 @@ version = gcovr.version.__version__
 # The full version, including alpha/beta/rc tags
 release = version
 
+# Define the canonical URL used on Read the Docs
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
 
 # -- General configuration ---------------------------------------------------
 
@@ -192,3 +194,11 @@ todo_include_todos = True
 
 # see http://www.sphinx-doc.org/en/master/ext/extlinks.html
 extlinks = {"issue": ("https://github.com/gcovr/gcovr/issues/%s", "#%s")}
+
+# -- Jinja2 template context ------------------------------------------
+
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    if "html_context" not in globals():
+        html_context = {}
+    html_context["READTHEDOCS"] = True


### PR DESCRIPTION
Read The Docs has deprecated Sphinx context injection and we need to do the configuration on our own.

Add settings from https://github.com/readthedocs/sphinx-build-compatibility/blob/main/sphinx_build_compatibility/extension.py to our configuration.

Closes #934