### PR TITLE
Fix file not found exception

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,9 +16,10 @@ New features and notable changes:
 
 Bug fixes and small improvements:
 
-- Fixed an error handling bug throwing a `TypeError` exception on a gcov merge assertion failure
+- Fixed an error handling bug throwing a ``TypeError`` exception on a gcov merge assertion failure
   instead of reporting the error and (if requested by the user) continuing execution. (:issue:`997`)
 - Check format version of external generated ``gcov`` JSON files. (:issue:`999`)
+- Fix crash on Windows when trying to fix the case of the files. (:issue:`1000`)
 
 Documentation:
 

--- a/gcovr/utils.py
+++ b/gcovr/utils.py
@@ -79,15 +79,18 @@ def fix_case_of_path(path: str):
     if not cur:  # e.g path = "C:/"
         return rest.upper()  # Always use uppercase drive letter
 
-    curL = cur.lower()
-    matchedFileName = [f for f in os.listdir(rest) if f.lower() == curL]
-    if len(matchedFileName) > 1:
-        raise RuntimeError(
-            "Seems that we have a case sensitive filesystem, can't fix file case"
-        )
+    try:
+        curL = cur.lower()
+        matchedFileName = [f for f in os.listdir(rest) if f.lower() == curL]
+        if len(matchedFileName) > 1:
+            raise RuntimeError(
+                "Seems that we have a case sensitive filesystem, can't fix file case"
+            )
 
-    if len(matchedFileName) == 1:
-        path = os.path.join(fix_case_of_path(rest), matchedFileName[0])
+        if len(matchedFileName) == 1:
+            path = os.path.join(fix_case_of_path(rest), matchedFileName[0])
+    except FileNotFoundError:
+        LOGGER.warning(f"Can not fix case of path because {rest} not found.")
 
     return path.replace("\\", "/")
 

--- a/gcovr/utils.py
+++ b/gcovr/utils.py
@@ -59,11 +59,13 @@ class LoopChecker(object):
 def is_fs_case_insensitive():
     cwd = os.getcwd()
     # Guessing if file system is case insensitive.
-    # The working directory is not the root and accessible in upper and lower case.
+    # The working directory is not the root and accessible in upper and lower case
+    # and pointing to same file.
     ret = (
         (cwd != os.path.sep)
         and os.path.exists(cwd.upper())
         and os.path.exists(cwd.lower())
+        and os.path.samefile(cwd.upper(), cwd.lower())
     )
     LOGGER.debug(f"File system is case {'in' if ret else ''}sensitive.")
 


### PR DESCRIPTION
If on Windows (case insensitive filesystems) a source folder is removed before running `gcovr` it results in a crash when the file case is fixed.

Closes #994