### PR TITLE
Fix line exclusion

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Bug fixes and small improvements:
 - Check format version of external generated ``gcov`` JSON files. (:issue:`999`)
 - Fix crash on Windows when trying to fix the case of the files. (:issue:`1000`)
 - Fix LCOV report. Excluded lines where added with a count of 0. (:issue:`1012`)
+- Fix line exclusion not clearing all child coverage data. (:issue:`1017`)
 
 Documentation:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,7 +25,7 @@ Bug fixes and small improvements:
 - Check format version of external generated ``gcov`` JSON files. (:issue:`999`)
 - Fix crash on Windows when trying to fix the case of the files. (:issue:`1000`)
 - Fix LCOV report. Excluded lines where added with a count of 0. (:issue:`1012`)
-- Fix line exclusion not clearing all child coverage data. (:issue:`1017`)
+- Fix line exclusion not clearing all child coverage data. (:issue:`1018`)
 
 Documentation:
 

--- a/gcovr/exclusions/__init__.py
+++ b/gcovr/exclusions/__init__.py
@@ -141,9 +141,7 @@ def remove_internal_functions(filecov: FileCoverage):
                     linecov.function_name is not None
                     and linecov.function_name == functioncov.name
                 ):
-                    linecov.excluded = True
-                    linecov.branches = {}
-                    linecov.count = 0
+                    linecov.exclude()
 
 
 def _function_can_be_excluded(name: str) -> bool:

