### PR TITLE
Add support to save zipped report

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -120,6 +120,8 @@ New features and notable changes:
 - Add :option:`--gcov-suspicious-hits-threshold` to configure the value for detecting suspicious hits in GCOV files. (:issue:`1021`)
 - Renamed JSON element ``destination_blockno`` to ``destination_block_id``. (:issue:`1045`)
 - Add :option:`--html-block-ids` to show the block ids of the lines and branches in ``HTML`` report. (:issue:`1055`)
+- Add support to save zipped reports if last suffix is ``.gz``. This is useable to reduce the size for JSON
+  report format :option:`--json`. (:issue:`1141`)
 
 Bug fixes and small improvements:
 

--- a/doc/source/output/clover.rst
+++ b/doc/source/output/clover.rst
@@ -29,6 +29,8 @@ The :option:`--clover` option generates a denser XML output, and the
 :option:`--clover-pretty` option generates an indented
 XML output that is easier to read.
 
+If the given name ends with the suffix ``.gz`` the report is compressed by gzip.
+
 .. versionadded:: 7.1
 
     Add :option:`--clover` and :option:`--clover-pretty`.

--- a/doc/source/output/cobertura.rst
+++ b/doc/source/output/cobertura.rst
@@ -29,11 +29,14 @@ continuous integration servers using the
 The :option:`--cobertura` option generates a denser XML output, and the
 :option:`--cobertura-pretty` option generates an indented
 XML output that is easier to read. Note that the XML output contains more
-information than the tabular summary.  The tabular summary shows the percentage
+information than the tabular summary. The tabular summary shows the percentage
 of covered lines, while the XML output includes branch statistics and the number
-of times that each line was covered.  Consequently, XML output can be
+of times that each line was covered. Consequently, XML output can be
 used to support performance optimization in the same manner that
 ``gcov`` does.
+
+If the given name ends with the suffix ``.gz`` the report is compressed by gzip
+and needs to be unzipped before using as input for other tools.
 
 .. versionadded:: 5.1
 

--- a/doc/source/output/coveralls.rst
+++ b/doc/source/output/coveralls.rst
@@ -13,6 +13,8 @@ in a suitable JSON format via the :option:`--coveralls` option::
 The :option:`--coveralls-pretty` option generates
 an indented JSON output that is easier to read.
 
+If the given name ends with the suffix ``.gz`` the report is compressed by gzip.
+
 Keep in mind that the output contains the checksums of the source files. If you are
 using different OSes, the line endings shall be the same.
 

--- a/doc/source/output/csv.rst
+++ b/doc/source/output/csv.rst
@@ -21,5 +21,8 @@ This generates an CSV:
 Be careful if you print the output of a CSV to STDOUT and redirect it to
 a file. According to :rfc:`4180`, the line endings must be CRLF.
 
+If the given name ends with the suffix ``.gz`` the report is compressed by gzip
+and needs to be unzipped before using as input for other tools.
+
 .. versionadded:: 5.0
    Added :option:`--csv`.

--- a/doc/source/output/html.rst
+++ b/doc/source/output/html.rst
@@ -21,9 +21,10 @@ following output:
     :align: center
 
 The default behavior of the :option:`--html` option is to generate
-HTML for a single webpage that summarizes the coverage for all files. The
-HTML is printed to standard output, but the :option:`-o/--output <--output>`
-option is used to specify a file that stores the HTML output.
+HTML for a single webpage that summarizes the coverage for all files.
+
+If the given name ends with the suffix ``.gz`` the report is compressed by gzip.
+This only make sense for a self contained report with one page.
 
 The :option:`--html-details` option is used to create a separate web
 page for each file. Each of these web pages includes the contents of

--- a/doc/source/output/jacoco.rst
+++ b/doc/source/output/jacoco.rst
@@ -26,11 +26,13 @@ DTD.
 The :option:`--jacoco` option generates a denser XML output, and the
 :option:`--jacoco-pretty` option generates an indented
 XML output that is easier to read. Note that the XML output contains more
-information than the tabular summary.  The tabular summary shows the percentage
+information than the tabular summary. The tabular summary shows the percentage
 of covered lines, while the XML output includes branch statistics and the number
