### PR TITLE
Fix deprecation warning in standalone application

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,7 @@ Bug fixes and small improvements:
 - Do not use option ``--calls`` as exclusion filter. (:issue:`1090`)
 - Add support for reading gcov JSON data without source files. (:issue:`1094`)
 - Add back references to the data model to get source location in error messages. (:issue:`1094`)
+- Fix deprecation warning in standalone application. (:issue:`1115`)
 
 Documentation:
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -590,6 +590,9 @@ def bundle_app(session: nox.Session) -> None:
             "./pyinstaller",
             "--specpath",
             "./pyinstaller",
+            # Workaround for "UserWarning: pkg_resources is deprecated as an API"
+            "--exclude-module",
+            "pkg_resources",
             "--onefile",
             "--collect-all",
             "gcovr",


### PR DESCRIPTION
When running the standalone application the following warning is printed:
   PyInstaller/loader/pyimod02_importers.py:384: UserWarning: pkg_resources is deprecated as an API