### PR TITLE
Support lcov v1 format

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -66,7 +66,12 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: "coverage-lcov"
-          path: ./tests/nested/reference/**/coverage.lcov
+          path: ./tests/nested/reference/gcc-5/coverage.lcov
+      - name: Upload Cobertura coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: "coverage-cobertura"
+          path: ./tests/**/reference/gcc-5/cobertura.xml
 
   host:
     needs: [changelog-check, spell-check, upload-lcov]

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,8 +58,18 @@ jobs:
         run: |
           cspell
 
+  upload-lcov:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Upload LCOV coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: "coverage-lcov"
+          path: ./tests/nested/reference/**/coverage.lcov
+
   host:
-    needs: [changelog-check, spell-check]
+    needs: [changelog-check, spell-check, upload-lcov]
     uses: ./.github/workflows/gcovr-ci-job.yml
     with:
       os: ${{ matrix.os }}
@@ -129,7 +139,7 @@ jobs:
 
 
   docker:
-    needs: [changelog-check, spell-check]
+    needs: [changelog-check, spell-check, upload-lcov]
     uses: ./.github/workflows/gcovr-ci-job.yml
     with:
       container: true

--- a/.github/workflows/upload_coverage.yml
+++ b/.github/workflows/upload_coverage.yml
@@ -23,8 +23,9 @@ jobs:
         if: ${{ (github.repository == 'gcovr/gcovr') }}
         run: |
           # Search the coverage files and upload them