-of times that each line was covered.  Consequently, XML output can be
+of times that each line was covered. Consequently, XML output can be
 used to support performance optimization in the same manner that
 ``gcov`` does.
+
+If the given name ends with the suffix ``.gz`` the report is compressed by gzip.
 
 .. versionadded:: 7.0
 

--- a/doc/source/output/lcov.rst
+++ b/doc/source/output/lcov.rst
@@ -10,6 +10,8 @@ in a suitable info format via the :option:`--lcov` option::
 
     gcovr --lcov coverage.lcov
 
+If the given name ends with the suffix ``.gz`` the report is compressed by gzip.
+
 With the following options you can set user defined fields in the coverage report:
 
 - :option:`--lcov-comment` defines an optional comment.

--- a/doc/source/output/markdown.rst
+++ b/doc/source/output/markdown.rst
@@ -15,6 +15,8 @@ the :option:`--markdown` option::
 If you just need a summary of the coverage information, you can use
 :option:`--markdown-summary` instead (see :ref:`markdown_summary_output`).
 
+If the given name ends with the suffix ``.gz`` the report is compressed by gzip.
+
 .. _markdown_summary_output:
 
 Markdown Summary Output

--- a/doc/source/output/sonarqube.rst
+++ b/doc/source/output/sonarqube.rst
@@ -10,6 +10,8 @@ in a suitable XML format via the :option:`--sonarqube` option::
 
     gcovr --sonarqube coverage.xml
 
+If the given name ends with the suffix ``.gz`` the report is compressed by gzip.
+
 The SonarQube XML format is documented at
 `<https://docs.sonarsource.com/sonarqube-server/2025.2/analyzing-source-code/test-coverage/generic-test-data/>`_.
 

--- a/doc/source/output/txt.rst
+++ b/doc/source/output/txt.rst
@@ -11,6 +11,8 @@ This is the default output format if no other format is selected.
 This output format can also be explicitly selected
 with the :option:`--txt` option.
 
+If the given name ends with the suffix ``.gz`` the report is compressed by gzip.
+
 .. versionadded:: 5.0
    Added explicit :option:`--txt` option.
 

--- a/src/gcovr/formats/html/write.py
+++ b/src/gcovr/formats/html/write.py
@@ -1151,8 +1151,6 @@ def _get_prefix_and_suffix(output_file: str) -> tuple[str, str]:
     (output_prefix, output_suffix) = os.path.splitext(os.path.abspath(output_file))
     if output_suffix == GZIP_SUFFIX:
         return _get_prefix_and_suffix(output_prefix)
-    if output_suffix == "":
-        output_suffix = ".html"
 
     return (output_prefix, output_suffix)
 

