### PR TITLE
Update docs and add a log message

### DIFF
--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -93,15 +93,6 @@ With the :option:`gcovr --exclude-throw-branches` option,
 exception-only branches will be ignored.
 These are typically arcs from a function call into an exception handler.
 
-With the :option:`gcovr --decisions` option,
-gcovr parses the source code to extract a ISO 26262 compliant metric
-for decision coverage. This metric can be interpreted as the branch coverage
-on C/C++-Level.
-While the feature is not always able to detect the decisions reliably
-when the code is written very compact (uncheckable decisions will be marked),
-it provides a reliable tool for (i.e. MISRA-compliant) code
-in security-relevant situations.
-
 Compiling with optimizations will typically remove unreachable branches
 and remove superfluous branches,
 but makes the coverage report less exact.

--- a/src/gcovr/__main__.py
+++ b/src/gcovr/__main__.py
@@ -373,6 +373,12 @@ def main(args: Optional[list[str]] = None) -> int:  # pylint: disable=too-many-r
         LOGGER.error("--fail-under-decision need also option --decision.")
         return EXIT_CMDLINE_ERROR
 
+    if options.show_decision:
+        LOGGER.info(
+            "Attention, the decision analysis is experimental. "
+            "It uses a fragile heuristic and depends on the code format."
+        )
+
     LOGGER.info("Reading coverage data...")
     try:
         covdata = gcovr_formats.read_reports(options)


### PR DESCRIPTION
As described in https://github.com/gcovr/gcovr/issues/1042#issuecomment-2564490670, this PR removes the section about the decision coverage from the FAQ and adds a log message if `--decision` is used.

[no changelog]