-          bash <(curl -Ls https://coverage.codacy.com/get.sh) report --partial -l python --force-coverage-parser cobertura -r 'coverage-*/coverage.xml'
-          bash <(curl -Ls https://coverage.codacy.com/get.sh) report --partial -l C --force-coverage-parser lcov -r 'coverage-lcov/**/*.lcov'
+          bash <(curl -Ls https://coverage.codacy.com/get.sh) report --partial -l python --force-coverage-parser cobertura $(find . -name 'coverage.xml' -print | sed -e 's/^/ -r /' | tr -d '\n')
+          bash <(curl -Ls https://coverage.codacy.com/get.sh) report --partial -l C --force-coverage-parser cobertura $(find . -regex '.*/coverage-cobertura/.*/cobertura\.xml' -print | sed -e 's/^/ -r /' | tr -d '\n')
+          bash <(curl -Ls https://coverage.codacy.com/get.sh) report --partial -l C --force-coverage-parser lcov $(find . -regex '.*/coverage-lcov/.*/coverage\.lcov' -print | sed -e 's/^/ -r /' | tr -d '\n') || echo ignored
         env:
           CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
 

--- a/.github/workflows/upload_coverage.yml
+++ b/.github/workflows/upload_coverage.yml
@@ -23,9 +23,8 @@ jobs:
         if: ${{ (github.repository == 'gcovr/gcovr') }}
         run: |
           # Search the coverage files and upload them
-          bash <(curl -Ls https://coverage.codacy.com/get.sh) report --partial -l python --force-coverage-parser cobertura $(find . -name 'coverage.xml' -print | sed -e 's/^/ -r /' | tr -d '\n')
-          # Do not upload lcov because of https://github.com/codacy/codacy-coverage-reporter/issues/510#issuecomment-2297469928
-          # bash <(curl -Ls https://coverage.codacy.com/get.sh) report --partial -l C --force-coverage-parser lcov $(find . -regex '.*/nested/reference/.*/coverage\.lcov' -print | sed -e 's/^/ -r /' | tr -d '\n')
+          bash <(curl -Ls https://coverage.codacy.com/get.sh) report --partial -l python --force-coverage-parser cobertura -r 'coverage-*/coverage.xml'
+          bash <(curl -Ls https://coverage.codacy.com/get.sh) report --partial -l C --force-coverage-parser lcov -r 'coverage-lcov/**/*.lcov'
         env:
           CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Breaking changes:
 New features and notable changes:
 
 - Add condition coverage to text summary report. (:issue:`985`)
+- Add option to generate LCOV format produced by version 1.x of LCOV tool. (:issue:`1001`)
 
 Bug fixes and small improvements:
 

--- a/gcovr/formats/lcov/__init__.py
+++ b/gcovr/formats/lcov/__init__.py
@@ -44,6 +44,13 @@ class LcovHandler(BaseHandler):
                 const=OutputOrDefault(None),
             ),
             GcovrConfigOption(
+                "lcov_format_v1",
+                ["--lcov-format-1.x"],
+                group="output_options",
+                help="Write format from LCOV version 1.x instead of 2.x.",
+                action="store_true",
+            ),
+            GcovrConfigOption(
                 "lcov_comment",
                 ["--lcov-comment"],
                 group="output_options",

--- a/gcovr/formats/lcov/write.py
+++ b/gcovr/formats/lcov/write.py
@@ -55,7 +55,7 @@ def write_report(covdata: CovData, output_file: str, options: Options) -> None:
             fh.write(f"SF:{filename}\n")
 
             # This filename is generated in the JSON intermediate format
-            if not filename.endswith("<stdin>"):
+            if not options.lcov_format_v1 and not filename.endswith("<stdin>"):
                 # VER:<version ID>
                 # Generate md5 hash of file contents
                 with open(filename, "rb") as file_handle:

--- a/tests/nested/Makefile
+++ b/tests/nested/Makefile
@@ -21,7 +21,7 @@ txt: coverage.json
 	$(GCOVR) -r subdir -a $< -o coverage.txt
 
 lcov: coverage.json
-	$(GCOVR) -r subdir -a $< --lcov coverage.lcov
+	$(GCOVR) -r subdir -a $< --lcov coverage.lcov --lcov-format-1.x
 
 clover: coverage.json
 	$(GCOVR) -r subdir -a $< --clover-pretty --clover clover.xml --clover-project "Test project"

--- a/tests/nested/reference/clang-10/coverage.lcov
+++ b/tests/nested/reference/clang-10/coverage.lcov
@@ -1,6 +1,5 @@
 TN:GCOVR report
 SF:tests/nested/subdir/A/C/D/File6.cpp
-VER:51c81752202f160b25ffc07fb9134018
 FN:1,_Z4foo6i
 FNDA:1,_Z4foo6i
 FNF:1
@@ -18,7 +17,6 @@ LH:4
 LF:5
 end_of_record
 SF:tests/nested/subdir/A/C/file5.cpp
-VER:994904d7cb6f33c4235bc1f132c029f9
 FN:1,_Z4foo5i
 FNDA:1,_Z4foo5i
 FNF:1
@@ -36,7 +34,6 @@ LH:4
 LF:5
 end_of_record
 SF:tests/nested/subdir/A/file1.cpp
-VER:cf6b72cbb3c9c004a97684f1495332fd
 FN:1,_Z3fooi
 FNDA:1,_Z3fooi
 FNF:1
@@ -54,7 +51,6 @@ LH:4
 LF:5
 end_of_record
 SF:tests/nested/subdir/A/File2.cpp
-VER:44683de2597fa27a9410e0f65f71fde0
 FN:1,_Z3barv
 FNDA:1,_Z3barv
 FN:8,_Z4bar_v
@@ -74,7 +70,6 @@ LH:4
 LF:7
 end_of_record
 SF:tests/nested/subdir/A/file3.cpp
-VER:17749ac4040d8e71ff948fceb4e522d9
 FN:1,_Z8four_barv
 FNDA:1,_Z8four_barv
 FN:8,_Z9four_bar_v
@@ -99,7 +94,6 @@ LH:4
 LF:10
 end_of_record
 SF:tests/nested/subdir/A/File4.cpp
-VER:7451828cfb58f0fefc6e5fbf44d9a6f4
 FN:1,_Z6foobari
 FNDA:1,_Z6foobari
 FNF:1
@@ -117,7 +111,6 @@ LH:4
 LF:5
 end_of_record
 SF:tests/nested/subdir/A/file7.cpp
-VER:cbd3974ad5ed983ce0a47c7a7d8b5725
 FN:1,_Z9uncoveredv
 FNDA:0,_Z9uncoveredv
 FNF:1
@@ -130,7 +123,6 @@ LH:0
 LF:2
 end_of_record
 SF:tests/nested/subdir/B/main.cpp
-VER:c95232e53ac0253b638414c18fd6ba6c
 FN:12,main
 FNDA:1,main
 FNF:1

--- a/tests/nested/reference/clang-13/coverage.lcov
+++ b/tests/nested/reference/clang-13/coverage.lcov
@@ -1,6 +1,5 @@
 TN:GCOVR report
 SF:tests/nested/subdir/A/C/D/File6.cpp
-VER:51c81752202f160b25ffc07fb9134018
 FN:1,foo6(int)
 FNDA:1,foo6(int)
 FNF:1
@@ -18,7 +17,6 @@ LH:4
 LF:5
 end_of_record
 SF:tests/nested/subdir/A/C/file5.cpp
-VER:994904d7cb6f33c4235bc1f132c029f9
 FN:1,foo5(int)
 FNDA:1,foo5(int)
 FNF:1
@@ -36,7 +34,6 @@ LH:4
 LF:5
 end_of_record
 SF:tests/nested/subdir/A/file1.cpp
-VER:cf6b72cbb3c9c004a97684f1495332fd
 FN:1,foo(int)
 FNDA:1,foo(int)
 FNF:1
@@ -54,7 +51,6 @@ LH:4
 LF:5
 end_of_record
 SF:tests/nested/subdir/A/File2.cpp
-VER:44683de2597fa27a9410e0f65f71fde0
 FN:1,bar()
 FNDA:1,bar()
 FN:8,bar_()
@@ -74,7 +70,6 @@ LH:4
 LF:7
 end_of_record
 SF:tests/nested/subdir/A/file3.cpp
-VER:17749ac4040d8e71ff948fceb4e522d9
 FN:1,four_bar()
 FNDA:1,four_bar()
 FN:8,four_bar_()
@@ -99,7 +94,6 @@ LH:4
 LF:10
 end_of_record
 SF:tests/nested/subdir/A/File4.cpp
-VER:7451828cfb58f0fefc6e5fbf44d9a6f4
 FN:1,foobar(int)
 FNDA:1,foobar(int)
 FNF:1
@@ -117,7 +111,6 @@ LH:4
 LF:5
 end_of_record
 SF:tests/nested/subdir/A/file7.cpp
-VER:cbd3974ad5ed983ce0a47c7a7d8b5725
 FN:1,uncovered()
 FNDA:0,uncovered()
 FNF:1
@@ -130,7 +123,6 @@ LH:0
 LF:2
 end_of_record
 SF:tests/nested/subdir/B/main.cpp
-VER:c95232e53ac0253b638414c18fd6ba6c
 FN:12,main
 FNDA:1,main
 FNF:1

--- a/tests/nested/reference/gcc-14/coverage.lcov
+++ b/tests/nested/reference/gcc-14/coverage.lcov
@@ -1,6 +1,5 @@
 TN:GCOVR report
 SF:tests/nested/subdir/A/C/D/File6.cpp
-VER:51c81752202f160b25ffc07fb9134018
 FN:1,_Z4foo6i
 FNDA:1,_Z4foo6i
 FNF:1
@@ -17,7 +16,6 @@ LH:3
 LF:4
 end_of_record
 SF:tests/nested/subdir/A/C/file5.cpp
-VER:994904d7cb6f33c4235bc1f132c029f9
 FN:1,_Z4foo5i
 FNDA:1,_Z4foo5i
 FNF:1
@@ -34,7 +32,6 @@ LH:3
 LF:4
 end_of_record
 SF:tests/nested/subdir/A/file1.cpp
-VER:cf6b72cbb3c9c004a97684f1495332fd
 FN:1,_Z3fooi
 FNDA:1,_Z3fooi
 FNF:1
@@ -51,7 +48,6 @@ LH:3
 LF:4
 end_of_record
 SF:tests/nested/subdir/A/File2.cpp
-VER:44683de2597fa27a9410e0f65f71fde0
 FN:1,_Z3barv
 FNDA:1,_Z3barv
 FN:8,_Z4bar_v
@@ -71,7 +67,6 @@ LH:4
 LF:7
 end_of_record
 SF:tests/nested/subdir/A/file3.cpp
-VER:17749ac4040d8e71ff948fceb4e522d9
 FN:1,_Z8four_barv
 FNDA:1,_Z8four_barv
 FN:8,_Z9four_bar_v
@@ -95,7 +90,6 @@ LH:4
 LF:9
 end_of_record
 SF:tests/nested/subdir/A/File4.cpp
-VER:7451828cfb58f0fefc6e5fbf44d9a6f4
 FN:1,_Z6foobari
 FNDA:1,_Z6foobari
 FNF:1
@@ -112,7 +106,6 @@ LH:3
 LF:4
 end_of_record
 SF:tests/nested/subdir/A/file7.cpp
-VER:cbd3974ad5ed983ce0a47c7a7d8b5725
 FN:1,_Z9uncoveredv
 FNDA:0,_Z9uncoveredv
 FNF:1
@@ -125,7 +118,6 @@ LH:0
 LF:2
 end_of_record
 SF:tests/nested/subdir/B/main.cpp
-VER:c95232e53ac0253b638414c18fd6ba6c
 FN:12,main
 FNDA:1,main
 FNF:1

--- a/tests/nested/reference/gcc-5/coverage.lcov
+++ b/tests/nested/reference/gcc-5/coverage.lcov
@@ -1,6 +1,5 @@
 TN:GCOVR report
 SF:tests/nested/subdir/A/C/D/File6.cpp
-VER:51c81752202f160b25ffc07fb9134018
 FN:1,foo6(int)
 FNDA:1,foo6(int)
 FNF:1
@@ -17,7 +16,6 @@ LH:3
 LF:4
 end_of_record
 SF:tests/nested/subdir/A/C/file5.cpp
-VER:994904d7cb6f33c4235bc1f132c029f9
 FN:1,foo5(int)
 FNDA:1,foo5(int)
 FNF:1
@@ -34,7 +32,6 @@ LH:3
 LF:4
 end_of_record
 SF:tests/nested/subdir/A/file1.cpp
-VER:cf6b72cbb3c9c004a97684f1495332fd
 FN:1,foo(int)
 FNDA:1,foo(int)
 FNF:1
@@ -51,7 +48,6 @@ LH:3
 LF:4
 end_of_record
 SF:tests/nested/subdir/A/File2.cpp
-VER:44683de2597fa27a9410e0f65f71fde0
 FN:1,bar()
 FNDA:1,bar()
 FN:8,bar_()
@@ -71,7 +67,6 @@ LH:4
 LF:7
 end_of_record
 SF:tests/nested/subdir/A/file3.cpp
-VER:17749ac4040d8e71ff948fceb4e522d9
 FN:1,four_bar()
 FNDA:1,four_bar()
 FN:8,four_bar_()
@@ -95,7 +90,6 @@ LH:4
 LF:9
 end_of_record
 SF:tests/nested/subdir/A/File4.cpp
-VER:7451828cfb58f0fefc6e5fbf44d9a6f4
 FN:1,foobar(int)
 FNDA:1,foobar(int)
 FNF:1
@@ -112,7 +106,6 @@ LH:3
 LF:4
 end_of_record
 SF:tests/nested/subdir/A/file7.cpp
-VER:cbd3974ad5ed983ce0a47c7a7d8b5725
 FN:1,uncovered()
 FNDA:0,uncovered()
 FNF:1
@@ -125,7 +118,6 @@ LH:0
 LF:2
 end_of_record
 SF:tests/nested/subdir/B/main.cpp
-VER:c95232e53ac0253b638414c18fd6ba6c
 FN:12,main
 FNDA:1,main
 FNF:1

--- a/tests/nested/reference/gcc-8/coverage.lcov
+++ b/tests/nested/reference/gcc-8/coverage.lcov
@@ -1,6 +1,5 @@
 TN:GCOVR report
 SF:tests/nested/subdir/A/C/D/File6.cpp
-VER:51c81752202f160b25ffc07fb9134018
 FN:1,foo6(int)
 FNDA:1,foo6(int)
 FNF:1
@@ -17,7 +16,6 @@ LH:3
 LF:4
 end_of_record
 SF:tests/nested/subdir/A/C/file5.cpp
-VER:994904d7cb6f33c4235bc1f132c029f9
 FN:1,foo5(int)
 FNDA:1,foo5(int)
 FNF:1
@@ -34,7 +32,6 @@ LH:3
 LF:4
 end_of_record
 SF:tests/nested/subdir/A/file1.cpp
-VER:cf6b72cbb3c9c004a97684f1495332fd
 FN:1,foo(int)
 FNDA:1,foo(int)
 FNF:1
@@ -51,7 +48,6 @@ LH:3
 LF:4
 end_of_record
 SF:tests/nested/subdir/A/File2.cpp
-VER:44683de2597fa27a9410e0f65f71fde0
 FN:1,bar()
 FNDA:1,bar()
 FN:8,bar_()
@@ -71,7 +67,6 @@ LH:4
 LF:7
 end_of_record
 SF:tests/nested/subdir/A/file3.cpp
-VER:17749ac4040d8e71ff948fceb4e522d9
 FN:1,four_bar()
 FNDA:1,four_bar()
 FN:8,four_bar_()
@@ -95,7 +90,6 @@ LH:4
 LF:9
 end_of_record
 SF:tests/nested/subdir/A/File4.cpp
-VER:7451828cfb58f0fefc6e5fbf44d9a6f4
 FN:1,foobar(int)
 FNDA:1,foobar(int)
 FNF:1
@@ -112,7 +106,6 @@ LH:3
 LF:4
 end_of_record
 SF:tests/nested/subdir/A/file7.cpp
-VER:cbd3974ad5ed983ce0a47c7a7d8b5725
 FN:1,uncovered()
 FNDA:0,uncovered()
 FNF:1
@@ -125,7 +118,6 @@ LH:0
 LF:2
 end_of_record
 SF:tests/nested/subdir/B/main.cpp
-VER:c95232e53ac0253b638414c18fd6ba6c
 FN:12,main
 FNDA:1,main
 FNF:1


### PR DESCRIPTION
Add option to generate LCOV format produced by version 1.x of LCOV tool because this is supported by most CI/CD systems for uploading coverage data.