### PR TITLE
Add option `--sonarqube-metric` to define which metrics to report

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -16,6 +16,7 @@ The following developers contributed to gcovr (ordered alphabetically):
     Cary Converse,
     Cezary Gapiński,
     Cheng-Yeh(Ken) Chung,
+    Christian Granzin,
     Christian Taedcke,
     Dave George,
     Davide Pesavento,

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,7 @@ New features and notable changes:
 - Add branch information to ``Coveralls`` report. (:issue:`1121`)
 - Add support to define :option:`--exclude-lines-by-pattern` and :option:`--exclude-branches-by-pattern`
   more than once. (:issue:`1129`)
+- Add support to define :option:`--sonarqube-metric` (:issue:`1042`)
 
 Bug fixes and small improvements:
 

--- a/doc/source/output/sonarqube.rst
+++ b/doc/source/output/sonarqube.rst
@@ -12,3 +12,23 @@ in a suitable XML format via the :option:`--sonarqube` option::
 
 The SonarQube XML format is documented at
 `<https://docs.sonarsource.com/sonarqube-server/2025.2/analyzing-source-code/test-coverage/generic-test-data/>`_.
+
+Coverage Metrics
+----------------
+
+By default the coverage report contains metrics for line and branch coverage. You can adjust the metrics available in the report with the ``--sonarqube-metric`` option. The following options are available:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Option
+     - Description
+
+   * - ``--sonarqube-metric=line``
+     - The generated XML contains only line coverage information
+
+   * - ``--sonarqube-metric=branch``
+     - The generated XML contains line and branch coverage information
+
+   * - ``--sonarqube-metric=decision``
+     - The generated XML contains line and branch coverage information, but the branch coverage is actually decision coverage. Requires the option ``--decisions`` to be enabled

--- a/src/gcovr/formats/sonarqube/__init__.py
+++ b/src/gcovr/formats/sonarqube/__init__.py
@@ -30,6 +30,8 @@ class SonarqubeHandler(BaseHandler):
     @classmethod
     def get_options(cls) -> list[Union[GcovrConfigOption, str]]:
         return [
+            # Global options needed for report
+            "show_decision",
             GcovrConfigOption(
                 "sonarqube",
                 ["--sonarqube"],
@@ -43,6 +45,15 @@ class SonarqubeHandler(BaseHandler):
                 type=OutputOrDefault,
                 default=None,
                 const=OutputOrDefault(None),
+            ),
+            GcovrConfigOption(
+                "sonarqube_metric",
+                ["--sonarqube-metric"],
+                config="sonarqube-metric",
+                group="output_options",
+                help=("The metric type to report."),
+                choices=("line", "branch", "decision"),
+                default="branch",
             ),
         ]
 

--- a/src/gcovr/formats/sonarqube/write.py
+++ b/src/gcovr/formats/sonarqube/write.py
@@ -17,9 +17,11 @@
 #
 # ****************************************************************************
 
+from typing import Optional, Union
 from lxml import etree  # nosec # We only write XML files
 
 from ...data_model.container import CoverageContainer
+from ...data_model.stats import CoverageStat, DecisionCoverageStat
 from ...options import Options
 from ...utils import write_xml_output
 
@@ -28,6 +30,11 @@ def write_report(
     covdata: CoverageContainer, output_file: str, options: Options
 ) -> None:
     """produce an XML report in the SonarQube generic coverage format"""
+
+    if options.sonarqube_metric == "decision" and not options.show_decision:
+        raise AssertionError(
+            "--sonarqube-metric=decision needs the option --decisions."
+        )
 
     root_elem = etree.Element("coverage")
     root_elem.set("version", "1")
@@ -44,8 +51,12 @@ def write_report(
                 line_node.set("lineNumber", str(linecov.lineno))
                 line_node.set("covered", "true" if linecov.is_covered else "false")
 
-                if linecov.branches:
+                stat: Optional[Union[CoverageStat, DecisionCoverageStat]] = None
+                if options.sonarqube_metric == "branch" and linecov.branches:
                     stat = linecov.branch_coverage()
+                elif options.sonarqube_metric == "decision" and linecov.decision:
+                    stat = linecov.decision_coverage()
+                if stat:
                     line_node.set("branchesToCover", str(stat.total))
                     line_node.set("coveredBranches", str(stat.covered))
 


### PR DESCRIPTION
Introduce an option ``--sonarqube-metric`` that lets the user define which metrics are printed in the SonarQube XML report.

Related to https://github.com/gcovr/gcovr/issues/1042