### PR TITLE
Fix warning about deprecated config key `None`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -173,6 +173,10 @@ jobs:
           fetch-depth: 75
           fetch-tags: true
 
+      - name: Workaround because fetch-tags doesn't work with git 2.48 in the GH actions
+        run: |
+          git fetch --tags
+
       - name: Set up Python
         uses: "./.github/actions/setup-python"
         with:
@@ -181,23 +185,22 @@ jobs:
 
       - name: Set up environment
         run: |
-          echo "NEW_RELEASE=$(if [ -z "$(sed -n '/Next Release/ p' CHANGELOG.rst)" ] ; then echo 'true' ; else echo 'false' ; fi)" >> $GITHUB_ENV
+          if [ -z "$(sed -n '/Next Release/ p' CHANGELOG.rst)" ] ; then
+            echo "GCOVR_VERSION=$(sed -n 's/^\([1-9][0-9]*\.[0-9][0-9]*\).*/\1/ p' CHANGELOG.rst | head -n 1)" >> $GITHUB_ENV
+          else
+            echo "GCOVR_VERSION=" >> $GITHUB_ENV
+          fi
 
       - name: Create new tag without pushing to get the correct name of the apps
-        if: ${{ (github.repository == 'gcovr/gcovr') && env.NEW_RELEASE == 'true' }}
+        if: ${{ (github.repository == 'gcovr/gcovr') && env.GCOVR_VERSION != '' }}
         run: |
-          # Get the version
-          GcovrVersion="$(sed -n 's/^\([1-9][0-9]*\.[0-9][0-9]*\).*/\1/ p' CHANGELOG.rst | head -n 1)"
-
           # Set git user info
           git config --global user.email "noreply@gcovr.com"
           git config --global user.name "gcovr authors"
 
           # Create the tag and print the output.
-          git tag -a "$GcovrVersion" -m "$GcovrVersion ($(date -I))"
-          git tag --list -n "$GcovrVersion"
-
-          echo "GCOVR_VERSION=$GcovrVersion" >> $GITHUB_ENV
+          git tag -a "$GCOVR_VERSION" -m "$GCOVR_VERSION ($(date -I))"
+          git tag --list -n "$GCOVR_VERSION"
 
       - name: Install dependencies
         run: |
@@ -240,12 +243,12 @@ jobs:
           ls -al build
 
       - name: Push new tag
-        if: ${{ (github.repository == 'gcovr/gcovr') && (github.event.ref == 'refs/heads/main') && env.NEW_RELEASE == 'true' }}
+        if: ${{ (github.repository == 'gcovr/gcovr') && (github.event.ref == 'refs/heads/main') && env.GCOVR_VERSION != '' }}
         run: |
           git push origin "refs/tags/$GCOVR_VERSION"
 
       - name: Create release and upload build artifacts
-        if: ${{ (github.repository == 'gcovr/gcovr') && (github.event.ref == 'refs/heads/main') && (env.NEW_RELEASE == 'true') }}
+        if: ${{ (github.repository == 'gcovr/gcovr') && (github.event.ref == 'refs/heads/main') && (env.GCOVR_VERSION != '') }}
         uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191
         with:
           tag_name: ${{ env.GCOVR_VERSION }}
@@ -253,7 +256,7 @@ jobs:
           files: build/*
 
       - name: Publish to PyPi
-        if: ${{ (github.repository == 'gcovr/gcovr') && (github.event.ref == 'refs/heads/main') && (env.NEW_RELEASE == 'true') }}
+        if: ${{ (github.repository == 'gcovr/gcovr') && (github.event.ref == 'refs/heads/main') && (env.GCOVR_VERSION != '') }}
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/gcovr-ci-job.yml
+++ b/.github/workflows/gcovr-ci-job.yml
@@ -43,6 +43,10 @@ jobs:
           fetch-depth: 75
           fetch-tags: true
 
+      - name: Workaround because fetch-tags doesn't work with git 2.48 in the GH actions
+        run: |
+          git fetch --tags
+
       - name: Set up Runner
         if: ${{ !inputs.container }}
         uses: "./.github/actions/setup-runner"
@@ -82,21 +86,22 @@ jobs:
           # Set the CC environment
           echo "CC=${{ inputs.gcc }}" >> $GITHUB_ENV
 
-          echo "NEW_RELEASE=$(if [ -z "$(sed -n '/Next Release/ p' CHANGELOG.rst)" ] ; then echo 'true' ; else echo 'false' ; fi)" >> $GITHUB_ENV
+          if [ -z "$(sed -n '/Next Release/ p' CHANGELOG.rst)" ] ; then
+            echo "GCOVR_VERSION=$(sed -n 's/^\([1-9][0-9]*\.[0-9][0-9]*\).*/\1/ p' CHANGELOG.rst | head -n 1)" >> $GITHUB_ENV
+          else
+            echo "GCOVR_VERSION=" >> $GITHUB_ENV
+          fi
 
       - name: Create new tag without pushing to get the correct name of the apps
