### PR TITLE
Ignore empty data from gcov JSON report

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -52,6 +52,7 @@ Bug fixes and small improvements:
 - Fix error when merging conditions (and branches) for the same line if they are reported different
   across GCOV data files. (:issue:`1092`)
 - Improve branch details view if there are branches for several functions on same line. (:issue:`1128`)
+- Do not add files without functions and lines from ``gcov`` JSON files to data model. (:issue:`1130`)
 
 Documentation:
 
@@ -82,6 +83,7 @@ Known bugs:
 - ``JaCoCo`` report does not follow the DTD. Fixed in :ref:`Next release <next_release>`.
 - Error if conditions for the same line are reported different across GCOV data files.
   Workaround in this release available and fixed in :ref:`Next release <next_release>`.
+- Files without functions and lines from ``gcov`` JSON files are added to data model. (:issue:`1130`)
 
 Breaking changes:
 
@@ -143,6 +145,7 @@ Known bugs:
 - ``JaCoCo`` report does not follow the DTD. Fixed in :ref:`Next release <next_release>`.
 - Error if conditions for the same line are reported different across GCOV data files.
   Workaround in :ref:`8.3 <release_8_3>` available and fixed in :ref:`Next release <next_release>`.
+- Files without functions and lines from ``gcov`` JSON files are added to data model. (:issue:`1130`)
 
 Breaking changes:
 
@@ -170,6 +173,7 @@ Known bugs:
 - ``JaCoCo`` report does not follow the DTD. Fixed in :ref:`Next release <next_release>`.
 - Error if conditions for the same line are reported different across GCOV data files.
   Workaround in :ref:`8.3 <release_8_3>` available and fixed in :ref:`Next release <next_release>`.
+- Files without functions and lines from ``gcov`` JSON files are added to data model. (:issue:`1130`)
 
 Breaking changes:
 
@@ -199,6 +203,7 @@ Known bugs:
 - ``JaCoCo`` report does not follow the DTD. Fixed in :ref:`Next release <next_release>`.
 - Error if conditions for the same line are reported different across GCOV data files.
   Workaround in :ref:`8.3 <release_8_3>` available and fixed in :ref:`Next release <next_release>`.
+- Files without functions and lines from ``gcov`` JSON files are added to data model. (:issue:`1130`)
 
 Breaking changes:
 

--- a/src/gcovr/formats/gcov/parser/json.py
+++ b/src/gcovr/formats/gcov/parser/json.py
@@ -71,6 +71,12 @@ def parse_coverage(
         )
 
     for file in gcov_json_data["files"]:
+        if not file["lines"] and not file["functions"]:
+            LOGGER.debug(
+                f"Skip data for file {file['file']} because no lines and functions defined."
+            )
+            continue
+
         source_lines: list[bytes] = []
         fname = os.path.normpath(
             os.path.join(gcov_json_data["current_working_directory"], file["file"])
@@ -84,8 +90,8 @@ def parse_coverage(
             max(line["line_number"] for line in file["lines"]) if file["lines"] else 1
         )
         try:
-            with open(fname, "rb") as fh_in2:
-                source_lines = fh_in2.read().splitlines()
+            with open(fname, "rb") as fh_in:
+                source_lines = fh_in.read().splitlines()
             lines = len(source_lines)
             if lines < max_line_number:
                 LOGGER.warning(

--- a/tests/decisions/reference/gcc-14-Windows/coverage.json
+++ b/tests/decisions/reference/gcc-14-Windows/coverage.json
@@ -6197,9 +6197,6 @@
             ],
             "gcovr/data_sources": [
                 [
-                    "testcase-main##ab9fd553a654e1ba919762756d077556.gcov.json.gz"
-                ],
-                [
                     "testcase-switch_test##e57207397cce95ab6339a10280bf4337.gcov.json.gz"
                 ]
             ]

--- a/tests/decisions/reference/gcc-14/coverage.json
+++ b/tests/decisions/reference/gcc-14/coverage.json
@@ -6197,9 +6197,6 @@
             ],
             "gcovr/data_sources": [
                 [
-                    "testcase-main##82c8f4f173fe16bf08b8b8fa721fa188.gcov.json.gz"
-                ],
-                [
                     "testcase-switch_test##8dc93b0f0ad79b5d86720ccd66d7cbf1.gcov.json.gz"
                 ]
             ]


### PR DESCRIPTION
In gcov JSON report there can be files without lines and function, e.g.:
```json
   {
      "file": "/<…>/d4f0bc5a/13edd1ef.h",
      "functions": [],
      "lines": []
    },
```

This files are now ignored and not added to the data model.