### PR TITLE
Extend option `-j` to support "all but N CPUs"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,7 @@ New features and notable changes:
   more than once. (:issue:`1129`)
 - Add :option:`--sonarqube-metric` to define which metric is used as branch metric in report. (:issue:`1132`)
 - Add :option:`--sonarqube-pretty` to pretty print the report. (:issue:`1136`)
+- If the value for :option:`-j` is 0, the number of CPUs is used. If it is negative the it means "all but N CPUs". (:issue:`1148`)
 
 Bug fixes and small improvements:
 

--- a/src/gcovr/formats/gcov/__init__.py
+++ b/src/gcovr/formats/gcov/__init__.py
@@ -17,7 +17,6 @@
 #
 # ****************************************************************************
 
-from multiprocessing import cpu_count
 import os
 from typing import Union
 
@@ -212,9 +211,12 @@ class GcovHandler(BaseHandler):
                 ["-j"],
                 config="gcov-parallel",
                 group="gcov_options",
-                help="Set the number of threads to use in parallel.",
+                help=(
+                    "Set the number of threads to use in parallel. "
+                    "0=Number of CPUs, negative number='all but N CPUs'."
+                ),
                 nargs="?",
-                const=cpu_count(),
+                const=0,
                 type=int,
                 default=1,
             ),

--- a/src/gcovr/logging.py
+++ b/src/gcovr/logging.py
@@ -38,7 +38,7 @@ def __colored_formatter(options: Optional[Options] = None) -> ColoredFormatter:
     """Configure the colored logging formatter."""
     if options is not None:
         log_format = (
-            COLOR_LOG_FORMAT_THREADS if options.gcov_parallel > 1 else COLOR_LOG_FORMAT
+            COLOR_LOG_FORMAT_THREADS if options.gcov_parallel != 1 else COLOR_LOG_FORMAT
         )
         force_color = getattr(options, "force_color", False)
         no_color = getattr(options, "no_color", False)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -329,7 +329,7 @@ class Ref:
     This is useful to represent the presence of a value that may be None.
     """
 
-    def __init__(self, value: Union[str, list[str]]) -> None:
+    def __init__(self, value: Union[Optional[str], list[str]]) -> None:
         self.value = value
 
 


### PR DESCRIPTION
If the value for `-j` is 0, the number of CPUs is used. If it is negative the it means "all but N CPUs".
E.g. if we have 8 CPUs and set the value to -1 we use 7 processes.

Related #1145