### PR TITLE
Trigger again pipeline on PR open

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [synchronize, reopened, edited]  # opened: If PR is created a 'opened' and a 'edited' is triggered
+    types: [opened, synchronize, reopened, edited]
 
 jobs:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [synchronize, reopened, edited]  # opened: If PR is created a 'opened' and a 'edited' is triggered
+    types: [opened, synchronize, reopened, edited]
 
 jobs:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,7 +44,6 @@ Internal changes:
 - Add gcc-14 to the test suite. (:issue:`923`)
 - Skip coverage upload if executed in a fork. (:issue:`930`)
 - Only execute pipeline if pushed on main and add button to execute workflow manual. (:issue:`930`)
-- Do not trigger pipeline twice for new PR. (:issue:`931`)
 - Check spelling in test pipeline. (:issue:`932`)
 
 7.2 (24 February 2024)


### PR DESCRIPTION
Revert #931.

This seems to be only an issue for maintainers. PRs from otheres need to be triggered on `opened`.

[no changelog]