### PR TITLE
Add option for suspicious hits

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ New features and notable changes:
 - Add option to generate LCOV format produced by version 1.x of LCOV tool. (:issue:`1001`)
 - Extend logging for data merge errors with info about the data sources. (:issue:`1010`)
 - Add condition coverage merge mode option :option:`--merge-mode-conditions` (:issue:`1009`)
+- Add :option:`--gcov-suspicious-hits-threshold` to configure the value for detecting suspicious hits in GCOV files. (:issue:`1021`)
 
 Bug fixes and small improvements:
 

--- a/doc/source/guide/gcov_parser.rst
+++ b/doc/source/guide/gcov_parser.rst
@@ -56,10 +56,14 @@ Suspicious hit counts
 _____________________
 
 A bug in gcov can produce very high hit values (see `gcov issue_suspicious_hits`_) which are not accepted by default.
-A suspicious value is assumed if the counter is 2^32 or greater.
+A suspicious value is assumed if the counter is greater than the value of :option:`--gcov-suspicious-hits-threshold`.
 This behavior can be changed by using the value ``--gcov-ignore-parse-errors=suspicious_hits.warn`` or
 ``--gcov-ignore-parse-errors=suspicious_hits.warn_once_per_file``. The first form warns on every line
 with a suspicious value the second one only once per processed file and adds a summary with the overall
 issues in the file.
+
+.. versionadded:: NEXT
+
+    The threshold for detection of suspicious hits can be configured with :option:`--gcov-suspicious-hits-threshold`.
 
 .. _gcov issue_suspicious_hits: https://github.com/gcovr/gcovr/issues/898

--- a/gcovr/formats/gcov/__init__.py
+++ b/gcovr/formats/gcov/__init__.py
@@ -102,6 +102,19 @@ class GcovHandler(BaseHandler):
                 action="append",
             ),
             GcovrConfigOption(
+                "gcov_suspicious_hits_threshold",
+                ["--gcov-suspicious-hits-threshold"],
+                config="gcov-suspicious-hits-threshold",
+                group="gcov_options",
+                help=(
+                    "Set the threshold for detecting suspicious hits "
+                    "in gcov output files. "
+                    "Set to 0 to turn the detection of."
+                ),
+                type=int,
+                default=2**32,
+            ),
+            GcovrConfigOption(
                 "gcov_filter",
                 ["--gcov-filter"],
                 group="filter_options",

--- a/gcovr/formats/gcov/read.py
+++ b/gcovr/formats/gcov/read.py
@@ -318,7 +318,9 @@ def process_gcov_data(
         lines = fh_in.read().splitlines()
 
     # Find the source file
-    metadata = parse_metadata(lines)
+    metadata = parse_metadata(
+        lines, suspicious_hits_threshold=options.gcov_suspicious_hits_threshold
+    )
     source = metadata.get("Source")
     if source is None:
         raise RuntimeError("Unexpected value 'None' for metadata 'Source'.")
@@ -351,6 +353,7 @@ def process_gcov_data(
         filename=key,
         data_filename=gcda_fname or data_fname,
         ignore_parse_errors=options.gcov_ignore_parse_errors,
+        suspicious_hits_threshold=options.gcov_suspicious_hits_threshold,
     )
 
     LOGGER.debug(f"Apply exclusions for {fname}")


### PR DESCRIPTION
https://github.com/gcovr/gcovr/pull/903#issuecomment-2444895806 pointed out that the threshold of 2**32 needs to be increased. This PR adds an option to increase it or to turn off the detection at all.