--- a/gcovr/exclusions/utils.py
+++ b/gcovr/exclusions/utils.py
@@ -143,9 +143,7 @@ def apply_exclusion_ranges(
         linecov.decision = None
 
         if line_is_excluded(linecov.lineno):
-            linecov.excluded = True
-            linecov.branches = {}
-            linecov.count = 0
+            linecov.exclude()
 
         elif branch_is_excluded(linecov.lineno):
             linecov.branches = {}

--- a/tests/excl-function/reference/gcc-14/coverage.json
+++ b/tests/excl-function/reference/gcc-14/coverage.json
@@ -18,16 +18,6 @@
                     "function_name": "_Z3fooi",
                     "count": 0,
                     "branches": [],
-                    "conditions": [
-                        {
-                            "count": 2,
-                            "covered": 1,
-                            "not_covered_false": [],
-                            "not_covered_true": [
-                                0
-                            ]
-                        }
-                    ],
                     "block_ids": [
                         2
                     ],
@@ -81,16 +71,6 @@
                     "function_name": "_Z3bari",
                     "count": 0,
                     "branches": [],
-                    "conditions": [
-                        {
-                            "count": 2,
-                            "covered": 1,
-                            "not_covered_false": [],
-                            "not_covered_true": [
-                                0
-                            ]
-                        }
-                    ],
                     "block_ids": [
                         2
                     ],
@@ -321,14 +301,6 @@
                     "function_name": "_ZZ20sort_lambda_excludedvENKUliiE0_clEii",
                     "count": 0,
                     "branches": [],
-                    "conditions": [
-                        {
-                            "count": 2,
-                            "covered": 2,
-                            "not_covered_false": [],
-                            "not_covered_true": []
-                        }
-                    ],
                     "block_ids": [
                         2
                     ],
@@ -413,14 +385,6 @@
                     "function_name": "_ZZ18sort_excluded_bothvENKUliiE_clEii",
                     "count": 0,
                     "branches": [],
-                    "conditions": [
-                        {
-                            "count": 2,
-                            "covered": 2,
-                            "not_covered_false": [],
-                            "not_covered_true": []
-                        }
-                    ],
                     "block_ids": [
                         2
                     ],
@@ -475,16 +439,6 @@
                     "function_name": "_ZZ18sort_excluded_bothvENKUliiE0_clEii",
                     "count": 0,
                     "branches": [],
-                    "conditions": [
-                        {
-                            "count": 2,
-                            "covered": 1,
-                            "not_covered_false": [],
-                            "not_covered_true": [
-                                0
-                            ]
-                        }
-                    ],
                     "block_ids": [
                         2
                     ],

--- a/tests/excl-line-branch/reference/gcc-14/coverage.json
+++ b/tests/excl-line-branch/reference/gcc-14/coverage.json
@@ -110,16 +110,6 @@
                     "function_name": "_Z3fooi",
                     "count": 0,
                     "branches": [],
-                    "conditions": [
-                        {
-                            "count": 4,
-                            "covered": 3,
-                            "not_covered_false": [],
-                            "not_covered_true": [
-                                1
-                            ]
-                        }
-                    ],
                     "block_ids": [
                         5,
                         6
@@ -232,14 +222,6 @@
                     "function_name": "_Z3fooi",
                     "count": 0,
                     "branches": [],
-                    "conditions": [
-                        {
-                            "count": 2,
-                            "covered": 2,
-                            "not_covered_false": [],
-                            "not_covered_true": []
-                        }
-                    ],
                     "block_ids": [
                         12
                     ],
@@ -262,16 +244,6 @@
                     "function_name": "_Z3fooi",
                     "count": 0,
                     "branches": [],
-                    "conditions": [
-                        {
-                            "count": 2,
-                            "covered": 1,
-                            "not_covered_false": [],
-                            "not_covered_true": [
-                                0
-                            ]
-                        }
-                    ],
                     "block_ids": [
                         14
                     ],
@@ -313,18 +285,6 @@
                     "function_name": "_Z3bari",
                     "count": 0,
                     "branches": [],
-                    "conditions": [
-                        {
-                            "count": 2,
-                            "covered": 0,
-                            "not_covered_false": [
-                                0
-                            ],
-                            "not_covered_true": [
-                                0
-                            ]
-                        }
-                    ],
                     "block_ids": [
                         2
                     ],

--- a/tests/html-themes-github/reference/gcc-10/coverage.call_decisions.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/tests/html-themes-github/reference/gcc-10/coverage.call_decisions.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -533,14 +533,6 @@
                 <td class="text-right src linenos ws-unset">
                 </td>
                 <td class="text-right src linenos ws-unset">
-                    <details class="normal details-overlay">
-                        <summary>2/3</summary>
-                        <div class="text-left position-absolute color-bg-subtle p-3 mt-2" style="z-index: 1;">
-                            <div class="color-invoked-call">&check; Call 0 invoked.</div>
-                            <div class="color-invoked-call">&check; Call 3 invoked.</div>
-                            <div class="color-fg-danger">&cross; Call 4 not invoked.</div>
-                        </div>
-                    </details>
                 </td>
                 <td class="src excludedLine pr-2 pl-2 color-fg-muted text-right">&minus;</td>
                 <td class="src excludedLine"><span class="w">    </span><span class="n">RAII</span><span class="w"> </span><span class="n">raii</span><span class="p">(</span><span class="n">die_again</span><span class="p">);</span><span class="w"></span></td>

--- a/tests/html-themes-github/reference/gcc-10/coverage.calls.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/tests/html-themes-github/reference/gcc-10/coverage.calls.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -451,14 +451,6 @@
                 <td class="text-right src linenos ws-unset">
                 </td>
                 <td class="text-right src linenos ws-unset">
-                    <details class="normal details-overlay">
-                        <summary>2/3</summary>
-                        <div class="text-left position-absolute color-bg-subtle p-3 mt-2" style="z-index: 1;">
-                            <div class="color-invoked-call">&check; Call 0 invoked.</div>
-                            <div class="color-invoked-call">&check; Call 3 invoked.</div>
-                            <div class="color-fg-danger">&cross; Call 4 not invoked.</div>
-                        </div>
-                    </details>
                 </td>
                 <td class="src excludedLine pr-2 pl-2 color-fg-muted text-right">&minus;</td>
                 <td class="src excludedLine"><span class="w">    </span><span class="n">RAII</span><span class="w"> </span><span class="n">raii</span><span class="p">(</span><span class="n">die_again</span><span class="p">);</span><span class="w"></span></td>

--- a/tests/html-themes-github/reference/gcc-11/coverage.call_decisions.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/tests/html-themes-github/reference/gcc-11/coverage.call_decisions.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -533,12 +533,6 @@
                 <td class="text-right src linenos ws-unset">
                 </td>
                 <td class="text-right src linenos ws-unset">
-                    <details class="normal details-overlay">
-                        <summary>1/1</summary>
-                        <div class="text-left position-absolute color-bg-subtle p-3 mt-2" style="z-index: 1;">
-                            <div class="color-invoked-call">&check; Call 0 invoked.</div>
-                        </div>
-                    </details>
                 </td>
                 <td class="src excludedLine pr-2 pl-2 color-fg-muted text-right">&minus;</td>
                 <td class="src excludedLine"><span class="w">    </span><span class="n">RAII</span><span class="w"> </span><span class="n">raii</span><span class="p">(</span><span class="n">die_again</span><span class="p">);</span><span class="w"></span></td>

--- a/tests/html-themes-github/reference/gcc-11/coverage.calls.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/tests/html-themes-github/reference/gcc-11/coverage.calls.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -451,12 +451,6 @@
                 <td class="text-right src linenos ws-unset">
                 </td>
                 <td class="text-right src linenos ws-unset">
-                    <details class="normal details-overlay">
-                        <summary>1/1</summary>
-                        <div class="text-left position-absolute color-bg-subtle p-3 mt-2" style="z-index: 1;">
-                            <div class="color-invoked-call">&check; Call 0 invoked.</div>
-                        </div>
-                    </details>
                 </td>
                 <td class="src excludedLine pr-2 pl-2 color-fg-muted text-right">&minus;</td>
                 <td class="src excludedLine"><span class="w">    </span><span class="n">RAII</span><span class="w"> </span><span class="n">raii</span><span class="p">(</span><span class="n">die_again</span><span class="p">);</span><span class="w"></span></td>

--- a/tests/html-themes-github/reference/gcc-13-Darwin/coverage.call_decisions.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/tests/html-themes-github/reference/gcc-13-Darwin/coverage.call_decisions.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -533,12 +533,6 @@
                 <td class="text-right src linenos ws-unset">
                 </td>
                 <td class="text-right src linenos ws-unset">
-                    <details class="normal details-overlay">
-                        <summary>1/1</summary>
-                        <div class="text-left position-absolute color-bg-subtle p-3 mt-2" style="z-index: 1;">
-                            <div class="color-invoked-call">&check; Call 0 invoked.</div>
-                        </div>
-                    </details>
                 </td>
                 <td class="src excludedLine pr-2 pl-2 color-fg-muted text-right">&minus;</td>
                 <td class="src excludedLine"><span class="w">    </span><span class="n">RAII</span><span class="w"> </span><span class="n">raii</span><span class="p">(</span><span class="n">die_again</span><span class="p">);</span><span class="w"></span></td>

--- a/tests/html-themes-github/reference/gcc-13-Darwin/coverage.calls.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/tests/html-themes-github/reference/gcc-13-Darwin/coverage.calls.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -451,12 +451,6 @@
                 <td class="text-right src linenos ws-unset">
                 </td>
                 <td class="text-right src linenos ws-unset">
-                    <details class="normal details-overlay">
-                        <summary>1/1</summary>
-                        <div class="text-left position-absolute color-bg-subtle p-3 mt-2" style="z-index: 1;">
-                            <div class="color-invoked-call">&check; Call 0 invoked.</div>
-                        </div>
-                    </details>
                 </td>
                 <td class="src excludedLine pr-2 pl-2 color-fg-muted text-right">&minus;</td>
                 <td class="src excludedLine"><span class="w">    </span><span class="n">RAII</span><span class="w"> </span><span class="n">raii</span><span class="p">(</span><span class="n">die_again</span><span class="p">);</span><span class="w"></span></td>

--- a/tests/html-themes-github/reference/gcc-5/coverage.call_decisions.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/tests/html-themes-github/reference/gcc-5/coverage.call_decisions.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -536,14 +536,6 @@
                 <td class="text-right src linenos ws-unset">
                 </td>
                 <td class="text-right src linenos ws-unset">
-                    <details class="normal details-overlay">
-                        <summary>2/3</summary>
-                        <div class="text-left position-absolute color-bg-subtle p-3 mt-2" style="z-index: 1;">
-                            <div class="color-invoked-call">&check; Call 0 invoked.</div>
-                            <div class="color-invoked-call">&check; Call 3 invoked.</div>
-                            <div class="color-fg-danger">&cross; Call 8 not invoked.</div>
-                        </div>
-                    </details>
                 </td>
                 <td class="src excludedLine pr-2 pl-2 color-fg-muted text-right">&minus;</td>
                 <td class="src excludedLine"><span class="w">    </span><span class="n">RAII</span><span class="w"> </span><span class="n">raii</span><span class="p">(</span><span class="n">die_again</span><span class="p">);</span><span class="w"></span></td>

--- a/tests/html-themes-github/reference/gcc-5/coverage.calls.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/tests/html-themes-github/reference/gcc-5/coverage.calls.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -454,14 +454,6 @@
                 <td class="text-right src linenos ws-unset">
                 </td>
                 <td class="text-right src linenos ws-unset">
-                    <details class="normal details-overlay">
-                        <summary>2/3</summary>
-                        <div class="text-left position-absolute color-bg-subtle p-3 mt-2" style="z-index: 1;">
-                            <div class="color-invoked-call">&check; Call 0 invoked.</div>
-                            <div class="color-invoked-call">&check; Call 3 invoked.</div>
-                            <div class="color-fg-danger">&cross; Call 8 not invoked.</div>
-                        </div>
-                    </details>
                 </td>
                 <td class="src excludedLine pr-2 pl-2 color-fg-muted text-right">&minus;</td>
                 <td class="src excludedLine"><span class="w">    </span><span class="n">RAII</span><span class="w"> </span><span class="n">raii</span><span class="p">(</span><span class="n">die_again</span><span class="p">);</span><span class="w"></span></td>

--- a/tests/html-themes-github/reference/gcc-6/coverage.call_decisions.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/tests/html-themes-github/reference/gcc-6/coverage.call_decisions.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -528,14 +528,6 @@
                 <td class="text-right src linenos ws-unset">
                 </td>
                 <td class="text-right src linenos ws-unset">
-                    <details class="normal details-overlay">
-                        <summary>2/3</summary>
-                        <div class="text-left position-absolute color-bg-subtle p-3 mt-2" style="z-index: 1;">
-                            <div class="color-invoked-call">&check; Call 0 invoked.</div>
-                            <div class="color-invoked-call">&check; Call 3 invoked.</div>
-                            <div class="color-fg-danger">&cross; Call 6 not invoked.</div>
-                        </div>
-                    </details>
                 </td>
                 <td class="src excludedLine pr-2 pl-2 color-fg-muted text-right">&minus;</td>
                 <td class="src excludedLine"><span class="w">    </span><span class="n">RAII</span><span class="w"> </span><span class="n">raii</span><span class="p">(</span><span class="n">die_again</span><span class="p">);</span><span class="w"></span></td>

--- a/tests/html-themes-github/reference/gcc-6/coverage.calls.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/tests/html-themes-github/reference/gcc-6/coverage.calls.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -446,14 +446,6 @@
                 <td class="text-right src linenos ws-unset">
                 </td>
                 <td class="text-right src linenos ws-unset">
-                    <details class="normal details-overlay">
-                        <summary>2/3</summary>
-                        <div class="text-left position-absolute color-bg-subtle p-3 mt-2" style="z-index: 1;">
-                            <div class="color-invoked-call">&check; Call 0 invoked.</div>
-                            <div class="color-invoked-call">&check; Call 3 invoked.</div>
-                            <div class="color-fg-danger">&cross; Call 6 not invoked.</div>
-                        </div>
-                    </details>
                 </td>
                 <td class="src excludedLine pr-2 pl-2 color-fg-muted text-right">&minus;</td>
                 <td class="src excludedLine"><span class="w">    </span><span class="n">RAII</span><span class="w"> </span><span class="n">raii</span><span class="p">(</span><span class="n">die_again</span><span class="p">);</span><span class="w"></span></td>

--- a/tests/html-themes-github/reference/gcc-8-Windows/coverage.call_decisions.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/tests/html-themes-github/reference/gcc-8-Windows/coverage.call_decisions.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -526,14 +526,6 @@
                 <td class="text-right src linenos ws-unset">
                 </td>
                 <td class="text-right src linenos ws-unset">
-                    <details class="normal details-overlay">
-                        <summary>2/3</summary>
-                        <div class="text-left position-absolute color-bg-subtle p-3 mt-2" style="z-index: 1;">
-                            <div class="color-invoked-call">&check; Call 0 invoked.</div>
-                            <div class="color-invoked-call">&check; Call 1 invoked.</div>
-                            <div class="color-fg-danger">&cross; Call 2 not invoked.</div>
-                        </div>
-                    </details>
                 </td>
                 <td class="src excludedLine pr-2 pl-2 color-fg-muted text-right">&minus;</td>
                 <td class="src excludedLine"><span class="w">    </span><span class="n">RAII</span><span class="w"> </span><span class="n">raii</span><span class="p">(</span><span class="n">die_again</span><span class="p">);</span><span class="w"></span></td>

--- a/tests/html-themes-github/reference/gcc-8-Windows/coverage.calls.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/tests/html-themes-github/reference/gcc-8-Windows/coverage.calls.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -444,14 +444,6 @@
                 <td class="text-right src linenos ws-unset">
                 </td>
                 <td class="text-right src linenos ws-unset">
-                    <details class="normal details-overlay">
-                        <summary>2/3</summary>
-                        <div class="text-left position-absolute color-bg-subtle p-3 mt-2" style="z-index: 1;">
-                            <div class="color-invoked-call">&check; Call 0 invoked.</div>
-                            <div class="color-invoked-call">&check; Call 1 invoked.</div>
-                            <div class="color-fg-danger">&cross; Call 2 not invoked.</div>
-                        </div>
-                    </details>
                 </td>
                 <td class="src excludedLine pr-2 pl-2 color-fg-muted text-right">&minus;</td>
                 <td class="src excludedLine"><span class="w">    </span><span class="n">RAII</span><span class="w"> </span><span class="n">raii</span><span class="p">(</span><span class="n">die_again</span><span class="p">);</span><span class="w"></span></td>

--- a/tests/html-themes-github/reference/gcc-8/coverage.call_decisions.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/tests/html-themes-github/reference/gcc-8/coverage.call_decisions.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -526,14 +526,6 @@
                 <td class="text-right src linenos ws-unset">
                 </td>
                 <td class="text-right src linenos ws-unset">
-                    <details class="normal details-overlay">
-                        <summary>2/3</summary>
-                        <div class="text-left position-absolute color-bg-subtle p-3 mt-2" style="z-index: 1;">
-                            <div class="color-invoked-call">&check; Call 0 invoked.</div>
-                            <div class="color-invoked-call">&check; Call 3 invoked.</div>
-                            <div class="color-fg-danger">&cross; Call 4 not invoked.</div>
-                        </div>
-                    </details>
                 </td>
                 <td class="src excludedLine pr-2 pl-2 color-fg-muted text-right">&minus;</td>
                 <td class="src excludedLine"><span class="w">    </span><span class="n">RAII</span><span class="w"> </span><span class="n">raii</span><span class="p">(</span><span class="n">die_again</span><span class="p">);</span><span class="w"></span></td>

--- a/tests/html-themes-github/reference/gcc-8/coverage.calls.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/tests/html-themes-github/reference/gcc-8/coverage.calls.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -444,14 +444,6 @@
                 <td class="text-right src linenos ws-unset">
                 </td>
                 <td class="text-right src linenos ws-unset">
-                    <details class="normal details-overlay">
-                        <summary>2/3</summary>
-                        <div class="text-left position-absolute color-bg-subtle p-3 mt-2" style="z-index: 1;">
-                            <div class="color-invoked-call">&check; Call 0 invoked.</div>
-                            <div class="color-invoked-call">&check; Call 3 invoked.</div>
-                            <div class="color-fg-danger">&cross; Call 4 not invoked.</div>
-                        </div>
-                    </details>
                 </td>
                 <td class="src excludedLine pr-2 pl-2 color-fg-muted text-right">&minus;</td>
                 <td class="src excludedLine"><span class="w">    </span><span class="n">RAII</span><span class="w"> </span><span class="n">raii</span><span class="p">(</span><span class="n">die_again</span><span class="p">);</span><span class="w"></span></td>


### PR DESCRIPTION
- When lines are excluded, they should remove coverage for branches, calls and conditions.
- This ensures consistency of reporting for future enhancements to exclusion metrics

#988 