### PR TITLE
Exclude also lines belonging to excluded functions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,8 @@ Breaking changes:
 
 New features and notable changes:
 
+- If a internal generated function is excluded the lines, if present, are excluded as well. (:issue:`991`)
+
 Bug fixes and small improvements:
 
 - Fix exclusion of internal functions. (:issue:`987`)

--- a/gcovr/exclusions/__init__.py
+++ b/gcovr/exclusions/__init__.py
@@ -134,7 +134,16 @@ def remove_internal_functions(filecov: FileCoverage):
                 filecov.filename,
             )
 
+            # Remove function and exclude the related lines
             filecov.functions.pop(key)
+            for linecov in filecov.lines.values():
+                if (
+                    linecov.function_name is not None
+                    and linecov.function_name == function.name
+                ):
+                    linecov.excluded = True
+                    linecov.branches = {}
+                    linecov.count = 0
 
 
 def _function_can_be_excluded(name: str) -> bool:
@@ -160,15 +169,13 @@ def remove_throw_branches(filecov: FileCoverage) -> None:
     for linecov in filecov.lines.values():
         # iterate over shallow copy
         for branch_id, branch in list(linecov.branches.items()):
-            if not branch.throw:
-                continue
-
-            LOGGER.debug(
-                "Excluding unreachable branch on line %d file %s: detected as exception-only code",
-                linecov.lineno,
-                filecov.filename,
-            )
-            linecov.branches.pop(branch_id)
+            if branch.throw:
+                LOGGER.debug(
+                    "Excluding unreachable branch on line %d file %s: detected as exception-only code",
+                    linecov.lineno,
+                    filecov.filename,
+                )
+                linecov.branches.pop(branch_id)
 
 
 def remove_functions(filecov: FileCoverage, patterns: List[re.Pattern]) -> None:


### PR DESCRIPTION
If a compiler generated function is excluded and a line is assigned to this function the line is excluded as well.