### PR TITLE
Abort on version missmatch between gcc/gcov

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install spellchecker
         run: |
-          npm install -g cspell@latest
+          npm install -g cspell@8.19.4
       - name: Run spellchecker
         run: |
           cspell --config cspell.json --color --show-suggestions '**'

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,8 @@ New features and notable changes:
 
   - Add option :option:`--markdown-file-link` to link files in markdown report. (:issue:`1079`)
 
+- Abort on version mismatch between gcc/gcov instead of trying all working directories. (:issue:`1097`)
+
 Bug fixes and small improvements:
 
 - Fix warning ``Deprecated config key None used, please use 'txt-metric=branch' instead.``

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -201,7 +201,10 @@ extlinks = {"issue": ("https://github.com/gcovr/gcovr/issues/%s", "#%s")}
 
 # -- linkcheck extenstion ------------------------------------------
 linkcheck_anchors_ignore_for_url = [r"https://github.com/.+/blob/.+"]
-linkcheck_ignore = [r"https://github.com/gcovr/gcovr/issues/\d+"]
+linkcheck_ignore = [
+    r"https://github.com/gcovr/gcovr/issues/\d+",
+    r"https://stackoverflow.com/questions/tagged/gcovr",
+]
 
 # -- Jinja2 template context ------------------------------------------
 

--- a/src/gcovr/formats/gcov/read.py
+++ b/src/gcovr/formats/gcov/read.py
@@ -58,6 +58,7 @@ output_error_re = re.compile(
     r"(?:[Cc](?:annot|ould not) open output file|Operation not permitted|Permission denied|Read-only file system)"
 )
 unknown_cla_re = re.compile(r"Unknown command line argument")
+version_mismatch_re = re.compile(r":version '[']+', prefer '[']+'")
 
 
 def read_report(options: Options) -> CoverageContainer:
@@ -786,6 +787,9 @@ def run_gcov_and_process_files(
             if unknown_cla_re.search(err):
                 # gcov tossed errors: throw exception
                 raise RuntimeError(f"Error in gcov command line: {err}")
+            if version_mismatch_re.search(err):
+                # gcov tossed errors: throw exception
+                raise RuntimeError(f"Version mismatch in gcc/gcov: {err}")
 
             ignore_source_errors = options.gcov_ignore_errors is not None and any(
                 v in options.gcov_ignore_errors for v in ["all", "source_not_found"]


### PR DESCRIPTION
The error message `xxx.gcno:version 'B42*', prefer 'B33*'` is now detected and handled by gcovr instead of trying next working directory.