-        if: ${{ (github.repository == 'gcovr/gcovr') && env.NEW_RELEASE == 'true' }}
+        if: ${{ (github.repository == 'gcovr/gcovr') && env.GCOVR_VERSION != '' }}
         run: |
-          # Get the version
-          GcovrVersion="$(sed -n 's/^\([1-9][0-9]*\.[0-9][0-9]*\).*/\1/ p' CHANGELOG.rst | head -n 1)"
-
           # Set git user info
           git config --global user.email "noreply@gcovr.com"
           git config --global user.name "gcovr authors"
 
           # Create the tag and print the output. Do not push.
-          git tag -a "$GcovrVersion" -m "$GcovrVersion ($(date -I))"
-          git tag --list -n "$GcovrVersion"
+          git tag -a "$GCOVR_VERSION" -m "$GCOVR_VERSION ($(date -I))"
+          git tag --list -n "$GCOVR_VERSION"
 
       - name: Install dependencies
         run: |
@@ -119,10 +124,9 @@ jobs:
         run: |
           nox --non-interactive $NOX_CONTAINER_ARGUMENTS --session tests --  --archive_differences
           # There must not be any modifications to get the correct versions later
-          Status=$(git status --porcelain)
-          if [ -n "$Status" ] ; then
+          if [ -n "$(git status --porcelain)" ] ; then
             echo "Following files are modified:"
-            echo "$Status"
+            git diff
             exit 1
           fi
 
@@ -146,10 +150,8 @@ jobs:
           nox --non-interactive $NOX_CONTAINER_ARGUMENTS --session doc || exit 1
 
           # Check if files are modified (outdated screenshots)
-          Status=$(git status --porcelain)
-          if [ -n "$Status" ] ; then
-            echo "Following files are modified:"
-            echo "$Status"
+          if [ -n "$(git status --porcelain)" ] ; then
+            git diff
 
             echo "Please regenerate the screenshots!"
             exit 1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,9 @@ New features and notable changes:
 
 Bug fixes and small improvements:
 
+- Fix warning ``Deprecated config key None used, please use 'txt-metric=branch' instead.``
+  if ``txt-metric="branch"`` is used in config file. (:issue:`1066`)
+
 Documentation:
 
 Internal changes:

--- a/noxfile.py
+++ b/noxfile.py
@@ -424,22 +424,24 @@ def tests(session: nox.Session) -> None:
     session.log("Print tool versions")
     session.run("python", "--version")
     # Use full path to executable
-    session.env["CC"] = str(shutil.which(session.env["CC"])).replace(os.path.sep, "/")
-    session.run(session.env["CC"], "--version", external=True)
-    session.env["CXX"] = str(shutil.which(session.env["CXX"])).replace(os.path.sep, "/")
-    session.run(session.env["CXX"], "--version", external=True)
-    cc_path, cc_file = os.path.split(session.env["CC"])
-    session.env["GCOV"] = str(
+    cc = str(session.env["CC"])
+    session.env["CC"] = str(shutil.which(cc)).replace(os.path.sep, "/")
+    session.run(cc, "--version", external=True)
+    cxx = str(session.env["CXX"])
+    session.env["CXX"] = str(shutil.which(cxx)).replace(os.path.sep, "/")
+    session.run(cxx, "--version", external=True)
+    cc_path, cc_file = os.path.split(cc)
+    gcov = str(
         shutil.which(
             os.path.join(
                 cc_path, cc_file.replace("clang", "llvm-cov").replace("gcc", "gcov")
             )
         )
     ).replace(os.path.sep, "/")
-
-    session.run(session.env["GCOV"], "--version", external=True)
-    if "llvm-cov" in session.env["GCOV"]:
-        session.env["GCOV"] += " gcov"
+    session.run(gcov, "--version", external=True)
+    if "llvm-cov" in gcov:
+        gcov += " gcov"
+    session.env["GCOV"] = gcov
     session.log(f"Using reference data for {session.env['CC_REFERENCE']}")
 
     with session.chdir("tests"):

--- a/src/gcovr/options.py
+++ b/src/gcovr/options.py
@@ -265,9 +265,10 @@ class GcovrDeprecatedConfigOptionAction(GcovrConfigOptionAction):
     def store_config_key(
         self, namespace: dict[str, Any], values: Any, config: Optional[str]
     ) -> None:
-        LOGGER.warning(
-            f"Deprecated config key {config} used, please use '{self.config}={self.value}' instead."
-        )
+        if config is not None:
+            LOGGER.warning(
+                f"Deprecated config key {config} used, please use '{self.config}={self.value}' instead."
+            )
         namespace[self.dest] = values
 
 


### PR DESCRIPTION
Fix warning `Deprecated config key None used, please use 'txt-metric=branch' instead.` if `txt-metric="branch"` is used in config file.

Fixes #1064, #1060