### PR TITLE
Only check the links during deployment stage

### DIFF
--- a/.github/workflows/gcovr-ci-job.yml
+++ b/.github/workflows/gcovr-ci-job.yml
@@ -33,6 +33,7 @@ jobs:
   gcovr-ci-job:
     runs-on: ${{ inputs.container && 'ubuntu-22.04' || inputs.os }}
     env:
+      SPHINX_SKIP_CHECK_LINKS: "True"
       FORCE_COLOR: "1"
       NOX_CONTAINER_ARGUMENTS: ${{ inputs.container && format(' --session docker_run_compiler({0}) --', inputs.gcc) || '' }}
       GENERATE_DOCUMENTATION: ${{ inputs.container && (inputs.gcc != 'gcc-5') && (inputs.gcc != 'gcc-6') && (inputs.gcc != 'gcc-8') && (inputs.gcc != 'gcc-9') && (inputs.gcc != 'clang-10') }}

--- a/README.rst
+++ b/README.rst
@@ -91,7 +91,7 @@ The development of gcovr was motivated by the need for
 text summaries and XML reports.
 
 .. _gcov: https://gcc.gnu.org/onlinedocs/gcc/Gcov.html
-.. _coverage.py: https://coverage.readthedocs.io/en/stable/
+.. _coverage.py: https://coverage.readthedocs.io/
 .. _clover: https://bitbucket.org/atlassian/clover/src/master/
 .. _cobertura: https://github.com/cobertura/cobertura/
 .. _coveralls: https://coveralls.io/

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -200,7 +200,6 @@ todo_include_todos = True
 extlinks = {"issue": ("https://github.com/gcovr/gcovr/issues/%s", "#%s")}
 
 # -- linkcheck extenstion ------------------------------------------
-
 linkcheck_anchors_ignore_for_url = [r"https://github.com/.+/blob/.+"]
 linkcheck_ignore = [r"https://github.com/gcovr/gcovr/issues/\d+"]
 

--- a/doc/source/cookbook.rst
+++ b/doc/source/cookbook.rst
@@ -41,7 +41,7 @@ Before we invoke the ``build_ext`` step, we first ``export CC="ccache gcc"``.
 Ccache works well but isn't absolutely perfect,
 see the `ccache manual`_ for caveats.
 
-.. _ccache manual: https://ccache.samba.org/manual/latest.html#_caveats
+.. _ccache manual: https://ccache.dev/manual/latest.html
 
 A shell session might look like this:
 

--- a/doc/source/output/cobertura.rst
+++ b/doc/source/output/cobertura.rst
@@ -20,11 +20,11 @@ This generates an XML summary of the lines executed:
     :code: xml
 
 This XML format is described in the
-`Cobertura XML DTD <https://github.com/gcovr/gcovr/tree/main/tests/cobertura.coverage-04.dtd>`__
+`Cobertura XML DTD <https://github.com/gcovr/gcovr/blob/main/tests/cobertura.coverage-04.dtd>`__
 suitable for import and display within the
-`Jenkins <http://www.jenkins-ci.org/>`__ and `Hudson <https://projects.eclipse.org/projects/technology.hudson>`__
+`Jenkins <https://www.jenkins.io/>`__ and `Hudson <https://projects.eclipse.org/projects/technology.hudson>`__
 continuous integration servers using the
-`Cobertura Plugin <https://wiki.jenkins-ci.org/display/JENKINS/Cobertura+Plugin>`__.
+`Jenkins Coverage Plugin <https://github.com/jenkinsci/coverage-plugin>`__.
 Gcovr also supports a :ref:`sonarqube_xml_output`.
 
 The :option:`--cobertura` option generates a denser XML output, and the

--- a/doc/source/output/html.rst
+++ b/doc/source/output/html.rst
@@ -103,7 +103,7 @@ between release versions.
 Note that you do not have to copy every single template and can copy and edit only the
 templates you wish to customize.
 
-.. _CSP: https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
+.. _CSP: https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP
 
 .. versionadded:: 7.0
    Added :option:`--html-template-dir<gcovr --html-template-dir>`

--- a/doc/source/output/sonarqube.rst
+++ b/doc/source/output/sonarqube.rst
@@ -9,4 +9,4 @@ in a suitable XML format via the :option:`--sonarqube<gcovr --sonarqube>` option
     gcovr --sonarqube coverage.xml
 
 The SonarQube XML format is documented at
-`<https://docs.sonarqube.org/latest/analysis/generic-test/>`_.
+`<https://docs.sonarsource.com/sonarqube-server/2025.2/analyzing-source-code/test-coverage/generic-test-data/>`_.

--- a/noxfile.py
+++ b/noxfile.py
@@ -336,8 +336,13 @@ def doc(session: nox.Session) -> None:
         with open("examples/gcovr.out", "w", encoding="UTF-8") as fh_out:
             session.run("gcovr", "-h", stdout=fh_out)
         for builder in ("linkcheck", "html", "latex", "epub"):
-            if os.environ.get("SPHINX_SKIP_CHECK_LINKS", "") == "True" and builder == "linkcheck":
-                session.log("Skip link checker due to environment SPHINX_SKIP_CHECK_LINKS=True.")
+            if (
+                os.environ.get("SPHINX_SKIP_CHECK_LINKS", "") == "True"
+                and builder == "linkcheck"
+            ):
+                session.log(
+                    "Skip link checker due to environment SPHINX_SKIP_CHECK_LINKS=True."
+                )
                 continue
             session.run(
                 "sphinx-build",

--- a/noxfile.py
+++ b/noxfile.py
@@ -336,6 +336,9 @@ def doc(session: nox.Session) -> None:
         with open("examples/gcovr.out", "w", encoding="UTF-8") as fh_out:
             session.run("gcovr", "-h", stdout=fh_out)
         for builder in ("linkcheck", "html", "latex", "epub"):
+            if os.environ.get("SPHINX_SKIP_CHECK_LINKS", "") == "True" and builder == "linkcheck":
+                session.log("Skip link checker due to environment SPHINX_SKIP_CHECK_LINKS=True.")
+                continue
             session.run(
                 "sphinx-build",
                 "-b",
@@ -880,6 +883,8 @@ def docker_run_compiler(session: nox.Session, version: str) -> None:
         "FORCE_COLOR",
         "-e",
         f"HOST_OS={platform.system()}",
+        "-e",
+        "SPHINX_SKIP_CHECK_LINKS",
         "-v",
         f"{os.getcwd()}:/gcovr",
         docker_container_id(session, version),


### PR DESCRIPTION
The check sometimes can't reach the target. To reduce the target request the links are now only checked during deployment stage.

[no changelog]