### PR TITLE
Add license type and update documentation

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,3 +1,5 @@
+BSD 3-Clause License
+
 Copyright (c) 2013-2024 the gcovr authors
 Copyright (c) 2013 Sandia Corporation.
 Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
@@ -9,25 +11,24 @@ Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions
 are met:
 
-* Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
 
-* Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
 
-* Neither the name of the Sandia National Laboratories nor the names of
-its contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
-TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.rst
+++ b/README.rst
@@ -236,23 +236,12 @@ Contributing
 
 If you want to report a bug or contribute to gcovr development,
 please read our contributing guidelines first:
-`<https://github.com/gcovr/gcovr/blob/main/CONTRIBUTING.rst>`_
+`<https://gcovr.com/en/latest/contributing.html>`_
 
 License
 -------
 
-.. begin license
-
-Copyright (c) 2013-2024 the gcovr authors
-Copyright (c) 2013 Sandia Corporation.
-Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
-the U.S. Government retains certain rights in this software.
-
 This software is distributed under the 3-clause BSD License.
-See LICENSE.txt for full details.
-See AUTHORS.txt for the full list of contributors.
-
-Gcovr development moved to this repository in September, 2013 from
-Sandia National Laboratories.
-
-.. end license
+See `<https://gcovr.com/en/latest/license.html#license-terms>`_ for details.
+See `<https://gcovr.com/en/latest/license.html#acknowledgements>`_
+for the full list of contributors.

--- a/admin/bump_version.py
+++ b/admin/bump_version.py
@@ -184,35 +184,6 @@ def updateChangelog(filename: str, lines: List[str]):
     return newLines
 
 
-def updateReadme(filename: str, lines: List[str]):
-    newLines = []
-
-    iterLines = iter(lines)
-    for line in iterLines:
-        newLines.append(line)
-        if line == ".. begin license":
-            break
-    else:
-        raise RuntimeError(f"Start of license not found in {filename!r}.")
-
-    newLines.append("")
-    for line in COPYRIGHT:
-        newLines.append(line)
-    newLines.append("")
-    newLines.append(LICENSE)
-
-    for line in iterLines:
-        if line == "See LICENSE.txt for full details.":
-            newLines.append(line)
-            break
-    else:
-        raise RuntimeError(f"Reference to LICENSE.txr not found in {filename!r}.")
-
-    newLines.extend(iterLines)
-
-    return newLines
-
-
 def updateDocumentation(filename: str, lines: List[str]):
     newLines = []
 
@@ -256,7 +227,10 @@ def updateReferenceData(filename: str, lines: List[str]):
 
 
 def updateLicense(filename: str, lines: List[str]):
-    newLines = []
+    newLines = [
+        "BSD 3-Clause License",
+        "",
+    ]
 
     for line in COPYRIGHT:
         newLines.append(line)
@@ -309,8 +283,6 @@ def main():
                 handlers.append(updateCopyrightString)
             if filename == "CI.yml":
                 handlers.append(updateCallOfReleaseChecklist)
-            if filename == "README.rst":
-                handlers.append(updateReadme)
             if filename == "LICENSE.txt":
                 handlers.append(updateLicense)
             if filename == "test_gcovr.py":

--- a/doc/source/license.rst
+++ b/doc/source/license.rst
@@ -1,14 +1,8 @@
 License
 =======
 
-.. include:: ../../README.rst
-   :start-after: .. begin license
-   :end-before: .. end license
-
 License Terms
 -------------
-
-Gcovr is available under the terms of a BSD-3-clause license:
 
 .. literalinclude:: ../../LICENSE.txt
    :language: none
@@ -19,8 +13,11 @@ Acknowledgements
 .. include:: ../../AUTHORS.txt
 
 The development of Gcovr has been partially supported
-by Sandia National Laboratories.  Sandia National Laboratories is
+by Sandia National Laboratories. Sandia National Laboratories is
 a multi-program laboratory managed and operated by Sandia Corporation,
 a wholly owned subsidiary of Lockheed Martin Corporation, for the
 U.S.  Department of Energy's National Nuclear Security Administration
 under contract DE-AC04-94AL85000.
+
+Gcovr development moved to this repository in September, 2013 from
+Sandia National Laboratories.


### PR DESCRIPTION
Use the license template for the `BSD 3-Clause License` from GitHub.
Instead of having the copyright notice in README.rst, license.rst and LICENSE.txt all locations reference the section in the documentation with the included LICENSE.txt.
From the README.rst rendered by GitHub we now link to the latest documentation instead of having the copyright notice and a textual reference to the other files.

[no changelog]