### PR TITLE
Add support for ignoring negative hit count in gcov json parser

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,7 @@ Bug fixes and small improvements:
 - Fix line exclusion not clearing all child coverage data. (:issue:`1018`)
 - Fix summary stats in ``JaCoCo`` report. (:issue:`1022`)
 - Fix path issue when reading/writing ``Coveralls`` report. (:issue:`1037`)
+- Fix issue with negative counters in GCOV JSON export. (:issue:`1048`)
 
 Documentation:
 

--- a/doc/examples/example_cmake.sh
+++ b/doc/examples/example_cmake.sh
@@ -27,7 +27,7 @@ exec >&2  # redirect output to STDERR
 #BEGIN cmake_build
 cd $BLD_DIR
 cmake -DCMAKE_BUILD_TYPE=PROFILE $SRC_DIR
-make VERBOSE=1
+cmake --build . --verbose
 #END cmake_build
 )
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -164,7 +164,9 @@ def set_environment(session: nox.Session, cc: Optional[str] = None) -> None:
     session.env["GCOVR_TEST_SUITE"] = "1"
     session.env["CC"] = os.path.join(cc_path, cc_file)
     session.env["CFLAGS"] = "--this_flag_does_not_exist"
-    session.env["CXX"] = os.path.join(cc_path, cc_file.replace("clang", "clang++").replace("gcc", "g++"))
+    session.env["CXX"] = os.path.join(
+        cc_path, cc_file.replace("clang", "clang++").replace("gcc", "g++")
+    )
     session.env["CXXFLAGS"] = "--this_flag_does_not_exist"
     if cc_reference is not None:
         session.env["CC_REFERENCE"] = cc_reference
@@ -409,7 +411,9 @@ def tests(session: nox.Session) -> None:
     cc_path, cc_file = os.path.split(session.env["CC"])
     session.env["GCOV"] = str(
         shutil.which(
-            os.path.join(cc_path, cc_file.replace("clang", "llvm-cov").replace("gcc", "gcov"))
+            os.path.join(
+                cc_path, cc_file.replace("clang", "llvm-cov").replace("gcc", "gcov")
+            )
         )
     ).replace(os.path.sep, "/")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -158,10 +158,13 @@ def set_environment(session: nox.Session, cc: Optional[str] = None) -> None:
         cc, cc_reference = get_gcc_versions()
     else:
         cc_reference = cc
+
+    cc_path, cc_file = os.path.split(cc)
+
     session.env["GCOVR_TEST_SUITE"] = "1"
-    session.env["CC"] = cc
+    session.env["CC"] = os.path.join(cc_path, cc_file)
     session.env["CFLAGS"] = "--this_flag_does_not_exist"
-    session.env["CXX"] = cc.replace("clang", "clang++").replace("gcc", "g++")
+    session.env["CXX"] = os.path.join(cc_path, cc_file.replace("clang", "clang++").replace("gcc", "g++"))
     session.env["CXXFLAGS"] = "--this_flag_does_not_exist"
     if cc_reference is not None:
         session.env["CC_REFERENCE"] = cc_reference
@@ -403,9 +406,10 @@ def tests(session: nox.Session) -> None:
     session.run(session.env["CC"], "--version", external=True)
     session.env["CXX"] = str(shutil.which(session.env["CXX"])).replace(os.path.sep, "/")
     session.run(session.env["CXX"], "--version", external=True)
+    cc_path, cc_file = os.path.split(session.env["CC"])
     session.env["GCOV"] = str(
         shutil.which(
-            session.env["CC"].replace("clang", "llvm-cov").replace("gcc", "gcov")
+            os.path.join(cc_path, cc_file.replace("clang", "llvm-cov").replace("gcc", "gcov"))
         )
     ).replace(os.path.sep, "/")
 

--- a/src/gcovr/formats/gcov/parser.py
+++ b/src/gcovr/formats/gcov/parser.py
@@ -38,7 +38,6 @@ The behavior of this parser was informed by the following sources:
 import enum
 import logging
 import re
