### PR TITLE
Don't loose stderr and stdout of gcovr for non-zero return code

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,7 @@ Bug fixes and small improvements:
 - Fix bundle of standalone executable with Python 3.12. (:issue:`924`)
 - Fix merging of function coverage data. (:issue:`925`)
 - Fix inefficient regular expression. (:issue:`933`)
+- Fix missing output of gcov if execution fails. (:issue:`956`)
 
 Documentation:
 

--- a/gcovr/formats/gcov/read.py
+++ b/gcovr/formats/gcov/read.py
@@ -793,10 +793,16 @@ class GcovProgram:
         out, err = gcov_process.communicate()
         if gcov_process.returncode < 0:
             raise RuntimeError(
-                f"GCOV returncode was {gcov_process.returncode} (exited by signal)."
+                f"GCOV returncode was {gcov_process.returncode} (exited by signal).\n"
+                f"Stdout of gcov was >>{out}<< End of stdout\n"
+                f"Stderr of gcov was >>{err}<< End of stderr"
             )
         elif gcov_process.returncode not in GcovProgram.__exitcode_to_ignore:
-            raise RuntimeError(f"GCOV returncode was {gcov_process.returncode}.")
+            raise RuntimeError(
+                f"GCOV returncode was {gcov_process.returncode}.\n"
+                f"Stdout of gcov was >>{out}<< End of stdout\n"
+                f"Stderr of gcov was >>{err}<< End of stderr"
+                )
 
         return (out, err)
 

--- a/gcovr/formats/gcov/read.py
+++ b/gcovr/formats/gcov/read.py
@@ -802,7 +802,7 @@ class GcovProgram:
                 f"GCOV returncode was {gcov_process.returncode}.\n"
                 f"Stdout of gcov was >>{out}<< End of stdout\n"
                 f"Stderr of gcov was >>{err}<< End of stderr"
-                )
+            )
 
         return (out, err)
 


### PR DESCRIPTION
I try to fix next message
```
(ERROR) GCOV produced the following errors processing /home/gitlab-runner/disk/builds/HafKdfP1/0/PT/hiper100re/build/contrib/libre2/CMakeFiles/re2.dir/util/strutil.cc.gcda:
	Trouble processing '/home/gitlab-runner/disk/builds/HafKdfP1/0/PT/hiper100re/build/contrib/libre2/CMakeFiles/re2.dir/util/strutil.cc.gcda' with working directory '/home/gitlab-runner/disk/builds/HafKdfP1/0/PT/hiper100re'.
Stdout of gcov was >>None<< End of stdout    (<- Here)
Stderr of gcov was >>None<< End of stderr   (<- Here)
Exception was >>GCOV returncode was 5.<< End of stderr
```
We lose stdout and stderr when return code of gcov is not 0 or 6, so all useful information lost ( I used strace tool to get messages).

Now, stdout and stderr are saved in object for sure