### PR TITLE
Add file version check for external files

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,8 +14,9 @@ New features and notable changes:
 
 Bug fixes and small improvements:
 
- - Fixed an error handling bug throwing a `TypeError` exception on a gcov merge assertion failure instead of reporting 
-   the error and (if requested by the user) continuing execution. (:issue:`997`)
+- Fixed an error handling bug throwing a `TypeError` exception on a gcov merge assertion failure
+  instead of reporting the error and (if requested by the user) continuing execution. (:issue:`997`)
+- Check format version of external generated ``gcov`` JSON files. (:issue:`999`)
 
 Documentation:
 


### PR DESCRIPTION
This PR adds a check for the format version mentioned inside the gcov JSON file.

Closes #995 