--- a/src/gcovr/formats/html/write.py
+++ b/src/gcovr/formats/html/write.py
@@ -50,6 +50,7 @@ from ...data_model.coverage import (
 from ...data_model.coverage import CoverageStat, DecisionCoverageStat
 from ...options import Options
 from ...utils import (
+    GZIP_SUFFIX,
     chdir,
     commonpath,
     force_unix_separator,
@@ -381,7 +382,11 @@ def write_report(
         cdata_fname[f] = force_unix_separator(filtered_fname)
         if options.html_details or options.html_nested or options.html_single_page:
             if os.path.normpath(f) == os.path.normpath(options.root_dir):
-                cdata_sourcefile[f] = output_file
+                cdata_sourcefile[f] = (
+                    output_file[: -len(GZIP_SUFFIX)]
+                    if output_file.endswith(GZIP_SUFFIX)
+                    else output_file
+                )
             else:
                 cdata_sourcefile[f] = _make_short_source_filename(
                     output_file, filtered_fname.rstrip(os.sep)
@@ -409,9 +414,7 @@ def write_report(
     root_info.set_directory(root_directory)
 
     if options.html_details or options.html_nested:
-        (output_prefix, output_suffix) = os.path.splitext(os.path.abspath(output_file))
-        if output_suffix == "":
-            output_suffix = ".html"
+        (output_prefix, output_suffix) = _get_prefix_and_suffix(output_file)
         functions_output_file = f"{output_prefix}.functions{output_suffix}"
         data["FUNCTIONS_FNAME"] = os.path.basename(functions_output_file)
         if options.html_single_page:
@@ -1143,6 +1146,17 @@ def source_row_call(linecov: LineCoverage) -> dict[str, Any]:
     }
 
 
+def _get_prefix_and_suffix(output_file: str) -> tuple[str, str]:
+    """Split into prefix and suffix, ignoring the last suffix for GZIP."""
+    (output_prefix, output_suffix) = os.path.splitext(os.path.abspath(output_file))
+    if output_suffix == GZIP_SUFFIX:
+        return _get_prefix_and_suffix(output_prefix)
+    if output_suffix == "":
+        output_suffix = ".html"
+
+    return (output_prefix, output_suffix)
+
+
 def _make_short_source_filename(output_file: str, filename: str) -> str:
     r"""Make a short-ish file path for --html-detail output.
 
@@ -1151,10 +1165,7 @@ def _make_short_source_filename(output_file: str, filename: str) -> str:
         filename (str): Path from root to source code.
     """
 
-    (output_prefix, output_suffix) = os.path.splitext(os.path.abspath(output_file))
-    if output_suffix == "":
-        output_suffix = ".html"
-
+    (output_prefix, output_suffix) = _get_prefix_and_suffix(output_file)
     filename = filename.replace(os.sep, "/").replace("<stdin>", "stdin")
     source_filename = (
         ".".join(

--- a/src/gcovr/formats/json/read.py
+++ b/src/gcovr/formats/json/read.py
@@ -17,6 +17,7 @@
 #
 # ****************************************************************************
 
+import gzip
 import json
 import logging
 import os
@@ -40,8 +41,8 @@ def read_report(options: Options) -> CoverageContainer:
     if len(options.json_tracefile) != 0:
         datafiles = set()
 
-        for trace_files_regex in options.json_tracefile:
-            trace_files = glob(trace_files_regex, recursive=True)
+        for trace_files_pattern in options.json_tracefile:
+            trace_files = glob(trace_files_pattern, recursive=True)
             if not trace_files:
                 raise RuntimeError(
                     "Bad --json-add-tracefile option.\n"
@@ -53,10 +54,14 @@ def read_report(options: Options) -> CoverageContainer:
 
         merge_options = get_merge_mode_from_options(options)
         for data_source in datafiles:
-            LOGGER.debug(f"Processing JSON file: {data_source}")
+            LOGGER.debug(f"Processing file: {data_source}")
 
-            with open(data_source, encoding="UTF-8") as json_file:
-                gcovr_json_data = json.load(json_file)
+            if data_source.casefold().endswith(".json.gz"):
+                with gzip.open(data_source, "rt", encoding="UTF-8") as fh:
+                    gcovr_json_data = json.loads(fh.read())
+            else:
+                with open(data_source, encoding="UTF-8") as json_file:
+                    gcovr_json_data = json.load(json_file)
 
             format_version = str(gcovr_json_data["gcovr/format_version"])
             if format_version != version.FORMAT_VERSION:

--- a/src/gcovr/formats/json/read.py
+++ b/src/gcovr/formats/json/read.py
@@ -23,6 +23,8 @@ import logging
 import os
 from glob import glob
 
+from ...utils import GZIP_SUFFIX
+
 from ...data_model import version
 from ...data_model.container import CoverageContainer
 from ...data_model.merging import get_merge_mode_from_options
@@ -56,7 +58,7 @@ def read_report(options: Options) -> CoverageContainer:
         for data_source in datafiles:
             LOGGER.debug(f"Processing file: {data_source}")
 
-            if data_source.casefold().endswith(".json.gz"):
+            if data_source.casefold().endswith(GZIP_SUFFIX):
                 with gzip.open(data_source, "rt", encoding="UTF-8") as fh:
                     gcovr_json_data = json.loads(fh.read())
             else:

--- a/src/gcovr/utils.py
+++ b/src/gcovr/utils.py
@@ -213,7 +213,7 @@ def open_text_for_writing(
         filename += default_filename
 
     if filename is not None and filename != "-":
-        if filename.endswith(".gz"):
+        if filename.endswith(GZIP_SUFFIX):
             with gzip.open(filename, "wt", **kwargs) as fh_out:
                 yield fh_out
         else:

--- a/src/gcovr/utils.py
+++ b/src/gcovr/utils.py
@@ -17,6 +17,7 @@
 #
 # ****************************************************************************
 
+import gzip
 from hashlib import md5
 import json
 from typing import Any, Callable, Iterator, Optional
@@ -34,6 +35,7 @@ LOGGER = logging.getLogger("gcovr")
 
 REGEX_VERSION_POSTFIX = re.compile(r"(.+?)(?:\.post\d+)?\.dev.+$")
 PRETTY_JSON_INDENT = 4
+GZIP_SUFFIX = ".gz"
 
 
 class LoopChecker:
@@ -211,8 +213,12 @@ def open_text_for_writing(
         filename += default_filename
 
     if filename is not None and filename != "-":
-        with open(filename, "w", **kwargs) as fh_out:  # pylint: disable=unspecified-encoding
-            yield fh_out
+        if filename.endswith(".gz"):
+            with gzip.open(filename, "wt", **kwargs) as fh_out:
+                yield fh_out
+        else:
+            with open(filename, "wt", **kwargs) as fh_out:  # pylint: disable=unspecified-encoding
+                yield fh_out
     else:
         yield sys.stdout
 
@@ -231,9 +237,13 @@ def open_binary_for_writing(
         filename += default_filename
 
     if filename is not None and filename != "-":
-        # files in write binary mode for UTF-8
-        with open(filename, "wb", **kwargs) as fh_out:
-            yield fh_out
+        if filename.endswith(GZIP_SUFFIX):
+            with gzip.open(filename, "wb", **kwargs) as fh_out:
+                yield fh_out
+        else:
+            # files in write binary mode for UTF-8
+            with open(filename, "wb", **kwargs) as fh_out:
+                yield fh_out
     else:
         yield sys.stdout.buffer
 
@@ -246,7 +256,7 @@ def write_json_output(
     default_filename: str,
     **kwargs: Any,
 ) -> None:
-    """Helper function to output JSON format dictionary to a file/STDOUT"""
+    """Helper function to output JSON dictionary to a file/STDOUT."""
     with open_text_for_writing(filename, default_filename, **kwargs) as fh:
         json.dump(json_dict, fh, indent=PRETTY_JSON_INDENT if pretty else None)
 

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -15,6 +15,9 @@ coveralls*.json
 jacoco*.xml
 sonarqube*.xml
 
+# Zipped reports
+*.*.gz
+
 # CMake build directory
 build/
 

--- a/tests/decisions/Makefile
+++ b/tests/decisions/Makefile
@@ -5,18 +5,21 @@ all:
 
 run: html txt json json_summary
 
-coverage.json:
+coverage.json: coverage.json.gz
+	$(GCOVR) --keep --verbose --add-tracefile $< --json-pretty --json -o $@
+
+coverage.json.gz:
 	./testcase
-	$(GCOVR) --keep --verbose --decisions --json-pretty --json -o coverage.json
+	$(GCOVR) --keep --verbose --decisions --json-pretty --json -o $@
 
-json_summary: coverage.json
-	$(GCOVR) --keep --verbose -a coverage.json --decisions --json-summary-pretty -o summary_coverage.json
+json_summary: coverage.json.gz
+	$(GCOVR) --keep --verbose -a $< --decisions --json-summary-pretty -o summary_coverage.json
 
-html: coverage.json
-	$(GCOVR) --verbose -a coverage.json --decisions --html-details -o coverage.html
+html: coverage.json.gz
+	$(GCOVR) --verbose -a $< --decisions --html-details -o coverage.html
 
-txt: coverage.json
-	$(GCOVR) --verbose -a coverage.json --txt-metric decision --txt-summary -o coverage.txt > coverage_summary.txt
+txt: coverage.json.gz
+	$(GCOVR) --verbose -a $< --txt-metric decision --txt-summary -o coverage.txt > coverage_summary.txt
 
 json: coverage.json
 	# pass

--- a/tests/html-single-page/Makefile
+++ b/tests/html-single-page/Makefile
@@ -18,10 +18,12 @@ coverage.json:
 	$(GCOVR) -r subdir --json-pretty --json $@
 
 html: coverage.json
-	$(GCOVR) -r subdir --filter subdir/A -a $< --verbose --html-details ./                                --html-single-page static --no-html-self-contained
-	$(GCOVR) -r subdir --filter subdir/A -a $< --verbose --html-details ./coverage_single_page-js.html    --html-single-page        --no-html-self-contained
-	$(GCOVR) -r subdir --filter subdir/A -a $< --verbose --html-nested  ./coverage_single_page-gh.html    --html-single-page static --html-theme github.blue
-	$(GCOVR) -r subdir --filter subdir/A -a $< --verbose --html-nested  ./coverage_single_page-gh-js.html --html-single-page        --html-theme github.blue
+	$(GCOVR) -r subdir --filter subdir/A -a $< --verbose --html-details ./                                   --html-single-page static --no-html-self-contained
+	$(GCOVR) -r subdir --filter subdir/A -a $< --verbose --html-details ./coverage_single_page-js.html       --html-single-page        --no-html-self-contained
+	$(GCOVR) -r subdir --filter subdir/A -a $< --verbose --html-nested  ./coverage_single_page-gh.html.gz    --html-single-page static --html-theme github.blue
+	gunzip -c ./coverage_single_page-gh.html.gz > ./coverage_single_page-gh.html
+	$(GCOVR) -r subdir --filter subdir/A -a $< --verbose --html-nested  ./coverage_single_page-gh-js.html.gz --html-single-page        --html-theme github.blue
+	gunzip -c ./coverage_single_page-gh-js.html.gz > ./coverage_single_page-gh-js.html
 
 clean:
 	rm -rf ./subdir

--- a/tests/virtual-classes/Makefile
+++ b/tests/virtual-classes/Makefile
@@ -7,15 +7,18 @@ run: txt clover cobertura html sonarqube jacoco json json_summary coveralls
 
 txt:
 	./testcase
-	$(GCOVR) -d --txt coverage.txt
+	$(GCOVR) -d --txt coverage.txt.gz
+	gunzip -c coverage.txt.gz > coverage.txt
 
 clover:
 	./testcase
-	$(GCOVR) -d --clover-pretty --clover clover.xml
+	$(GCOVR) -d --clover-pretty --clover clover.xml.gz
+	gunzip -c clover.xml.gz > clover.xml
 
 cobertura:
 	./testcase
-	$(GCOVR) -d --cobertura-pretty --cobertura cobertura.xml
+	$(GCOVR) -d --cobertura-pretty --cobertura cobertura.xml.gz
+	gunzip -c cobertura.xml.gz > cobertura.xml
 
 html:
 	./testcase
@@ -23,23 +26,28 @@ html:
 
 sonarqube:
 	./testcase
-	$(GCOVR) -d --sonarqube sonarqube.xml
+	$(GCOVR) -d --sonarqube sonarqube.xml.gz
+	gunzip -c sonarqube.xml.gz > sonarqube.xml
 
 jacoco:
 	./testcase
-	$(GCOVR) -d --jacoco-pretty --jacoco jacoco.xml
+	$(GCOVR) -d --jacoco-pretty --jacoco jacoco.xml.gz
+	gunzip -c jacoco.xml.gz > jacoco.xml
 
 json_summary:
 	./testcase
-	$(GCOVR) -d --json-summary-pretty -o summary_coverage.json
+	$(GCOVR) -d --json-summary-pretty -o summary_coverage.json.gz
+	gunzip -c summary_coverage.json.gz > summary_coverage.json
 
 json:
 	./testcase
-	$(GCOVR) --gcov-keep -d --json-pretty --json coverage.json
+	$(GCOVR) --gcov-keep -d --json-pretty --json coverage.json.gz
+	gunzip -c coverage.json.gz > coverage.json
 
 coveralls:
 	./testcase
-	$(GCOVR) -d --coveralls-pretty --coveralls coveralls.json
+	$(GCOVR) -d --coveralls-pretty --coveralls coveralls.json.gz
+	gunzip -c coveralls.json.gz > coveralls.json
 
 clean:
 	rm -f testcase


### PR DESCRIPTION
If the last suffix of the output is `.gz` it will be saved as zipped file.
The JSON report (trace file) used as input can also be a zipped file (`.json.'gz).