-
 from typing import (
     Any,
     Iterable,
@@ -52,23 +51,25 @@ from gcovr.utils import get_md5_hexdigest
 
 from ...coverage import (
     BranchCoverage,
+    CallCoverage,
+    ConditionCoverage,
     FileCoverage,
     FunctionCoverage,
-    CallCoverage,
     LineCoverage,
 )
 from ...merging import (
-    MergeOptions,
     FUNCTION_MAX_LINE_MERGE_OPTIONS,
+    MergeOptions,
     insert_branch_coverage,
-    insert_function_coverage,
-    insert_line_coverage,
     insert_call_coverage,
+    insert_function_coverage,
+    insert_condition_coverage,
+    insert_line_coverage,
 )
-
 
 LOGGER = logging.getLogger("gcovr")
 SUSPICIOUS_COUNTER = 2**32
+GCOV_JSON_VERSION = "2"
 
 
 def _line_pattern(pattern: str) -> Pattern[str]:
@@ -1001,3 +1002,130 @@ def _float_from_gcov_percent(formatted: str) -> float:
         raise AssertionError(f"Number must end with %, got {formatted}")
 
     return float(formatted[:-1])
+
+
+def parse_gcov_json_coverage(
+    gcov_file_node: dict[str, Any],
+    filename: str,
+    source_lines: list[str],
+    data_source: Optional[Union[str, set[str]]],
+    ignore_parse_errors: set[str],
+    suspicious_hits_threshold: int = SUSPICIOUS_COUNTER,
+) -> FileCoverage:
+    """
+    Extract coverage data from a json gcov report.
+
+    Logging:
+    Parse problems are reported as warnings.
+    Coverage exclusion decisions are reported as verbose messages.
+
+    Arguments:
+        gcov_file_node: one of the "files" node in the gcov json format
+        filename: for error reports
+        source_lines: decoded source code lines, for reporting
+        data_source: source of this node, for reporting
+        ignore_parse_errors: which errors should be converted to warnings
+
+    Returns:
+        The coverage data
+
+    Raises:
+        Any exceptions during parsing, unless ignore_parse_errors is set.
+    """
+    persistent_states = dict[str, Any]()
+
+    def check_hits(hits: int, line: str) -> int:
+        if hits < 0:
+            NegativeHits.raise_if_not_ignored(
+                line, ignore_parse_errors, persistent_states
+            )
+            hits = 0
+
+        if suspicious_hits_threshold != 0 and hits >= suspicious_hits_threshold:
+            SuspiciousHits.raise_if_not_ignored(
+                line, ignore_parse_errors, persistent_states
+            )
+            hits = 0
+
+        return hits
+
+    file_cov = FileCoverage(filename, data_source)
+    for line in gcov_file_node["lines"]:
+        line_cov = insert_line_coverage(
+            file_cov,
+            LineCoverage(
+                line["line_number"],
+                count=check_hits(line["count"], source_lines[line["line_number"] - 1]),
+                function_name=line.get("function_name"),
+                block_ids=line["block_ids"],
+                md5=get_md5_hexdigest(
+                    source_lines[line["line_number"] - 1].encode("utf-8")
+                ),
+            ),
+        )
+        for index, branch in enumerate(line["branches"]):
+            insert_branch_coverage(
+                line_cov,
+                index,
+                BranchCoverage(
+                    branch["source_block_id"],
+                    check_hits(branch["count"], source_lines[line["line_number"] - 1]),
+                    fallthrough=branch["fallthrough"],
+                    throw=branch["throw"],
+                    destination_block_id=branch["destination_block_id"],
+                ),
+            )
+        for index, condition in enumerate(line.get("conditions", [])):
+            insert_condition_coverage(
+                line_cov,
+                index,
+                ConditionCoverage(
+                    check_hits(
+                        condition["count"], source_lines[line["line_number"] - 1]
+                    ),
+                    condition["covered"],
+                    condition["not_covered_true"],
+                    condition["not_covered_false"],
+                ),
+            )
+    for function in gcov_file_node["functions"]:
+        # Use 100% only if covered == total.
+        if function["blocks_executed"] == function["blocks"]:
+            blocks = 100.0
+        else:
+            # There is at least one uncovered item.
+            # Round to 1 decimal and clamp to max 99.9%.
+            ratio = function["blocks_executed"] / function["blocks"]
+            blocks = min(99.9, round(ratio * 100.0, 1))
+
+        insert_function_coverage(
+            file_cov,
+            FunctionCoverage(
+                function["name"],
+                function["demangled_name"],
+                lineno=function["start_line"],
+                count=function["execution_count"],
+                blocks=blocks,
+                start=(function["start_line"], function["start_column"]),
+                end=(function["end_line"], function["end_column"]),
+            ),
+            MergeOptions(func_opts=FUNCTION_MAX_LINE_MERGE_OPTIONS),
+        )
+
+    if (
+        "negative_hits.warn_once_per_file" in persistent_states
+        and persistent_states["negative_hits.warn_once_per_file"] > 1
+    ):
+        LOGGER.warning(
+            f"Ignored {persistent_states['negative_hits.warn_once_per_file']} negative hits overall."
+        )
+
+    if (
+        "suspicious_hits.warn_once_per_file" in persistent_states
+        and persistent_states["suspicious_hits.warn_once_per_file"] > 1
+    ):
+        LOGGER.warning(
+            f"Ignored {persistent_states['suspicious_hits.warn_once_per_file']} suspicious hits overall."
+        )
+
+    return file_cov

--- a/src/gcovr/formats/gcov/parser/common.py
+++ b/src/gcovr/formats/gcov/parser/common.py
@@ -51,7 +51,29 @@ class NegativeHits(Exception):
     def raise_if_not_ignored(
         line: str, ignore_parse_errors: set[str], persistent_states: dict[str, Any]
     ) -> None:
-        """Raise exception if not ignored by options"""
+        """
+        Raise exception if not ignored by options
+        >>> state = dict()
+        >>> NegativeHits.raise_if_not_ignored("code", None, state)
+        Traceback (most recent call last):
+            ...
+        gcovr.formats.gcov.parser.common.NegativeHits: Got negative hit value in gcov line 'code' caused by a
+        bug in gcov tool, see
+        https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68080. Use option
+        --gcov-ignore-parse-errors with a value of negative_hits.warn,
+        or negative_hits.warn_once_per_file.
+        >>> NegativeHits.raise_if_not_ignored("code", {"all"}, state)
+        >>> state.get("negative_hits.warn_once_per_file")
+        >>> NegativeHits.raise_if_not_ignored("code", {"negative_hits.warn"}, state)
+        >>> state.get("negative_hits.warn_once_per_file")
+        >>> NegativeHits.raise_if_not_ignored("code", {"negative_hits.warn_once_per_file"}, state)
+        >>> state.get("negative_hits.warn_once_per_file")
+        1
+        >>> NegativeHits.raise_if_not_ignored("code", {"negative_hits.warn_once_per_file"}, state)
+        >>> state.get("negative_hits.warn_once_per_file")
+        2
+        """
+
         if ignore_parse_errors is not None and any(
             v in ignore_parse_errors
             for v in [
@@ -87,7 +109,29 @@ class SuspiciousHits(Exception):
     def raise_if_not_ignored(
         line: str, ignore_parse_errors: set[str], persistent_states: dict[str, Any]
     ) -> None:
-        """Raise exception if not ignored by options"""
+        """
+        Raise exception if not ignored by options
+        >>> state = dict()
+        >>> SuspiciousHits.raise_if_not_ignored("code", None, state)
+        Traceback (most recent call last):
+            ...
+        gcovr.formats.gcov.parser.common.SuspiciousHits: Got suspicious hit value in gcov line 'code' caused by a
+        bug in gcov tool, see
+        https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68080. Use option
+        --gcov-ignore-parse-errors with a value of suspicious_hits.warn,
+        or suspicious_hits.warn_once_per_file or change the threshold
+        for the detection with option --gcov-suspicious-hits-threshold.
+        >>> SuspiciousHits.raise_if_not_ignored("code", {"all"}, state)
+        >>> state.get("suspicious_hits.warn_once_per_file")
+        >>> SuspiciousHits.raise_if_not_ignored("code", {"suspicious_hits.warn"}, state)
+        >>> state.get("suspicious_hits.warn_once_per_file")
+        >>> SuspiciousHits.raise_if_not_ignored("code", {"suspicious_hits.warn_once_per_file"}, state)
+        >>> state.get("suspicious_hits.warn_once_per_file")
+        1
+        >>> SuspiciousHits.raise_if_not_ignored("code", {"suspicious_hits.warn_once_per_file"}, state)
+        >>> state.get("suspicious_hits.warn_once_per_file")
+        2
+        """
         if ignore_parse_errors is not None and any(
             v in ignore_parse_errors
             for v in [

--- a/src/gcovr/formats/gcov/parser/common.py
+++ b/src/gcovr/formats/gcov/parser/common.py
@@ -150,7 +150,7 @@ def check_hits(
     persistent_states: dict[str, Any],
 ) -> int:
     """
-    Check if hits count is negative or suspicous, if the issue is ignored returns 0
+    Check if hits count is negative or suspicious, if the issue is ignored returns 0
     >>> check_hits(1, "", {}, 10, {})
     1
     >>> check_hits(-1, "", {"all"}, 10, {})

--- a/src/gcovr/formats/gcov/parser/common.py
+++ b/src/gcovr/formats/gcov/parser/common.py
@@ -1,0 +1,106 @@
+# -*- coding:utf-8 -*-
+
+#  ************************** Copyrights and license ***************************
+#
+# This file is part of gcovr 8.2+main, a parsing and reporting tool for gcov.
+# https://gcovr.com/en/main
+#
+# _____________________________________________________________________________
+#
+# Copyright (c) 2013-2024 the gcovr authors
+# Copyright (c) 2013 Sandia Corporation.
+# Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+# the U.S. Government retains certain rights in this software.
+#
+# This software is distributed under the 3-clause BSD License.
+# For more information, see the README.rst file.
+#
+# ****************************************************************************
+
+# pylint: disable=too-many-lines
+
+import logging
+from typing import Any
+
+
+LOGGER = logging.getLogger("gcovr")
+SUSPICIOUS_COUNTER = 2**32
+
+
+class UnknownLineType(Exception):
+    """Used by `_parse_line()` to signal that no known line type matched."""
+
+    def __init__(self, line: str) -> None:
+        super().__init__(line)
+        self.line = line
+
+
+class NegativeHits(Exception):
+    """Used to signal that a negative count value was found."""
+
+    def __init__(self, line: str) -> None:
+        super().__init__(
+            f"Got negative hit value in gcov line {line!r} caused by a\n"
+            "bug in gcov tool, see\n"
+            "https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68080. Use option\n"
+            "--gcov-ignore-parse-errors with a value of negative_hits.warn,\n"
+            "or negative_hits.warn_once_per_file."
+        )
+
+    @staticmethod
+    def raise_if_not_ignored(
+        line: str, ignore_parse_errors: set[str], persistent_states: dict[str, Any]
+    ) -> None:
+        """Raise exception if not ignored by options"""
+        if ignore_parse_errors is not None and any(
+            v in ignore_parse_errors
+            for v in [
+                "all",
+                "negative_hits.warn",
+                "negative_hits.warn_once_per_file",
+            ]
+        ):
+            if "negative_hits.warn_once_per_file" in persistent_states:
+                persistent_states["negative_hits.warn_once_per_file"] += 1
+            else:
+                LOGGER.warning(f"Ignoring negative hits in line {line!r}.")
+                if "negative_hits.warn_once_per_file" in ignore_parse_errors:
+                    persistent_states["negative_hits.warn_once_per_file"] = 1
+        else:
+            raise NegativeHits(line)
+
+
+class SuspiciousHits(Exception):
+    """Used to signal that a negative count value was found."""
+
+    def __init__(self, line: str) -> None:
+        super().__init__(
+            f"Got suspicious hit value in gcov line {line!r} caused by a\n"
+            "bug in gcov tool, see\n"
+            "https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68080. Use option\n"
+            "--gcov-ignore-parse-errors with a value of suspicious_hits.warn,\n"
+            "or suspicious_hits.warn_once_per_file or change the threshold\n"
+            "for the detection with option --gcov-suspicious-hits-threshold."
+        )
+
+    @staticmethod
+    def raise_if_not_ignored(
+        line: str, ignore_parse_errors: set[str], persistent_states: dict[str, Any]
+    ) -> None:
+        """Raise exception if not ignored by options"""
+        if ignore_parse_errors is not None and any(
+            v in ignore_parse_errors
+            for v in [
+                "all",
+                "suspicious_hits.warn",
+                "suspicious_hits.warn_once_per_file",
+            ]
+        ):
+            if "suspicious_hits.warn_once_per_file" in persistent_states:
+                persistent_states["suspicious_hits.warn_once_per_file"] += 1
+            else:
+                LOGGER.warning(f"Ignoring suspicious hits in line {line!r}.")
+                if "suspicious_hits.warn_once_per_file" in ignore_parse_errors:
+                    persistent_states["suspicious_hits.warn_once_per_file"] = 1
+        else:
+            raise SuspiciousHits(line)

--- a/src/gcovr/formats/gcov/parser/json.py
+++ b/src/gcovr/formats/gcov/parser/json.py
@@ -30,8 +30,6 @@ The behavior of this parser was informed by the following sources:
 """
 # pylint: disable=too-many-lines
 
-import gzip
-import json
 import logging
 import os
 from locale import getpreferredencoding
@@ -70,29 +68,17 @@ DEFAULT_SOURCE_ENCODING = getpreferredencoding()
 
 
 def parse_coverage(
+    gcov_json_data: dict[str, Any],
     include_filters: list[Filter],
     exclude_filters: list[Filter],
     ignore_parse_errors: Optional[set[str]],
     data_source: Optional[str] = None,
     suspicious_hits_threshold: int = SUSPICIOUS_COUNTER,
     source_encoding: str = DEFAULT_SOURCE_ENCODING,
-    gcov_json_data: Optional[dict[str, Any]] = None,
 ) -> list[tuple[FileCoverage, list[str]]]:
     """Process a GCOV JSON output."""
 
-    if gcov_json_data is None and data_source is None:
-        raise RuntimeError(
-            "Need at least one of gcov_json_data or data_source to parse"
-        )
-
-    if gcov_json_data is None and data_source is not None:
-        with gzip.open(data_source, "rt", encoding="UTF-8") as fh_in:
-            gcov_json_data = json.loads(fh_in.read())
-
     file_covs = list[tuple[FileCoverage, list[str]]]()
-
-    if gcov_json_data is None:
-        return file_covs
 
     # Check format version because the file can be created external
     if gcov_json_data["format_version"] != GCOV_JSON_VERSION:

--- a/src/gcovr/formats/gcov/parser/json.py
+++ b/src/gcovr/formats/gcov/parser/json.py
@@ -123,12 +123,12 @@ def parse_coverage(
         ]
 
         file_cov = _parse_file_node(
-            file,
-            fname,
-            encoded_source_lines,
-            data_source,
-            ignore_parse_errors,
-            suspicious_hits_threshold,
+            gcov_file_node=file,
+            filename=fname,
+            source_lines=encoded_source_lines,
+            data_source=data_source,
+            ignore_parse_errors=ignore_parse_errors,
+            suspicious_hits_threshold=suspicious_hits_threshold,
         )
 
         files_coverage.append((file_cov, encoded_source_lines))

--- a/src/gcovr/formats/gcov/parser/json.py
+++ b/src/gcovr/formats/gcov/parser/json.py
@@ -29,6 +29,7 @@ The behavior of this parser was informed by the following sources:
   <https://gcc.gnu.org/onlinedocs/gcc-14.1.0/gcc/Invoking-Gcov.html>
 """
 # pylint: disable=too-many-lines
+# cspell:ignore getpreferredencoding
 
 import logging
 import os
@@ -78,7 +79,7 @@ def parse_coverage(
 ) -> list[tuple[FileCoverage, list[str]]]:
     """Process a GCOV JSON output."""
 
-    file_covs = list[tuple[FileCoverage, list[str]]]()
+    files_coverage = list[tuple[FileCoverage, list[str]]]()
 
     # Check format version because the file can be created external
     if gcov_json_data["format_version"] != GCOV_JSON_VERSION:
@@ -130,9 +131,9 @@ def parse_coverage(
             suspicious_hits_threshold,
         )
 
-        file_covs.append((file_cov, encoded_source_lines))
+        files_coverage.append((file_cov, encoded_source_lines))
 
-    return file_covs
+    return files_coverage
 
 
 def _parse_file_node(

--- a/src/gcovr/formats/gcov/parser/json.py
+++ b/src/gcovr/formats/gcov/parser/json.py
@@ -73,7 +73,7 @@ def parse_coverage(
     include_filters: list[Filter],
     exclude_filters: list[Filter],
     ignore_parse_errors: Optional[set[str]],
-    data_source: Optional[str] = None,
+    data_fname: Optional[str] = None,
     suspicious_hits_threshold: int = SUSPICIOUS_COUNTER,
     source_encoding: str = DEFAULT_SOURCE_ENCODING,
 ) -> list[tuple[FileCoverage, list[str]]]:
@@ -126,7 +126,7 @@ def parse_coverage(
             gcov_file_node=file,
             filename=fname,
             source_lines=encoded_source_lines,
-            data_source=data_source,
+            data_fname=data_fname,
             ignore_parse_errors=ignore_parse_errors,
             suspicious_hits_threshold=suspicious_hits_threshold,
         )
@@ -140,7 +140,7 @@ def _parse_file_node(
     gcov_file_node: dict[str, Any],
     filename: str,
     source_lines: list[str],
-    data_source: Optional[Union[str, set[str]]],
+    data_fname: Optional[Union[str, set[str]]],
     ignore_parse_errors: Optional[set[str]],
     suspicious_hits_threshold: int = SUSPICIOUS_COUNTER,
 ) -> FileCoverage:
@@ -155,7 +155,7 @@ def _parse_file_node(
         gcov_file_node: one of the "files" node in the gcov json format
         filename: for error reports
         source_lines: decoded source code lines, for reporting
-        data_source: source of this node, for reporting
+        data_fname: source of this node, for reporting
         ignore_parse_errors: which errors should be converted to warnings
 
     Returns:
@@ -168,7 +168,7 @@ def _parse_file_node(
     if ignore_parse_errors is None:
         ignore_parse_errors = set()
 
-    file_cov = FileCoverage(filename, data_source)
+    file_cov = FileCoverage(filename, data_fname)
     for line in gcov_file_node["lines"]:
         line_cov = insert_line_coverage(
             file_cov,

--- a/src/gcovr/formats/gcov/parser/json.py
+++ b/src/gcovr/formats/gcov/parser/json.py
@@ -27,9 +27,6 @@ The behavior of this parser was informed by the following sources:
 
 * the *Invoking Gcov* section in the GCC manual (version 11)
   <https://gcc.gnu.org/onlinedocs/gcc-14.1.0/gcc/Invoking-Gcov.html>
-* the ``gcov.c`` source code in GCC
-  (especially for understanding the exact number format)
-  <https://github.com/gcc-mirror/gcc/blob/releases/gcc-14.1.0/gcc/gcov.cc>
 """
 # pylint: disable=too-many-lines
 

--- a/src/gcovr/formats/gcov/parser/json.py
+++ b/src/gcovr/formats/gcov/parser/json.py
@@ -1,0 +1,268 @@
+# -*- coding:utf-8 -*-
+
+#  ************************** Copyrights and license ***************************
+#
+# This file is part of gcovr 8.2+main, a parsing and reporting tool for gcov.
+# https://gcovr.com/en/main
+#
+# _____________________________________________________________________________
+#
+# Copyright (c) 2013-2024 the gcovr authors
+# Copyright (c) 2013 Sandia Corporation.
+# Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+# the U.S. Government retains certain rights in this software.
+#
+# This software is distributed under the 3-clause BSD License.
+# For more information, see the README.rst file.
+#
+# ****************************************************************************
+
+"""
+Handle parsing of the json ``.gcov.json.gz`` file format.
+
+Other modules should only use the following items:
+`parse_json_coverage()`, `parse_json_file_node()`
+
+The behavior of this parser was informed by the following sources:
+
+* the *Invoking Gcov* section in the GCC manual (version 11)
+  <https://gcc.gnu.org/onlinedocs/gcc-14.1.0/gcc/Invoking-Gcov.html>
+* the ``gcov.c`` source code in GCC
+  (especially for understanding the exact number format)
+  <https://github.com/gcc-mirror/gcc/blob/releases/gcc-14.1.0/gcc/gcov.cc>
+"""
+# pylint: disable=too-many-lines
+
+import logging
+import os
+from locale import getpreferredencoding
+from typing import (
+    Any,
+    Optional,
+    Union,
+)
+
+from gcovr.utils import get_md5_hexdigest
+
+from ....coverage import (
+    BranchCoverage,
+    ConditionCoverage,
+    FileCoverage,
+    FunctionCoverage,
+    LineCoverage,
+)
+from ....filter import Filter, is_file_excluded
+from ....merging import (
+    FUNCTION_MAX_LINE_MERGE_OPTIONS,
+    MergeOptions,
+    insert_branch_coverage,
+    insert_condition_coverage,
+    insert_function_coverage,
+    insert_line_coverage,
+)
+from .common import (
+    SUSPICIOUS_COUNTER,
+    NegativeHits,
+    SuspiciousHits,
+)
+
+GCOV_JSON_VERSION = "2"
+LOGGER = logging.getLogger("gcovr")
+DEFAULT_SOURCE_ENCODING = getpreferredencoding()
+
+
+def parse_json_coverage(
+    gcov_json_data: dict[str, Any],
+    data_source: str,
+    include_filters: list[Filter],
+    exclude_filters: list[Filter],
+    ignore_parse_errors: Optional[set[str]],
+    suspicious_hits_threshold: int = SUSPICIOUS_COUNTER,
+    source_encoding: str = DEFAULT_SOURCE_ENCODING,
+) -> list[tuple[FileCoverage, list[str]]]:
+    """Process a GCOV JSON output."""
+
+    file_covs = []
+
+    # Check format version because the file can be created external
+    if gcov_json_data["format_version"] != GCOV_JSON_VERSION:
+        raise RuntimeError(
+            f"Got wrong JSON format version {gcov_json_data['format_version']}, expected {GCOV_JSON_VERSION}"
+        )
+
+    for file in gcov_json_data["files"]:
+        source_lines: list[bytes] = []
+        fname = os.path.normpath(
+            os.path.join(gcov_json_data["current_working_directory"], file["file"])
+        )
+        LOGGER.debug(f"Parsing coverage data for file {fname}")
+
+        if is_file_excluded(fname, include_filters, exclude_filters):
+            continue
+
+        if file["file"] == "<stdin>":
+            message = f"Got sourcefile {file['file']}, using empty lines."
+            LOGGER.info(message)
+            source_lines = [b"" for _ in range(file["lines"][-1]["line_number"])]
+            source_lines[0] = f"/* {message} */".encode()
+        else:
+            with open(fname, "rb") as fh_in2:
+                source_lines = fh_in2.read().splitlines()
+            lines = len(source_lines)
+            max_line_from_cdata = (
+                file["lines"][-1]["line_number"] if file["lines"] else 1
+            )
+            if lines < max_line_from_cdata:
+                LOGGER.warning(
+                    f"File {fname} has {lines} line(s) but coverage data has {max_line_from_cdata} line(s)."
+                )
+                # Python ranges are exclusive. We want to iterate over all lines, including
+                # that last line. Thus, we have to add a +1 to include that line.
+                for _ in range(lines, max_line_from_cdata):
+                    source_lines.append(b"/*EOF*/")
+
+        encoded_source_lines = [
+            line.decode(source_encoding, errors="replace") for line in source_lines
+        ]
+
+        file_cov = _parse_file_node(
+            file,
+            fname,
+            encoded_source_lines,
+            data_source,
+            ignore_parse_errors,
+            suspicious_hits_threshold,
+        )
+
+        file_covs.append((file_cov, encoded_source_lines))
+
+    return file_covs
+
+
+def _parse_file_node(
+    gcov_file_node: dict[str, Any],
+    filename: str,
+    source_lines: list[str],
+    data_source: Optional[Union[str, set[str]]],
+    ignore_parse_errors: Optional[set[str]],
+    suspicious_hits_threshold: int = SUSPICIOUS_COUNTER,
+) -> FileCoverage:
+    """
+    Extract coverage data from a json gcov report.
+
+    Logging:
+    Parse problems are reported as warnings.
+    Coverage exclusion decisions are reported as verbose messages.
+
+    Arguments:
+        gcov_file_node: one of the "files" node in the gcov json format
+        filename: for error reports
+        source_lines: decoded source code lines, for reporting
+        data_source: source of this node, for reporting
+        ignore_parse_errors: which errors should be converted to warnings
+
+    Returns:
+        The coverage data
+
+    Raises:
+        Any exceptions during parsing, unless ignore_parse_errors is set.
+    """
+    persistent_states = dict[str, Any]()
+    if ignore_parse_errors is None:
+        ignore_parse_errors = set()
+
+    def check_hits(hits: int, line: str) -> int:
+        if hits < 0:
+            NegativeHits.raise_if_not_ignored(
+                line, ignore_parse_errors, persistent_states
+            )
+            hits = 0
+
+        if suspicious_hits_threshold != 0 and hits >= suspicious_hits_threshold:
+            SuspiciousHits.raise_if_not_ignored(
+                line, ignore_parse_errors, persistent_states
+            )
+            hits = 0
+
+        return hits
+
+    file_cov = FileCoverage(filename, data_source)
+    for line in gcov_file_node["lines"]:
+        line_cov = insert_line_coverage(
+            file_cov,
+            LineCoverage(
+                line["line_number"],
+                count=check_hits(line["count"], source_lines[line["line_number"] - 1]),
+                function_name=line.get("function_name"),
+                block_ids=line["block_ids"],
+                md5=get_md5_hexdigest(
+                    source_lines[line["line_number"] - 1].encode("utf-8")
+                ),
+            ),
+        )
+        for index, branch in enumerate(line["branches"]):
+            insert_branch_coverage(
+                line_cov,
+                index,
+                BranchCoverage(
+                    branch["source_block_id"],
+                    check_hits(branch["count"], source_lines[line["line_number"] - 1]),
+                    fallthrough=branch["fallthrough"],
+                    throw=branch["throw"],
+                    destination_block_id=branch["destination_block_id"],
+                ),
+            )
+        for index, condition in enumerate(line.get("conditions", [])):
+            insert_condition_coverage(
+                line_cov,
+                index,
+                ConditionCoverage(
+                    check_hits(
+                        condition["count"], source_lines[line["line_number"] - 1]
+                    ),
+                    condition["covered"],
+                    condition["not_covered_true"],
+                    condition["not_covered_false"],
+                ),
+            )
+    for function in gcov_file_node["functions"]:
+        # Use 100% only if covered == total.
+        if function["blocks_executed"] == function["blocks"]:
+            blocks = 100.0
+        else:
+            # There is at least one uncovered item.
+            # Round to 1 decimal and clamp to max 99.9%.
+            ratio = function["blocks_executed"] / function["blocks"]
+            blocks = min(99.9, round(ratio * 100.0, 1))
+
+        insert_function_coverage(
+            file_cov,
+            FunctionCoverage(
+                function["name"],
+                function["demangled_name"],
+                lineno=function["start_line"],
+                count=function["execution_count"],
+                blocks=blocks,
+                start=(function["start_line"], function["start_column"]),
+                end=(function["end_line"], function["end_column"]),
+            ),
+            MergeOptions(func_opts=FUNCTION_MAX_LINE_MERGE_OPTIONS),
+        )
+
+    if (
+        "negative_hits.warn_once_per_file" in persistent_states
+        and persistent_states["negative_hits.warn_once_per_file"] > 1
+    ):
+        LOGGER.warning(
+            f"Ignored {persistent_states['negative_hits.warn_once_per_file']} negative hits overall."
+        )
+
+    if (
+        "suspicious_hits.warn_once_per_file" in persistent_states
+        and persistent_states["suspicious_hits.warn_once_per_file"] > 1
+    ):
+        LOGGER.warning(
+            f"Ignored {persistent_states['suspicious_hits.warn_once_per_file']} suspicious hits overall."
+        )
+
+    return file_cov

--- a/src/gcovr/formats/gcov/parser/text.py
+++ b/src/gcovr/formats/gcov/parser/text.py
@@ -588,7 +588,7 @@ def _parse_line(
     _BranchLine(branchno=0, hits=0, annotation='fallthrough')
     >>> _parse_line('branch 2 with some unknown format')
     Traceback (most recent call last):
-    gcovr.formats.gcov.parser.UnknownLineType: branch 2 with some unknown format
+    gcovr.formats.gcov.parser.text.UnknownLineType: branch 2 with some unknown format
 
     Example: can parse call tags:
     >>> _parse_line('call  0 never executed')
@@ -599,7 +599,7 @@ def _parse_line(
     _CallLine(callno=17, returned=9)
     >>> _parse_line('call 2 with some unknown format')
     Traceback (most recent call last):
-    gcovr.formats.gcov.parser.UnknownLineType: call 2 with some unknown format
+    gcovr.formats.gcov.parser.text.UnknownLineType: call 2 with some unknown format
 
     Example: can parse unconditional branches
     >>> _parse_line('unconditional 1 taken 17')
@@ -612,7 +612,7 @@ def _parse_line(
     _UnconditionalLine(branchno=3, hits=0)
     >>> _parse_line('unconditional with some unknown format')
     Traceback (most recent call last):
-    gcovr.formats.gcov.parser.UnknownLineType: unconditional with some unknown format
+    gcovr.formats.gcov.parser.text.UnknownLineType: unconditional with some unknown format
 
     Example: can parse function tags:
     >>> _parse_line('function foo called 2 returned 1 blocks executed 85%')
@@ -623,7 +623,7 @@ def _parse_line(
     _FunctionLine(name='foo', call_count=2, blocks_covered=85.0)
     >>> _parse_line('function foo with some unknown format')
     Traceback (most recent call last):
-    gcovr.formats.gcov.parser.UnknownLineType: function foo with some unknown format
+    gcovr.formats.gcov.parser.text.UnknownLineType: function foo with some unknown format
 
     Example: can parse template specialization markers:
     >>> _parse_line('------------------')
@@ -634,10 +634,10 @@ def _parse_line(
     _SpecializationNameLine(name='Foo<bar>::baz()')
     >>> _parse_line(' foo:')
     Traceback (most recent call last):
-    gcovr.formats.gcov.parser.UnknownLineType:  foo:
+    gcovr.formats.gcov.parser.text.UnknownLineType:  foo:
     >>> _parse_line(':')
     Traceback (most recent call last):
-    gcovr.formats.gcov.parser.UnknownLineType: :
+    gcovr.formats.gcov.parser.text.UnknownLineType: :
 
     Example: can parse block line:
     >>> _parse_line('     1: 32-block  0')
@@ -654,12 +654,12 @@ def _parse_line(
     _BlockLine(hits=0, lineno=32, block_id=0, extra_info=NONE)
     >>> _parse_line('     1: 9-block with some unknown format')
     Traceback (most recent call last):
-    gcovr.formats.gcov.parser.UnknownLineType:      1: 9-block with some unknown format
+    gcovr.formats.gcov.parser.text.UnknownLineType:      1: 9-block with some unknown format
 
     Example: will reject garbage:
     >>> _parse_line('nonexistent_tag foo bar')
     Traceback (most recent call last):
-    gcovr.formats.gcov.parser.UnknownLineType: nonexistent_tag foo bar
+    gcovr.formats.gcov.parser.text.UnknownLineType: nonexistent_tag foo bar
     """
     # pylint: disable=too-many-branches
     if ignore_parse_errors is None:

--- a/src/gcovr/formats/gcov/read.py
+++ b/src/gcovr/formats/gcov/read.py
@@ -18,7 +18,7 @@
 # ****************************************************************************
 
 import gzip
-import json
+from json import loads as json_loads
 import logging
 import os
 import re
@@ -177,12 +177,12 @@ def find_datafiles(search_path: str, exclude_dirs: list[re.Pattern[str]]) -> lis
 # Process a single gcov datafile
 #
 def process_gcov_json_data(
-    data_fname: str, covdata: CoverageContainer, options: Options
+    data_source: str, covdata: CoverageContainer, options: Options
 ) -> None:
     """Process a GCOV JSON output."""
 
     with gzip.open(data_source, "rt", encoding="UTF-8") as fh_in:
-        gcov_json_data = json.loads(fh_in.read())
+        gcov_json_data = json_loads(fh_in.read())
 
     coverage = json.parse_coverage(
         gcov_json_data=gcov_json_data,

--- a/src/gcovr/formats/gcov/read.py
+++ b/src/gcovr/formats/gcov/read.py
@@ -17,6 +17,8 @@
 #
 # ****************************************************************************
 
+import gzip
+import json
 import logging
 import os
 import re
@@ -179,8 +181,11 @@ def process_gcov_json_data(
 ) -> None:
     """Process a GCOV JSON output."""
 
+    with gzip.open(data_source, "rt", encoding="UTF-8") as fh_in:
+        gcov_json_data = json.loads(fh_in.read())
+
     coverage = json.parse_coverage(
-        data_source=data_fname,
+        gcov_json_data=gcov_json_data,
         include_filters=options.filter,
         exclude_filters=options.exclude,
         ignore_parse_errors=options.gcov_ignore_parse_errors,

--- a/src/gcovr/formats/gcov/read.py
+++ b/src/gcovr/formats/gcov/read.py
@@ -191,6 +191,7 @@ def process_gcov_json_data(
         ignore_parse_errors=options.gcov_ignore_parse_errors,
         suspicious_hits_threshold=options.gcov_suspicious_hits_threshold,
         source_encoding=options.source_encoding,
+        data_source=data_source,
     )
 
     for file_cov, source_lines in coverage:

--- a/src/gcovr/formats/gcov/read.py
+++ b/src/gcovr/formats/gcov/read.py
@@ -177,11 +177,11 @@ def find_datafiles(search_path: str, exclude_dirs: list[re.Pattern[str]]) -> lis
 # Process a single gcov datafile
 #
 def process_gcov_json_data(
-    data_source: str, covdata: CoverageContainer, options: Options
+    data_fname: str, covdata: CoverageContainer, options: Options
 ) -> None:
     """Process a GCOV JSON output."""
 
-    with gzip.open(data_source, "rt", encoding="UTF-8") as fh_in:
+    with gzip.open(data_fname, "rt", encoding="UTF-8") as fh_in:
         gcov_json_data = json_loads(fh_in.read())
 
     coverage = json.parse_coverage(
@@ -191,7 +191,7 @@ def process_gcov_json_data(
         ignore_parse_errors=options.gcov_ignore_parse_errors,
         suspicious_hits_threshold=options.gcov_suspicious_hits_threshold,
         source_encoding=options.source_encoding,
-        data_source=data_source,
+        data_fname=data_fname,
     )
 
     for file_cov, source_lines in coverage:

--- a/src/gcovr/formats/gcov/read.py
+++ b/src/gcovr/formats/gcov/read.py
@@ -27,46 +27,35 @@ import subprocess  # nosec # Commands are trusted.
 from threading import Lock
 from typing import Any, Callable, Optional
 
-from .parser import parse_metadata, parse_coverage
-from .workers import Workers, locked_directory
-from ...coverage import (
-    BranchCoverage,
-    ConditionCoverage,
-    CoverageContainer,
-    FileCoverage,
-    FunctionCoverage,
-    LineCoverage,
-)
+from ...coverage import CoverageContainer
+from ...decision_analysis import DecisionParser
 from ...exclusions import (
     apply_all_exclusions,
     get_exclusion_options_from_options,
 )
 from ...filter import Filter, is_file_excluded
-from ...decision_analysis import DecisionParser
 from ...merging import (
-    MergeOptions,
-    FUNCTION_MAX_LINE_MERGE_OPTIONS,
     GcovrMergeAssertionError,
-    insert_branch_coverage,
-    insert_condition_coverage,
-    insert_function_coverage,
-    insert_line_coverage,
-    merge_covdata,
     get_merge_mode_from_options,
     insert_file_coverage,
+    merge_covdata,
 )
 from ...options import Options
 from ...utils import (
-    search_file,
     commonpath,
-    is_fs_case_insensitive,
     fix_case_of_path,
-    get_md5_hexdigest,
+    is_fs_case_insensitive,
+    search_file,
 )
-
+from .parser import (
+    GCOV_JSON_VERSION,
+    parse_coverage,
+    parse_gcov_json_coverage,
+    parse_metadata,
+)
+from .workers import Workers, locked_directory
 
 LOGGER = logging.getLogger("gcovr")
-GCOV_JSON_VERSION = "2"
 
 output_re = re.compile(r"[Cc]reating [`'](.*)'$")
 source_error_re = re.compile(
@@ -193,121 +182,79 @@ def process_gcov_json_data(
     data_fname: str, covdata: CoverageContainer, options: Options
 ) -> None:
     """Process a GCOV JSON output."""
+
+    ignore_parse_errors = options.gcov_ignore_parse_errors
+    suspicious_hits_threshold = options.gcov_suspicious_hits_threshold
+
     with gzip.open(data_fname, "rt", encoding="UTF-8") as fh_in:
         gcov_json_data = json.loads(fh_in.read())
 
-    # Check format version because the file can be created external
-    if gcov_json_data["format_version"] != GCOV_JSON_VERSION:
-        raise RuntimeError(
-            f"Got wrong JSON format version {gcov_json_data['format_version']}, expected {GCOV_JSON_VERSION}"
-        )
-
-    for file in gcov_json_data["files"]:
-        fname = os.path.normpath(
-            os.path.join(gcov_json_data["current_working_directory"], file["file"])
-        )
-        LOGGER.debug(f"Parsing coverage data for file {fname}")
-
-        if is_file_excluded(fname, options.filter, options.exclude):
-            continue
-
-        if file["file"] == "<stdin>":
-            message = f"Got sourcefile {file['file']}, using empty lines."
-            LOGGER.info(message)
-            source_lines = [b"" for _ in range(file["lines"][-1]["line_number"])]
-            source_lines[0] = f"/* {message} */".encode()
-        else:
-            with open(fname, "rb") as fh_in:
-                source_lines = fh_in.read().splitlines()
-            lines = len(source_lines)
-            max_line_from_cdata = (
-                file["lines"][-1]["line_number"] if file["lines"] else 1
+        # Check format version because the file can be created external
+        if gcov_json_data["format_version"] != GCOV_JSON_VERSION:
+            raise RuntimeError(
+                f"Got wrong JSON format version {gcov_json_data['format_version']}, expected {GCOV_JSON_VERSION}"
             )
-            if lines < max_line_from_cdata:
-                LOGGER.warning(
-                    f"File {fname} has {lines} line(s) but coverage data has {max_line_from_cdata} line(s)."
-                )
-                # Python ranges are exclusive. We want to iterate over all lines, including
-                # that last line. Thus, we have to add a +1 to include that line.
-                for _ in range(lines, max_line_from_cdata):
-                    source_lines.append(b"/*EOF*/")
 
-        file_cov = FileCoverage(fname, data_fname)
-        for line in file["lines"]:
-            line_cov = insert_line_coverage(
-                file_cov,
-                LineCoverage(
-                    line["line_number"],
-                    count=line["count"],
-                    function_name=line.get("function_name"),
-                    block_ids=line["block_ids"],
-                    md5=get_md5_hexdigest(source_lines[line["line_number"] - 1]),
-                ),
+        for file in gcov_json_data["files"]:
+            source_lines: list[bytes] = []
+            fname = os.path.normpath(
+                os.path.join(gcov_json_data["current_working_directory"], file["file"])
             )
-            for index, branch in enumerate(line["branches"]):
-                insert_branch_coverage(
-                    line_cov,
-                    index,
-                    BranchCoverage(
-                        branch["source_block_id"],
-                        branch["count"],
-                        fallthrough=branch["fallthrough"],
-                        throw=branch["throw"],
-                        destination_block_id=branch["destination_block_id"],
-                    ),
-                )
-            for index, condition in enumerate(line.get("conditions", [])):
-                insert_condition_coverage(
-                    line_cov,
-                    index,
-                    ConditionCoverage(
-                        condition["count"],
-                        condition["covered"],
-                        condition["not_covered_true"],
-                        condition["not_covered_false"],
-                    ),
-                )
-        for function in file["functions"]:
-            # Use 100% only if covered == total.
-            if function["blocks_executed"] == function["blocks"]:
-                blocks = 100.0
+            LOGGER.debug(f"Parsing coverage data for file {fname}")
+
+            if is_file_excluded(fname, options.filter, options.exclude):
+                continue
+
+            if file["file"] == "<stdin>":
+                message = f"Got sourcefile {file['file']}, using empty lines."
+                LOGGER.info(message)
+                source_lines = [b"" for _ in range(file["lines"][-1]["line_number"])]
+                source_lines[0] = f"/* {message} */".encode()
             else:
-                # There is at least one uncovered item.
-                # Round to 1 decimal and clamp to max 99.9%.
-                ratio = function["blocks_executed"] / function["blocks"]
-                blocks = min(99.9, round(ratio * 100.0, 1))
+                with open(fname, "rb") as fh_in2:
+                    source_lines = fh_in2.read().splitlines()
+                lines = len(source_lines)
+                max_line_from_cdata = (
+                    file["lines"][-1]["line_number"] if file["lines"] else 1
+                )
+                if lines < max_line_from_cdata:
+                    LOGGER.warning(
+                        f"File {fname} has {lines} line(s) but coverage data has {max_line_from_cdata} line(s)."
+                    )
+                    # Python ranges are exclusive. We want to iterate over all lines, including
+                    # that last line. Thus, we have to add a +1 to include that line.
+                    for _ in range(lines, max_line_from_cdata):
+                        source_lines.append(b"/*EOF*/")
 
-            insert_function_coverage(
-                file_cov,
-                FunctionCoverage(
-                    function["name"],
-                    function["demangled_name"],
-                    lineno=function["start_line"],
-                    count=function["execution_count"],
-                    blocks=blocks,
-                    start=(function["start_line"], function["start_column"]),
-                    end=(function["end_line"], function["end_column"]),
-                ),
-                MergeOptions(func_opts=FUNCTION_MAX_LINE_MERGE_OPTIONS),
+            encoded_source_lines = [
+                line.decode(options.source_encoding, errors="replace")
+                for line in source_lines
+            ]
+
+            file_cov = parse_gcov_json_coverage(
+                file,
+                fname,
+                encoded_source_lines,
+                data_fname,
+                ignore_parse_errors,
+                suspicious_hits_threshold,
             )
 
-        encoded_source_lines = [
-            line.decode(options.source_encoding, errors="replace")
-            for line in source_lines
-        ]
-        LOGGER.debug(f"Apply exclusions for {fname}")
-        apply_all_exclusions(
-            file_cov,
-            lines=encoded_source_lines,
-            options=get_exclusion_options_from_options(options),
-        )
+            LOGGER.debug(f"Apply exclusions for {fname}")
+            apply_all_exclusions(
+                file_cov,
+                lines=encoded_source_lines,
+                options=get_exclusion_options_from_options(options),
+            )
 
-        if options.show_decision:
-            decision_parser = DecisionParser(file_cov, encoded_source_lines)
-            decision_parser.parse_all_lines()
+            if options.show_decision:
+                decision_parser = DecisionParser(file_cov, encoded_source_lines)
+                decision_parser.parse_all_lines()
 
-        LOGGER.debug(f"Merge coverage data for {fname}")
-        insert_file_coverage(covdata, file_cov, get_merge_mode_from_options(options))
+            LOGGER.debug(f"Merge coverage data for {fname}")
+            insert_file_coverage(
+                covdata, file_cov, get_merge_mode_from_options(options)
+            )
 
 
 #

--- a/tests/test_gcov_parser.py
+++ b/tests/test_gcov_parser.py
@@ -646,7 +646,7 @@ def test_negative_branch_count_json() -> None:
     with pytest.raises(NegativeHits):
         json.parse_coverage(
             gcov_json_data=source,
-            data_source="example.gcov.json.gz",
+            data_fname="example.gcov.json.gz",
             include_filters=[AlwaysMatchFilter()],
             exclude_filters=[],
             ignore_parse_errors=set(),
@@ -742,7 +742,7 @@ def test_negative_branch_count_ignored_json(
 
     json.parse_coverage(
         gcov_json_data=source,
-        data_source="example.gcov.json.gz",
+        data_fname="example.gcov.json.gz",
         include_filters=[AlwaysMatchFilter()],
         exclude_filters=[],
         ignore_parse_errors=set([flag]),

--- a/tests/test_gcov_parser.py
+++ b/tests/test_gcov_parser.py
@@ -457,7 +457,7 @@ def test_exception_during_coverage_processing(caplog: pytest.LogCaptureFixture) 
     )
     lines = source.splitlines()
 
-    with mock.patch("gcovr.formats.gcov.parser.insert_function_coverage") as m:
+    with mock.patch("gcovr.formats.gcov.parser.text.insert_function_coverage") as m:
         m.side_effect = AssertionError("totally broken")
         with pytest.raises(AssertionError) as ex_info:
             text.parse_coverage(


### PR DESCRIPTION
Since GCC 14, gcov outputs a json file instead the usual text file. The parsing code didn't implement the logic necessary for ignoring negative hits.
This PR:
 - Adds the missing logic
 - Splits the body of `process_gcov_json_data` to facilitate testing
 - Adds tests covering the three modes of reporting (exception, warning, one warning per file)