### PR TITLE
Set the timestamp as environment

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,8 @@ Documentation:
 
 Internal changes:
 
+- Fix sporadic timestamp mismatch in development build package. (:issue:`1006`)
+
 8.2 (13 October 2024)
 ---------------------
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -28,6 +28,7 @@ import sys
 from pathlib import Path
 import textwrap
 from time import sleep
+import time
 from typing import Tuple
 import requests
 import shutil
@@ -438,7 +439,7 @@ def build_wheel(session: nox.Session) -> None:
     dist_dir = Path("dist")
     if dist_dir.exists():
         shutil.rmtree(dist_dir)
-    session.run("python", "-m", "build")
+    session.run("python", "-m", "build", env={"TIMESTAMP": str(int(time.time()))})
     session.notify(("check_wheel"))
 
 

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@
 Script to generate the installer for gcovr.
 """
 
+import os
 from runpy import run_path
 import time
 from setuptools import setup, find_packages
@@ -29,6 +30,11 @@ import re
 
 
 version = run_path("./gcovr/version.py")["__version__"]
+if version.endswith("+main"):
+    # Add a default if environment is not set
+    os.environ["TIMESTAMP"] = os.environ.get("TIMESTAMP", str(int(time.time())))
+    # ...and use this timestamp.
+    version.replace("+main", f".dev{os.environ['TIMESTAMP']}+main")
 # read the contents of your README file
 this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, "README.rst"), encoding="utf-8") as f:
@@ -46,11 +52,7 @@ long_description = re.sub(
 
 setup(
     name="gcovr",
-    version=(
-        version.replace("+main", f".dev{int(time.time())}+main")
-        if version.endswith("+main")
-        else version
-    ),
+    version=version,
     long_description=long_description,
     long_description_content_type="text/x-rst",
     platforms=["any"],


### PR DESCRIPTION
Timestamp seems to be read twice and differs in 1 second. Pip complains about name mismatch of wheel file.