### PR TITLE
Remove the fixed with of HTML details

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,7 @@ Bug fixes and small improvements:
 - Fix warning ``Deprecated config key None used, please use 'txt-metric=branch' instead.``
   if ``txt-metric="branch"`` is used in config file. (:issue:`1066`)
 - Add ``excluded`` property for conditions and calls to the JSON report. (:issue:`1080`)
+- Remove the fixed with of the HTML details which leads to test overflows. (:issue:`1086`)
 
 Documentation:
 

--- a/doc/examples/example_html.details.css
+++ b/doc/examples/example_html.details.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/doc/examples/example_html.html
+++ b/doc/examples/example_html.html
@@ -394,7 +394,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/src/gcovr/formats/html/default/style.details.css
+++ b/src/gcovr/formats/html/default/style.details.css
@@ -62,7 +62,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/config-toml/reference/clang-10/coverage.html
+++ b/tests/config-toml/reference/clang-10/coverage.html
@@ -394,7 +394,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/config-toml/reference/gcc-5/coverage.html
+++ b/tests/config-toml/reference/gcc-5/coverage.html
@@ -394,7 +394,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/decisions-neg-delta/reference/clang-10/coverage.css
+++ b/tests/decisions-neg-delta/reference/clang-10/coverage.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/decisions-neg-delta/reference/gcc-5/coverage.css
+++ b/tests/decisions-neg-delta/reference/gcc-5/coverage.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/exclude-line-branch/reference/clang-10/coverage.css
+++ b/tests/exclude-line-branch/reference/clang-10/coverage.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/exclude-line-branch/reference/gcc-5/coverage.css
+++ b/tests/exclude-line-branch/reference/gcc-5/coverage.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/exclude-line-custom/reference/clang-10/coverage.css
+++ b/tests/exclude-line-custom/reference/clang-10/coverage.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/exclude-line-custom/reference/gcc-5/coverage.css
+++ b/tests/exclude-line-custom/reference/gcc-5/coverage.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/exclude-source-branch/reference/gcc-5/coverage.css
+++ b/tests/exclude-source-branch/reference/gcc-5/coverage.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/html-default/reference/clang-10/coverage.css
+++ b/tests/html-default/reference/clang-10/coverage.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/html-default/reference/gcc-5/coverage.css
+++ b/tests/html-default/reference/gcc-5/coverage.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/html-nested-filter/reference/clang-10/coverage_nested.css
+++ b/tests/html-nested-filter/reference/clang-10/coverage_nested.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/html-nested-filter/reference/gcc-5/coverage_nested.css
+++ b/tests/html-nested-filter/reference/gcc-5/coverage_nested.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/html-nested-nonsort/reference/clang-10/coverage_nested.css
+++ b/tests/html-nested-nonsort/reference/clang-10/coverage_nested.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/html-nested-nonsort/reference/gcc-5/coverage_nested.css
+++ b/tests/html-nested-nonsort/reference/gcc-5/coverage_nested.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/html-nested-sort-casefold/reference/clang-10/coverage_nested.css
+++ b/tests/html-nested-sort-casefold/reference/clang-10/coverage_nested.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/html-nested-sort-casefold/reference/gcc-5/coverage_nested.css
+++ b/tests/html-nested-sort-casefold/reference/gcc-5/coverage_nested.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/html-nested-sort-percentage/reference/clang-10/coverage.css
+++ b/tests/html-nested-sort-percentage/reference/clang-10/coverage.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/html-nested-sort-percentage/reference/gcc-5/coverage.css
+++ b/tests/html-nested-sort-percentage/reference/gcc-5/coverage.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/html-nested-sort-uncovered/reference/clang-10/coverage.css
+++ b/tests/html-nested-sort-uncovered/reference/clang-10/coverage.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/html-nested-sort-uncovered/reference/gcc-5/coverage.css
+++ b/tests/html-nested-sort-uncovered/reference/gcc-5/coverage.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/html-no-syntax-highlighting/reference/clang-10/coverage.css
+++ b/tests/html-no-syntax-highlighting/reference/clang-10/coverage.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/html-no-syntax-highlighting/reference/gcc-5/coverage.css
+++ b/tests/html-no-syntax-highlighting/reference/gcc-5/coverage.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/html-single-page/reference/clang-10/coverage_single_page-js.css
+++ b/tests/html-single-page/reference/clang-10/coverage_single_page-js.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/html-single-page/reference/clang-10/coverage_single_page.css
+++ b/tests/html-single-page/reference/clang-10/coverage_single_page.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/html-single-page/reference/gcc-5/coverage_single_page-js.css
+++ b/tests/html-single-page/reference/gcc-5/coverage_single_page-js.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/html-single-page/reference/gcc-5/coverage_single_page.css
+++ b/tests/html-single-page/reference/gcc-5/coverage_single_page.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/html-tab-size-2/reference/clang-10/coverage.css
+++ b/tests/html-tab-size-2/reference/clang-10/coverage.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/html-tab-size-2/reference/gcc-5/coverage.css
+++ b/tests/html-tab-size-2/reference/gcc-5/coverage.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/html-themes/reference/clang-10/coverage.blue.css
+++ b/tests/html-themes/reference/clang-10/coverage.blue.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/html-themes/reference/clang-10/coverage.green.css
+++ b/tests/html-themes/reference/clang-10/coverage.green.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/html-themes/reference/gcc-5/coverage.blue.css
+++ b/tests/html-themes/reference/gcc-5/coverage.blue.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/html-themes/reference/gcc-5/coverage.green.css
+++ b/tests/html-themes/reference/gcc-5/coverage.green.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/include/reference/clang-10/coverage.css
+++ b/tests/include/reference/clang-10/coverage.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/include/reference/gcc-5/coverage.css
+++ b/tests/include/reference/gcc-5/coverage.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/nested/reference/clang-10/coverage.css
+++ b/tests/nested/reference/clang-10/coverage.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/nested/reference/gcc-5/coverage.css
+++ b/tests/nested/reference/gcc-5/coverage.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/nested2/reference/clang-10/coverage.css
+++ b/tests/nested2/reference/clang-10/coverage.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/nested2/reference/gcc-5/coverage.css
+++ b/tests/nested2/reference/gcc-5/coverage.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/simple1-dir/reference/clang-10/coverage.html
+++ b/tests/simple1-dir/reference/clang-10/coverage.html
@@ -394,7 +394,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/simple1-dir/reference/clang-10/coverage_details.css
+++ b/tests/simple1-dir/reference/clang-10/coverage_details.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/simple1-dir/reference/gcc-14/coverage.html
+++ b/tests/simple1-dir/reference/gcc-14/coverage.html
@@ -394,7 +394,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/simple1-dir/reference/gcc-5/coverage.html
+++ b/tests/simple1-dir/reference/gcc-5/coverage.html
@@ -394,7 +394,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/simple1-dir/reference/gcc-5/coverage_details.css
+++ b/tests/simple1-dir/reference/gcc-5/coverage_details.css
@@ -386,7 +386,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/simple1-dir/reference/gcc-8/coverage.html
+++ b/tests/simple1-dir/reference/gcc-8/coverage.html
@@ -394,7 +394,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/simple1-stdout/reference/clang-10/coverage.html
+++ b/tests/simple1-stdout/reference/clang-10/coverage.html
@@ -394,7 +394,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/simple1-stdout/reference/gcc-14/coverage.html
+++ b/tests/simple1-stdout/reference/gcc-14/coverage.html
@@ -394,7 +394,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/simple1-stdout/reference/gcc-5/coverage.html
+++ b/tests/simple1-stdout/reference/gcc-5/coverage.html
@@ -394,7 +394,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/simple1-stdout/reference/gcc-8/coverage.html
+++ b/tests/simple1-stdout/reference/gcc-8/coverage.html
@@ -394,7 +394,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/simple1/reference/clang-10/coverage-details-includecss.functions.html
+++ b/tests/simple1/reference/clang-10/coverage-details-includecss.functions.html
@@ -394,7 +394,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/simple1/reference/clang-10/coverage-details-includecss.html
+++ b/tests/simple1/reference/clang-10/coverage-details-includecss.html
@@ -394,7 +394,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/simple1/reference/clang-10/coverage-details-includecss.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/tests/simple1/reference/clang-10/coverage-details-includecss.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -394,7 +394,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/simple1/reference/clang-10/coverage-summary-includecss.html
+++ b/tests/simple1/reference/clang-10/coverage-summary-includecss.html
@@ -394,7 +394,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/simple1/reference/clang-13/coverage-details-includecss.functions.html
+++ b/tests/simple1/reference/clang-13/coverage-details-includecss.functions.html
@@ -394,7 +394,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/simple1/reference/clang-13/coverage-details-includecss.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/tests/simple1/reference/clang-13/coverage-details-includecss.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -394,7 +394,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/simple1/reference/gcc-14/coverage-details-includecss.functions.html
+++ b/tests/simple1/reference/gcc-14/coverage-details-includecss.functions.html
@@ -394,7 +394,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/simple1/reference/gcc-14/coverage-details-includecss.html
+++ b/tests/simple1/reference/gcc-14/coverage-details-includecss.html
@@ -394,7 +394,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/simple1/reference/gcc-14/coverage-details-includecss.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/tests/simple1/reference/gcc-14/coverage-details-includecss.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -394,7 +394,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/simple1/reference/gcc-14/coverage-summary-includecss.html
+++ b/tests/simple1/reference/gcc-14/coverage-summary-includecss.html
@@ -394,7 +394,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/simple1/reference/gcc-5/coverage-details-includecss.functions.html
+++ b/tests/simple1/reference/gcc-5/coverage-details-includecss.functions.html
@@ -394,7 +394,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/simple1/reference/gcc-5/coverage-details-includecss.html
+++ b/tests/simple1/reference/gcc-5/coverage-details-includecss.html
@@ -394,7 +394,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/simple1/reference/gcc-5/coverage-details-includecss.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/tests/simple1/reference/gcc-5/coverage-details-includecss.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -394,7 +394,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/simple1/reference/gcc-5/coverage-summary-includecss.html
+++ b/tests/simple1/reference/gcc-5/coverage-summary-includecss.html
@@ -394,7 +394,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/simple1/reference/gcc-8-Windows/coverage-details-includecss.functions.html
+++ b/tests/simple1/reference/gcc-8-Windows/coverage-details-includecss.functions.html
@@ -394,7 +394,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/simple1/reference/gcc-8-Windows/coverage-details-includecss.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/tests/simple1/reference/gcc-8-Windows/coverage-details-includecss.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -394,7 +394,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/simple1/reference/gcc-8/coverage-details-includecss.functions.html
+++ b/tests/simple1/reference/gcc-8/coverage-details-includecss.functions.html
@@ -394,7 +394,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/simple1/reference/gcc-8/coverage-details-includecss.html
+++ b/tests/simple1/reference/gcc-8/coverage-details-includecss.html
@@ -394,7 +394,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/simple1/reference/gcc-8/coverage-details-includecss.main.cpp.118fcbaaba162ba17933c7893247df3a.html
+++ b/tests/simple1/reference/gcc-8/coverage-details-includecss.main.cpp.118fcbaaba162ba17933c7893247df3a.html
@@ -394,7 +394,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;

--- a/tests/simple1/reference/gcc-8/coverage-summary-includecss.html
+++ b/tests/simple1/reference/gcc-8/coverage-summary-includecss.html
@@ -394,7 +394,6 @@ span.excludedLine
     text-align: left;
     white-space: nowrap;
     position: absolute;
-    width: 20em;
     padding: 1em;
     background: white;
     border: solid gray 1px;


### PR DESCRIPTION
The fixed with leads to text overflows.

Fixes #1084 