### PR TITLE
Improve release notes and job summary

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -252,13 +252,7 @@ jobs:
 
       - name: Set release notes as job summary
         run: |
-          (
-            echo '''
-            # ${{ needs.build-package.outputs.gcovr_version_output }}
-
-            '''
-            cat doc/build/release_notes.md
-          ) >> $GITHUB_STEP_SUMMARY
+          cat doc/build/job_summary.md >> $GITHUB_STEP_SUMMARY
 
       - name: Upload release notes
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
- The empty line after a sub list is removed.
- The job summary is now also generated in nox session:
  - Version added without the leading spaces.
  - Issue links replaced by real links because #xxx is not rendered in job summary.
- Compare gcovr version with current release ID if not under development.

[no changelog]