### PR TITLE
Remove test on MacOs 12 because of installation issues

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -132,9 +132,6 @@ jobs:
             upload-app: true
 
           # Test minimum and maximum Python version on Mac OS.
-          - os: macos-12
-            gcc: gcc
-            python-version: '3.12'
           - os: macos-13
             gcc: gcc
             python-version: '3.12'

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -52,7 +52,7 @@ Documentation:
 Internal changes:
 
 - Move tests to directory in the root. (:issue:`897`)
-- Add MacOs to the GitHub test workflow. (:issue:`901`, :issue:`905`)
+- Add MacOs to the GitHub test workflow. (:issue:`901`, :issue:`905`, :issue:`980``)
 - Remove test exclusions for MacOs and adapt tests and reference data. (:issue:`902`)
 - Link correct documentation version in copyright header. (:issue:`907`)
 - Move tag creation before publish the distribution because tag from pipeline doesn't trigger additional runs. (:issue:`899`)


### PR DESCRIPTION
There is a deprecation warning and brew installation is failing since today.

```
Warning: You are using macOS 12.
We (and Apple) do not provide support for this old version.
```