### PR TITLE
Do not allow spaces in LCOV test name.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ Next Release
 
 Breaking changes:
 
+- The option :option:`--lcov-test-name` doesn't accept values with spaces anymore. (:issue:`1196`)
+
 New features and notable changes:
 
 - Due to added support for LLVM source based code coverage format some configuration file

--- a/src/gcovr/formats/lcov/__init__.py
+++ b/src/gcovr/formats/lcov/__init__.py
@@ -63,10 +63,22 @@ class LcovHandler(BaseHandler):
                 ["--lcov-test-name"],
                 group="output_options",
                 metavar="NAME",
-                help="The name used for TN in LCOV file. Default is '{default!s}'.",
-                default="GCOVR report",
+                help=(
+                    "The name used for TN in LCOV file, must not contain spaces. "
+                    "Default is '{default!s}'."
+                ),
+                default="GCOVR_report",
             ),
         ]
+
+    def validate_options(self) -> None:
+        if (
+            self.options.lcov_test_name is not None
+            and " " in self.options.lcov_test_name
+        ):
+            raise RuntimeError(
+                f"The LCOV test name must not contain spaces, got {self.options.lcov_test_name!r}."
+            )
 
     def write_report(self, covdata: CoverageContainer, output_file: str) -> None:
         from .write import write_report  # pylint: disable=import-outside-toplevel # Lazy loading is intended here

--- a/tests/const-functions/reference/clang-10/coverage.lcov
+++ b/tests/const-functions/reference/clang-10/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/const-functions/output/main.cpp
 VER:549f71f95b884f32c503c48f22ced191
 FN:6,_ZN3BarC2Ev

--- a/tests/const-functions/reference/clang-12/coverage.lcov
+++ b/tests/const-functions/reference/clang-12/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/const-functions/output/main.cpp
 VER:549f71f95b884f32c503c48f22ced191
 FN:6,Bar::Bar()

--- a/tests/const-functions/reference/clang-15-Darwin/coverage.lcov
+++ b/tests/const-functions/reference/clang-15-Darwin/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/const-functions/output/main.cpp
 VER:549f71f95b884f32c503c48f22ced191
 FN:6,Bar::Bar()

--- a/tests/const-functions/reference/clang-17-Darwin/coverage.lcov
+++ b/tests/const-functions/reference/clang-17-Darwin/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/const-functions/output/main.cpp
 VER:549f71f95b884f32c503c48f22ced191
 FN:6,Bar::Bar()

--- a/tests/const-functions/reference/gcc-11/coverage.lcov
+++ b/tests/const-functions/reference/gcc-11/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/const-functions/output/main.cpp
 VER:549f71f95b884f32c503c48f22ced191
 FN:6,Bar::Bar()

--- a/tests/const-functions/reference/gcc-14/coverage.lcov
+++ b/tests/const-functions/reference/gcc-14/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/const-functions/output/main.cpp
 VER:549f71f95b884f32c503c48f22ced191
 FN:6,Bar::Bar()

--- a/tests/const-functions/reference/gcc-5/coverage.lcov
+++ b/tests/const-functions/reference/gcc-5/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/const-functions/output/main.cpp
 VER:549f71f95b884f32c503c48f22ced191
 FN:6,Bar::Bar()

--- a/tests/const-functions/reference/gcc-6/coverage.lcov
+++ b/tests/const-functions/reference/gcc-6/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/const-functions/output/main.cpp
 VER:549f71f95b884f32c503c48f22ced191
 FN:6,Bar::Bar()

--- a/tests/const-functions/reference/gcc-8/coverage.lcov
+++ b/tests/const-functions/reference/gcc-8/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/const-functions/output/main.cpp
 VER:549f71f95b884f32c503c48f22ced191
 FN:6,Bar::Bar()

--- a/tests/dot-folder/reference/clang-10/coverage.lcov
+++ b/tests/dot-folder/reference/clang-10/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/dot-folder/output/.subdir/A/C/D/File6.cpp
 VER:51c81752202f160b25ffc07fb9134018
 FN:1,_Z4foo6i

--- a/tests/dot-folder/reference/clang-12/coverage.lcov
+++ b/tests/dot-folder/reference/clang-12/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/dot-folder/output/.subdir/A/C/D/File6.cpp
 VER:51c81752202f160b25ffc07fb9134018
 FN:1,foo6(int)

--- a/tests/dot-folder/reference/clang-17-Darwin/coverage.lcov
+++ b/tests/dot-folder/reference/clang-17-Darwin/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/dot-folder/output/.subdir/A/C/D/File6.cpp
 VER:51c81752202f160b25ffc07fb9134018
 FN:1,foo6(int)

--- a/tests/dot-folder/reference/clang-18/coverage.lcov
+++ b/tests/dot-folder/reference/clang-18/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/dot-folder/output/.subdir/A/C/D/File6.cpp
 VER:51c81752202f160b25ffc07fb9134018
 FN:1,foo6(int)

--- a/tests/dot-folder/reference/gcc-14/coverage.lcov
+++ b/tests/dot-folder/reference/gcc-14/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/dot-folder/output/.subdir/A/C/D/File6.cpp
 VER:51c81752202f160b25ffc07fb9134018
 FN:1,foo6(int)

--- a/tests/dot-folder/reference/gcc-5/coverage.lcov
+++ b/tests/dot-folder/reference/gcc-5/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/dot-folder/output/.subdir/A/C/D/File6.cpp
 VER:51c81752202f160b25ffc07fb9134018
 FN:1,foo6(int)

--- a/tests/exclusion/reference/exclude-branch-source/clang-10/coverage.lcov
+++ b/tests/exclusion/reference/exclude-branch-source/clang-10/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-branch-source/main.cpp
 VER:f772f69ebe297a2ae71c7ac233d77007
 FN:3,_Z3fooi

--- a/tests/exclusion/reference/exclude-branch-source/clang-11/coverage.lcov
+++ b/tests/exclusion/reference/exclude-branch-source/clang-11/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-branch-source/main.cpp
 VER:f772f69ebe297a2ae71c7ac233d77007
 FN:3,_Z3fooi

--- a/tests/exclusion/reference/exclude-branch-source/clang-12/coverage.lcov
+++ b/tests/exclusion/reference/exclude-branch-source/clang-12/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-branch-source/main.cpp
 VER:f772f69ebe297a2ae71c7ac233d77007
 FN:3,foo(int)

--- a/tests/exclusion/reference/exclude-branch-source/clang-18/coverage.lcov
+++ b/tests/exclusion/reference/exclude-branch-source/clang-18/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-branch-source/main.cpp
 VER:f772f69ebe297a2ae71c7ac233d77007
 FN:3,foo(int)

--- a/tests/exclusion/reference/exclude-branch-source/gcc-14/coverage.lcov
+++ b/tests/exclusion/reference/exclude-branch-source/gcc-14/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-branch-source/main.cpp
 VER:f772f69ebe297a2ae71c7ac233d77007
 FN:3,foo(int)

--- a/tests/exclusion/reference/exclude-branch-source/gcc-5/coverage.lcov
+++ b/tests/exclusion/reference/exclude-branch-source/gcc-5/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-branch-source/main.cpp
 VER:f772f69ebe297a2ae71c7ac233d77007
 FN:3,foo(int)

--- a/tests/exclusion/reference/exclude-branch-source/gcc-7/coverage.lcov
+++ b/tests/exclusion/reference/exclude-branch-source/gcc-7/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-branch-source/main.cpp
 VER:f772f69ebe297a2ae71c7ac233d77007
 FN:3,foo(int)

--- a/tests/exclusion/reference/exclude-branch-without-hit/clang-10/coverage.lcov
+++ b/tests/exclusion/reference/exclude-branch-without-hit/clang-10/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-branch-without-hit/main.cpp
 VER:06a1ee25a1f3006863b6ccc5c0cb0575
 FN:3,_Z3fooi

--- a/tests/exclusion/reference/exclude-branch-without-hit/clang-11/coverage.lcov
+++ b/tests/exclusion/reference/exclude-branch-without-hit/clang-11/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-branch-without-hit/main.cpp
 VER:06a1ee25a1f3006863b6ccc5c0cb0575
 FN:3,_Z3fooi

--- a/tests/exclusion/reference/exclude-branch-without-hit/clang-12/coverage.lcov
+++ b/tests/exclusion/reference/exclude-branch-without-hit/clang-12/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-branch-without-hit/main.cpp
 VER:06a1ee25a1f3006863b6ccc5c0cb0575
 FN:3,foo(int)

--- a/tests/exclusion/reference/exclude-branch-without-hit/clang-17-Darwin/coverage.lcov
+++ b/tests/exclusion/reference/exclude-branch-without-hit/clang-17-Darwin/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-branch-without-hit/main.cpp
 VER:06a1ee25a1f3006863b6ccc5c0cb0575
 FN:3,foo(int)

--- a/tests/exclusion/reference/exclude-branch-without-hit/clang-18/coverage.lcov
+++ b/tests/exclusion/reference/exclude-branch-without-hit/clang-18/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-branch-without-hit/main.cpp
 VER:06a1ee25a1f3006863b6ccc5c0cb0575
 FN:3,foo(int)

--- a/tests/exclusion/reference/exclude-branch-without-hit/gcc-14/coverage.lcov
+++ b/tests/exclusion/reference/exclude-branch-without-hit/gcc-14/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-branch-without-hit/main.cpp
 VER:06a1ee25a1f3006863b6ccc5c0cb0575
 FN:3,foo(int)

--- a/tests/exclusion/reference/exclude-branch-without-hit/gcc-5/coverage.lcov
+++ b/tests/exclusion/reference/exclude-branch-without-hit/gcc-5/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-branch-without-hit/main.cpp
 VER:06a1ee25a1f3006863b6ccc5c0cb0575
 FN:3,foo(int)

--- a/tests/exclusion/reference/exclude-branch-without-hit/gcc-7/coverage.lcov
+++ b/tests/exclusion/reference/exclude-branch-without-hit/gcc-7/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-branch-without-hit/main.cpp
 VER:06a1ee25a1f3006863b6ccc5c0cb0575
 FN:3,foo(int)

--- a/tests/exclusion/reference/exclude-branch/clang-10/coverage.lcov
+++ b/tests/exclusion/reference/exclude-branch/clang-10/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-branch/main.cpp
 VER:6d3285119b8ab4620218bf24baa23923
 FN:4,_Z3fooi

--- a/tests/exclusion/reference/exclude-branch/clang-12/coverage.lcov
+++ b/tests/exclusion/reference/exclude-branch/clang-12/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-branch/main.cpp
 VER:6d3285119b8ab4620218bf24baa23923
 FN:4,foo(int)

--- a/tests/exclusion/reference/exclude-branch/clang-18/coverage.lcov
+++ b/tests/exclusion/reference/exclude-branch/clang-18/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-branch/main.cpp
 VER:6d3285119b8ab4620218bf24baa23923
 FN:4,foo(int)

--- a/tests/exclusion/reference/exclude-branch/gcc-14/coverage.lcov
+++ b/tests/exclusion/reference/exclude-branch/gcc-14/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-branch/main.cpp
 VER:6d3285119b8ab4620218bf24baa23923
 FN:4,foo(int)

--- a/tests/exclusion/reference/exclude-branch/gcc-5/coverage.lcov
+++ b/tests/exclusion/reference/exclude-branch/gcc-5/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-branch/main.cpp
 VER:6d3285119b8ab4620218bf24baa23923
 FN:4,foo(int)

--- a/tests/exclusion/reference/exclude-directories-relative/clang-10/coverage.lcov
+++ b/tests/exclusion/reference/exclude-directories-relative/clang-10/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-directories-relative/b/main.cpp
 VER:aa3e0bff9ee1c3840efb1be8065bab01
 FN:5,_Z3fooi

--- a/tests/exclusion/reference/exclude-directories-relative/clang-12/coverage.lcov
+++ b/tests/exclusion/reference/exclude-directories-relative/clang-12/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-directories-relative/b/main.cpp
 VER:aa3e0bff9ee1c3840efb1be8065bab01
 FN:5,foo(int)

--- a/tests/exclusion/reference/exclude-directories-relative/gcc-14/coverage.lcov
+++ b/tests/exclusion/reference/exclude-directories-relative/gcc-14/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-directories-relative/b/main.cpp
 VER:aa3e0bff9ee1c3840efb1be8065bab01
 FN:5,foo(int)

--- a/tests/exclusion/reference/exclude-directories-relative/gcc-5/coverage.lcov
+++ b/tests/exclusion/reference/exclude-directories-relative/gcc-5/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-directories-relative/b/main.cpp
 VER:aa3e0bff9ee1c3840efb1be8065bab01
 FN:5,foo(int)

--- a/tests/exclusion/reference/exclude-line-branch/clang-10/coverage.lcov
+++ b/tests/exclusion/reference/exclude-line-branch/clang-10/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-line-branch/bar.cpp
 VER:7c2adb8c2d04277ae316f0bc581968cc
 FN:14,_Z3bari

--- a/tests/exclusion/reference/exclude-line-branch/clang-11/coverage.lcov
+++ b/tests/exclusion/reference/exclude-line-branch/clang-11/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-line-branch/bar.cpp
 VER:7c2adb8c2d04277ae316f0bc581968cc
 FN:14,_Z3bari

--- a/tests/exclusion/reference/exclude-line-branch/clang-12/coverage.lcov
+++ b/tests/exclusion/reference/exclude-line-branch/clang-12/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-line-branch/bar.cpp
 VER:7c2adb8c2d04277ae316f0bc581968cc
 FN:14,bar(int)

--- a/tests/exclusion/reference/exclude-line-branch/gcc-14/coverage.lcov
+++ b/tests/exclusion/reference/exclude-line-branch/gcc-14/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-line-branch/bar.cpp
 VER:7c2adb8c2d04277ae316f0bc581968cc
 FN:14,bar(int)

--- a/tests/exclusion/reference/exclude-line-branch/gcc-5/coverage.lcov
+++ b/tests/exclusion/reference/exclude-line-branch/gcc-5/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-line-branch/bar.cpp
 VER:7c2adb8c2d04277ae316f0bc581968cc
 FN:14,bar(int)

--- a/tests/exclusion/reference/exclude-line-branch/gcc-6/coverage.lcov
+++ b/tests/exclusion/reference/exclude-line-branch/gcc-6/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-line-branch/bar.cpp
 VER:7c2adb8c2d04277ae316f0bc581968cc
 FN:14,bar(int)

--- a/tests/exclusion/reference/exclude-line-branch/gcc-8/coverage.lcov
+++ b/tests/exclusion/reference/exclude-line-branch/gcc-8/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-line-branch/bar.cpp
 VER:7c2adb8c2d04277ae316f0bc581968cc
 FN:14,bar(int)

--- a/tests/exclusion/reference/exclude-line-custom/clang-10/coverage.lcov
+++ b/tests/exclusion/reference/exclude-line-custom/clang-10/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-line-custom/main.cpp
 VER:946992153a16ca487416932e28191a83
 FN:4,_Z3fooi

--- a/tests/exclusion/reference/exclude-line-custom/clang-12/coverage.lcov
+++ b/tests/exclusion/reference/exclude-line-custom/clang-12/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-line-custom/main.cpp
 VER:946992153a16ca487416932e28191a83
 FN:4,foo(int)

--- a/tests/exclusion/reference/exclude-line-custom/gcc-14/coverage.lcov
+++ b/tests/exclusion/reference/exclude-line-custom/gcc-14/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-line-custom/main.cpp
 VER:946992153a16ca487416932e28191a83
 FN:4,foo(int)

--- a/tests/exclusion/reference/exclude-line-custom/gcc-5/coverage.lcov
+++ b/tests/exclusion/reference/exclude-line-custom/gcc-5/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-line-custom/main.cpp
 VER:946992153a16ca487416932e28191a83
 FN:4,foo(int)

--- a/tests/exclusion/reference/exclude-line/clang-10/coverage.lcov
+++ b/tests/exclusion/reference/exclude-line/clang-10/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-line/main.cpp
 VER:66aceb0a241f4b80949ca5f212bf166f
 FN:4,_Z3fooi

--- a/tests/exclusion/reference/exclude-line/clang-12/coverage.lcov
+++ b/tests/exclusion/reference/exclude-line/clang-12/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-line/main.cpp
 VER:66aceb0a241f4b80949ca5f212bf166f
 FN:4,foo(int)

--- a/tests/exclusion/reference/exclude-line/gcc-14/coverage.lcov
+++ b/tests/exclusion/reference/exclude-line/gcc-14/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-line/main.cpp
 VER:66aceb0a241f4b80949ca5f212bf166f
 FN:4,foo(int)

--- a/tests/exclusion/reference/exclude-line/gcc-5/coverage.lcov
+++ b/tests/exclusion/reference/exclude-line/gcc-5/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-line/main.cpp
 VER:66aceb0a241f4b80949ca5f212bf166f
 FN:4,foo(int)

--- a/tests/exclusion/reference/exclude-lines-by-pattern/clang-10/coverage.lcov
+++ b/tests/exclusion/reference/exclude-lines-by-pattern/clang-10/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-lines-by-pattern/main.cpp
 VER:6bc26001ff07bea6b3466fcf1f18d4a5
 FN:5,_ZL5panicv

--- a/tests/exclusion/reference/exclude-lines-by-pattern/clang-12/coverage.lcov
+++ b/tests/exclusion/reference/exclude-lines-by-pattern/clang-12/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-lines-by-pattern/main.cpp
 VER:6bc26001ff07bea6b3466fcf1f18d4a5
 FN:5,panic()

--- a/tests/exclusion/reference/exclude-lines-by-pattern/gcc-14/coverage.lcov
+++ b/tests/exclusion/reference/exclude-lines-by-pattern/gcc-14/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-lines-by-pattern/main.cpp
 VER:6bc26001ff07bea6b3466fcf1f18d4a5
 FN:5,panic()

--- a/tests/exclusion/reference/exclude-lines-by-pattern/gcc-5/coverage.lcov
+++ b/tests/exclusion/reference/exclude-lines-by-pattern/gcc-5/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-lines-by-pattern/main.cpp
 VER:6bc26001ff07bea6b3466fcf1f18d4a5
 FN:5,panic()

--- a/tests/exclusion/reference/exclude-throw-branches/clang-10/coverage-exclude-throw.lcov
+++ b/tests/exclusion/reference/exclude-throw-branches/clang-10/coverage-exclude-throw.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-throw-branches/main.cpp
 VER:1a27c541bdd456d68b3ca671ff1cf419
 FN:3,_Z23function_that_may_throwb

--- a/tests/exclusion/reference/exclude-throw-branches/clang-10/coverage-throw.lcov
+++ b/tests/exclusion/reference/exclude-throw-branches/clang-10/coverage-throw.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-throw-branches/main.cpp
 VER:1a27c541bdd456d68b3ca671ff1cf419
 FN:3,_Z23function_that_may_throwb

--- a/tests/exclusion/reference/exclude-throw-branches/clang-11/coverage-exclude-throw.lcov
+++ b/tests/exclusion/reference/exclude-throw-branches/clang-11/coverage-exclude-throw.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-throw-branches/main.cpp
 VER:1a27c541bdd456d68b3ca671ff1cf419
 FN:3,_Z23function_that_may_throwb

--- a/tests/exclusion/reference/exclude-throw-branches/clang-11/coverage-throw.lcov
+++ b/tests/exclusion/reference/exclude-throw-branches/clang-11/coverage-throw.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-throw-branches/main.cpp
 VER:1a27c541bdd456d68b3ca671ff1cf419
 FN:3,_Z23function_that_may_throwb

--- a/tests/exclusion/reference/exclude-throw-branches/clang-12/coverage-exclude-throw.lcov
+++ b/tests/exclusion/reference/exclude-throw-branches/clang-12/coverage-exclude-throw.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-throw-branches/main.cpp
 VER:1a27c541bdd456d68b3ca671ff1cf419
 FN:3,function_that_may_throw(bool)

--- a/tests/exclusion/reference/exclude-throw-branches/clang-12/coverage-throw.lcov
+++ b/tests/exclusion/reference/exclude-throw-branches/clang-12/coverage-throw.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-throw-branches/main.cpp
 VER:1a27c541bdd456d68b3ca671ff1cf419
 FN:3,function_that_may_throw(bool)

--- a/tests/exclusion/reference/exclude-throw-branches/gcc-10/coverage-exclude-throw.lcov
+++ b/tests/exclusion/reference/exclude-throw-branches/gcc-10/coverage-exclude-throw.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-throw-branches/main.cpp
 VER:1a27c541bdd456d68b3ca671ff1cf419
 FN:3,function_that_may_throw(bool)

--- a/tests/exclusion/reference/exclude-throw-branches/gcc-10/coverage-throw.lcov
+++ b/tests/exclusion/reference/exclude-throw-branches/gcc-10/coverage-throw.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-throw-branches/main.cpp
 VER:1a27c541bdd456d68b3ca671ff1cf419
 FN:3,function_that_may_throw(bool)

--- a/tests/exclusion/reference/exclude-throw-branches/gcc-11/coverage-exclude-throw.lcov
+++ b/tests/exclusion/reference/exclude-throw-branches/gcc-11/coverage-exclude-throw.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-throw-branches/main.cpp
 VER:1a27c541bdd456d68b3ca671ff1cf419
 FN:3,function_that_may_throw(bool)

--- a/tests/exclusion/reference/exclude-throw-branches/gcc-11/coverage-throw.lcov
+++ b/tests/exclusion/reference/exclude-throw-branches/gcc-11/coverage-throw.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-throw-branches/main.cpp
 VER:1a27c541bdd456d68b3ca671ff1cf419
 FN:3,function_that_may_throw(bool)

--- a/tests/exclusion/reference/exclude-throw-branches/gcc-14/coverage-exclude-throw.lcov
+++ b/tests/exclusion/reference/exclude-throw-branches/gcc-14/coverage-exclude-throw.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-throw-branches/main.cpp
 VER:1a27c541bdd456d68b3ca671ff1cf419
 FN:3,function_that_may_throw(bool)

--- a/tests/exclusion/reference/exclude-throw-branches/gcc-14/coverage-throw.lcov
+++ b/tests/exclusion/reference/exclude-throw-branches/gcc-14/coverage-throw.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-throw-branches/main.cpp
 VER:1a27c541bdd456d68b3ca671ff1cf419
 FN:3,function_that_may_throw(bool)

--- a/tests/exclusion/reference/exclude-throw-branches/gcc-5/coverage-exclude-throw.lcov
+++ b/tests/exclusion/reference/exclude-throw-branches/gcc-5/coverage-exclude-throw.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-throw-branches/main.cpp
 VER:1a27c541bdd456d68b3ca671ff1cf419
 FN:3,function_that_may_throw(bool)

--- a/tests/exclusion/reference/exclude-throw-branches/gcc-5/coverage-throw.lcov
+++ b/tests/exclusion/reference/exclude-throw-branches/gcc-5/coverage-throw.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-throw-branches/main.cpp
 VER:1a27c541bdd456d68b3ca671ff1cf419
 FN:3,function_that_may_throw(bool)

--- a/tests/exclusion/reference/exclude-throw-branches/gcc-6/coverage-exclude-throw.lcov
+++ b/tests/exclusion/reference/exclude-throw-branches/gcc-6/coverage-exclude-throw.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-throw-branches/main.cpp
 VER:1a27c541bdd456d68b3ca671ff1cf419
 FN:3,function_that_may_throw(bool)

--- a/tests/exclusion/reference/exclude-throw-branches/gcc-6/coverage-throw.lcov
+++ b/tests/exclusion/reference/exclude-throw-branches/gcc-6/coverage-throw.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-throw-branches/main.cpp
 VER:1a27c541bdd456d68b3ca671ff1cf419
 FN:3,function_that_may_throw(bool)

--- a/tests/exclusion/reference/exclude-throw-branches/gcc-8/coverage-exclude-throw.lcov
+++ b/tests/exclusion/reference/exclude-throw-branches/gcc-8/coverage-exclude-throw.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-throw-branches/main.cpp
 VER:1a27c541bdd456d68b3ca671ff1cf419
 FN:3,function_that_may_throw(bool)

--- a/tests/exclusion/reference/exclude-throw-branches/gcc-8/coverage-throw.lcov
+++ b/tests/exclusion/reference/exclude-throw-branches/gcc-8/coverage-throw.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/exclusion/output/exclude-throw-branches/main.cpp
 VER:1a27c541bdd456d68b3ca671ff1cf419
 FN:3,function_that_may_throw(bool)

--- a/tests/filter/reference/absolute-from-unfiltered-tracefile/clang-10/coverage.lcov
+++ b/tests/filter/reference/absolute-from-unfiltered-tracefile/clang-10/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/filter/output/absolute-from-unfiltered-tracefile/main.cpp
 VER:aa3e0bff9ee1c3840efb1be8065bab01
 FN:5,_Z3fooi

--- a/tests/filter/reference/absolute-from-unfiltered-tracefile/clang-12/coverage.lcov
+++ b/tests/filter/reference/absolute-from-unfiltered-tracefile/clang-12/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/filter/output/absolute-from-unfiltered-tracefile/main.cpp
 VER:aa3e0bff9ee1c3840efb1be8065bab01
 FN:5,foo(int)

--- a/tests/filter/reference/absolute-from-unfiltered-tracefile/gcc-14/coverage.lcov
+++ b/tests/filter/reference/absolute-from-unfiltered-tracefile/gcc-14/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/filter/output/absolute-from-unfiltered-tracefile/main.cpp
 VER:aa3e0bff9ee1c3840efb1be8065bab01
 FN:5,foo(int)

--- a/tests/filter/reference/absolute-from-unfiltered-tracefile/gcc-5/coverage.lcov
+++ b/tests/filter/reference/absolute-from-unfiltered-tracefile/gcc-5/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/filter/output/absolute-from-unfiltered-tracefile/main.cpp
 VER:aa3e0bff9ee1c3840efb1be8065bab01
 FN:5,foo(int)

--- a/tests/filter/reference/absolute/clang-10/coverage.lcov
+++ b/tests/filter/reference/absolute/clang-10/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/filter/output/absolute/main.cpp
 VER:aa3e0bff9ee1c3840efb1be8065bab01
 FN:5,_Z3fooi

--- a/tests/filter/reference/absolute/clang-12/coverage.lcov
+++ b/tests/filter/reference/absolute/clang-12/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/filter/output/absolute/main.cpp
 VER:aa3e0bff9ee1c3840efb1be8065bab01
 FN:5,foo(int)

--- a/tests/filter/reference/absolute/gcc-14/coverage.lcov
+++ b/tests/filter/reference/absolute/gcc-14/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/filter/output/absolute/main.cpp
 VER:aa3e0bff9ee1c3840efb1be8065bab01
 FN:5,foo(int)

--- a/tests/filter/reference/absolute/gcc-5/coverage.lcov
+++ b/tests/filter/reference/absolute/gcc-5/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/filter/output/absolute/main.cpp
 VER:aa3e0bff9ee1c3840efb1be8065bab01
 FN:5,foo(int)

--- a/tests/filter/reference/relative-from-unfiltered-tracefile/clang-10/coverage.lcov
+++ b/tests/filter/reference/relative-from-unfiltered-tracefile/clang-10/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/filter/output/relative-from-unfiltered-tracefile/main.cpp
 VER:aa3e0bff9ee1c3840efb1be8065bab01
 FN:5,_Z3fooi

--- a/tests/filter/reference/relative-from-unfiltered-tracefile/clang-12/coverage.lcov
+++ b/tests/filter/reference/relative-from-unfiltered-tracefile/clang-12/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/filter/output/relative-from-unfiltered-tracefile/main.cpp
 VER:aa3e0bff9ee1c3840efb1be8065bab01
 FN:5,foo(int)

--- a/tests/filter/reference/relative-from-unfiltered-tracefile/gcc-14/coverage.lcov
+++ b/tests/filter/reference/relative-from-unfiltered-tracefile/gcc-14/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/filter/output/relative-from-unfiltered-tracefile/main.cpp
 VER:aa3e0bff9ee1c3840efb1be8065bab01
 FN:5,foo(int)

--- a/tests/filter/reference/relative-from-unfiltered-tracefile/gcc-5/coverage.lcov
+++ b/tests/filter/reference/relative-from-unfiltered-tracefile/gcc-5/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/filter/output/relative-from-unfiltered-tracefile/main.cpp
 VER:aa3e0bff9ee1c3840efb1be8065bab01
 FN:5,foo(int)

--- a/tests/filter/reference/relative-lib-from-unfiltered-tracefile/clang-10/coverage.lcov
+++ b/tests/filter/reference/relative-lib-from-unfiltered-tracefile/clang-10/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/filter/output/relative-lib-from-unfiltered-tracefile/project/relevant-library/src/yes.cpp
 VER:62521d726248e71c9a4b8d0a8c62ef43
 FN:1,_Z3yesi

--- a/tests/filter/reference/relative-lib-from-unfiltered-tracefile/clang-12/coverage.lcov
+++ b/tests/filter/reference/relative-lib-from-unfiltered-tracefile/clang-12/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/filter/output/relative-lib-from-unfiltered-tracefile/project/relevant-library/src/yes.cpp
 VER:62521d726248e71c9a4b8d0a8c62ef43
 FN:1,yes(int)

--- a/tests/filter/reference/relative-lib-from-unfiltered-tracefile/gcc-5/coverage.lcov
+++ b/tests/filter/reference/relative-lib-from-unfiltered-tracefile/gcc-5/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/filter/output/relative-lib-from-unfiltered-tracefile/project/relevant-library/src/yes.cpp
 VER:62521d726248e71c9a4b8d0a8c62ef43
 FN:1,yes(int)

--- a/tests/filter/reference/relative-lib/clang-10/coverage.lcov
+++ b/tests/filter/reference/relative-lib/clang-10/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/filter/output/relative-lib/project/relevant-library/src/yes.cpp
 VER:62521d726248e71c9a4b8d0a8c62ef43
 FN:1,_Z3yesi

--- a/tests/filter/reference/relative-lib/clang-12/coverage.lcov
+++ b/tests/filter/reference/relative-lib/clang-12/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/filter/output/relative-lib/project/relevant-library/src/yes.cpp
 VER:62521d726248e71c9a4b8d0a8c62ef43
 FN:1,yes(int)

--- a/tests/filter/reference/relative-lib/gcc-14/coverage.lcov
+++ b/tests/filter/reference/relative-lib/gcc-14/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/filter/output/relative-lib/project/relevant-library/src/yes.cpp
 VER:62521d726248e71c9a4b8d0a8c62ef43
 FN:1,yes(int)

--- a/tests/filter/reference/relative-lib/gcc-5/coverage.lcov
+++ b/tests/filter/reference/relative-lib/gcc-5/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/filter/output/relative-lib/project/relevant-library/src/yes.cpp
 VER:62521d726248e71c9a4b8d0a8c62ef43
 FN:1,yes(int)

--- a/tests/filter/reference/relative/clang-10/coverage.lcov
+++ b/tests/filter/reference/relative/clang-10/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/filter/output/relative/main.cpp
 VER:aa3e0bff9ee1c3840efb1be8065bab01
 FN:5,_Z3fooi

--- a/tests/filter/reference/relative/clang-12/coverage.lcov
+++ b/tests/filter/reference/relative/clang-12/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/filter/output/relative/main.cpp
 VER:aa3e0bff9ee1c3840efb1be8065bab01
 FN:5,foo(int)

--- a/tests/filter/reference/relative/gcc-14/coverage.lcov
+++ b/tests/filter/reference/relative/gcc-14/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/filter/output/relative/main.cpp
 VER:aa3e0bff9ee1c3840efb1be8065bab01
 FN:5,foo(int)

--- a/tests/filter/reference/relative/gcc-5/coverage.lcov
+++ b/tests/filter/reference/relative/gcc-5/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/filter/output/relative/main.cpp
 VER:aa3e0bff9ee1c3840efb1be8065bab01
 FN:5,foo(int)

--- a/tests/lcov/test_lcov.py
+++ b/tests/lcov/test_lcov.py
@@ -1,0 +1,25 @@
+import logging
+import typing
+
+import pytest
+
+
+if typing.TYPE_CHECKING:
+    from tests.conftest import GcovrTestExec
+
+
+def test_report_name_with_spaces(
+    gcovr_test_exec: "GcovrTestExec", caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test error if report name contains spaces."""
+    process = gcovr_test_exec.gcovr(
+        "--lcov-test-name", "Name with spaces", use_main=True
+    )
+    assert process.returncode == 1
+    messages = caplog.record_tuples
+    assert len(messages) == 1
+    assert messages[0][1] == logging.ERROR
+    assert (
+        messages[0][2]
+        == "The LCOV test name must not contain spaces, got 'Name with spaces'."
+    )

--- a/tests/merging/reference/different-functions-merge-use-line-0/clang-10/coverage.lcov
+++ b/tests/merging/reference/different-functions-merge-use-line-0/clang-10/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/merging/output/different-functions-merge-use-line-0/func.h
 VER:038c9fe6d002775301b38c63c7aa5e6c
 FN:0,_Z3fooi

--- a/tests/merging/reference/different-functions-merge-use-line-0/clang-12/coverage.lcov
+++ b/tests/merging/reference/different-functions-merge-use-line-0/clang-12/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/merging/output/different-functions-merge-use-line-0/func.h
 VER:038c9fe6d002775301b38c63c7aa5e6c
 FN:0,foo(int)

--- a/tests/merging/reference/different-functions-merge-use-line-0/gcc-14/coverage.lcov
+++ b/tests/merging/reference/different-functions-merge-use-line-0/gcc-14/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/merging/output/different-functions-merge-use-line-0/func.h
 VER:038c9fe6d002775301b38c63c7aa5e6c
 FN:0,foo(int)

--- a/tests/merging/reference/different-functions-merge-use-line-0/gcc-5/coverage.lcov
+++ b/tests/merging/reference/different-functions-merge-use-line-0/gcc-5/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/merging/output/different-functions-merge-use-line-0/func.h
 VER:038c9fe6d002775301b38c63c7aa5e6c
 FN:0,foo(int)

--- a/tests/merging/reference/different-functions-merge-use-line-max/clang-10/coverage.lcov
+++ b/tests/merging/reference/different-functions-merge-use-line-max/clang-10/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/merging/output/different-functions-merge-use-line-max/func.h
 VER:038c9fe6d002775301b38c63c7aa5e6c
 FN:5,_Z3fooi

--- a/tests/merging/reference/different-functions-merge-use-line-max/clang-12/coverage.lcov
+++ b/tests/merging/reference/different-functions-merge-use-line-max/clang-12/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/merging/output/different-functions-merge-use-line-max/func.h
 VER:038c9fe6d002775301b38c63c7aa5e6c
 FN:5,foo(int)

--- a/tests/merging/reference/different-functions-merge-use-line-max/gcc-14/coverage.lcov
+++ b/tests/merging/reference/different-functions-merge-use-line-max/gcc-14/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/merging/output/different-functions-merge-use-line-max/func.h
 VER:038c9fe6d002775301b38c63c7aa5e6c
 FN:5,foo(int)

--- a/tests/merging/reference/different-functions-merge-use-line-max/gcc-5/coverage.lcov
+++ b/tests/merging/reference/different-functions-merge-use-line-max/gcc-5/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/merging/output/different-functions-merge-use-line-max/func.h
 VER:038c9fe6d002775301b38c63c7aa5e6c
 FN:5,foo(int)

--- a/tests/merging/reference/different-functions-merge-use-line-min/clang-10/coverage.lcov
+++ b/tests/merging/reference/different-functions-merge-use-line-min/clang-10/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/merging/output/different-functions-merge-use-line-min/func.h
 VER:038c9fe6d002775301b38c63c7aa5e6c
 FN:3,_Z3fooi

--- a/tests/merging/reference/different-functions-merge-use-line-min/clang-12/coverage.lcov
+++ b/tests/merging/reference/different-functions-merge-use-line-min/clang-12/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/merging/output/different-functions-merge-use-line-min/func.h
 VER:038c9fe6d002775301b38c63c7aa5e6c
 FN:3,foo(int)

--- a/tests/merging/reference/different-functions-merge-use-line-min/gcc-14/coverage.lcov
+++ b/tests/merging/reference/different-functions-merge-use-line-min/gcc-14/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/merging/output/different-functions-merge-use-line-min/func.h
 VER:038c9fe6d002775301b38c63c7aa5e6c
 FN:3,foo(int)

--- a/tests/merging/reference/different-functions-merge-use-line-min/gcc-5/coverage.lcov
+++ b/tests/merging/reference/different-functions-merge-use-line-min/gcc-5/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/merging/output/different-functions-merge-use-line-min/func.h
 VER:038c9fe6d002775301b38c63c7aa5e6c
 FN:3,foo(int)

--- a/tests/merging/reference/different-functions-separate/clang-10/coverage.lcov
+++ b/tests/merging/reference/different-functions-separate/clang-10/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/merging/output/different-functions-separate/func.h
 VER:038c9fe6d002775301b38c63c7aa5e6c
 FN:3,_Z3fooi_3

--- a/tests/merging/reference/different-functions-separate/clang-12/coverage.lcov
+++ b/tests/merging/reference/different-functions-separate/clang-12/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/merging/output/different-functions-separate/func.h
 VER:038c9fe6d002775301b38c63c7aa5e6c
 FN:3,foo(int)_3

--- a/tests/merging/reference/different-functions-separate/gcc-14/coverage.lcov
+++ b/tests/merging/reference/different-functions-separate/gcc-14/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/merging/output/different-functions-separate/func.h
 VER:038c9fe6d002775301b38c63c7aa5e6c
 FN:3,foo(int)_3

--- a/tests/merging/reference/different-functions-separate/gcc-5/coverage.lcov
+++ b/tests/merging/reference/different-functions-separate/gcc-5/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/merging/output/different-functions-separate/func.h
 VER:038c9fe6d002775301b38c63c7aa5e6c
 FN:3,foo(int)_3

--- a/tests/nested/reference/linked/clang-10/coverage.lcov
+++ b/tests/nested/reference/linked/clang-10/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/nested/output/linked/subdir/A/C/D/File6.cpp
 VER:51c81752202f160b25ffc07fb9134018
 FN:1,_Z4foo6i

--- a/tests/nested/reference/linked/clang-12/coverage.lcov
+++ b/tests/nested/reference/linked/clang-12/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/nested/output/linked/subdir/A/C/D/File6.cpp
 VER:51c81752202f160b25ffc07fb9134018
 FN:1,foo6(int)

--- a/tests/nested/reference/linked/clang-17-Darwin/coverage.lcov
+++ b/tests/nested/reference/linked/clang-17-Darwin/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/nested/output/linked/subdir/A/C/D/File6.cpp
 VER:51c81752202f160b25ffc07fb9134018
 FN:1,foo6(int)

--- a/tests/nested/reference/linked/clang-18/coverage.lcov
+++ b/tests/nested/reference/linked/clang-18/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/nested/output/linked/subdir/A/C/D/File6.cpp
 VER:51c81752202f160b25ffc07fb9134018
 FN:1,foo6(int)

--- a/tests/nested/reference/linked/gcc-14/coverage.lcov
+++ b/tests/nested/reference/linked/gcc-14/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/nested/output/linked/subdir/A/C/D/File6.cpp
 VER:51c81752202f160b25ffc07fb9134018
 FN:1,foo6(int)

--- a/tests/nested/reference/linked/gcc-5/coverage.lcov
+++ b/tests/nested/reference/linked/gcc-5/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/nested/output/linked/subdir/A/C/D/File6.cpp
 VER:51c81752202f160b25ffc07fb9134018
 FN:1,foo6(int)

--- a/tests/nested/reference/oos/clang-10/coverage.lcov
+++ b/tests/nested/reference/oos/clang-10/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/nested/output/oos/subdir/A/C/D/File6.cpp
 VER:51c81752202f160b25ffc07fb9134018
 FN:1,_Z4foo6i

--- a/tests/nested/reference/oos/clang-12/coverage.lcov
+++ b/tests/nested/reference/oos/clang-12/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/nested/output/oos/subdir/A/C/D/File6.cpp
 VER:51c81752202f160b25ffc07fb9134018
 FN:1,foo6(int)

--- a/tests/nested/reference/oos/clang-17-Darwin/coverage.lcov
+++ b/tests/nested/reference/oos/clang-17-Darwin/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/nested/output/oos/subdir/A/C/D/File6.cpp
 VER:51c81752202f160b25ffc07fb9134018
 FN:1,foo6(int)

--- a/tests/nested/reference/oos/clang-18/coverage.lcov
+++ b/tests/nested/reference/oos/clang-18/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/nested/output/oos/subdir/A/C/D/File6.cpp
 VER:51c81752202f160b25ffc07fb9134018
 FN:1,foo6(int)

--- a/tests/nested/reference/oos/gcc-14/coverage.lcov
+++ b/tests/nested/reference/oos/gcc-14/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/nested/output/oos/subdir/A/C/D/File6.cpp
 VER:51c81752202f160b25ffc07fb9134018
 FN:1,foo6(int)

--- a/tests/nested/reference/oos/gcc-5/coverage.lcov
+++ b/tests/nested/reference/oos/gcc-5/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/nested/output/oos/subdir/A/C/D/File6.cpp
 VER:51c81752202f160b25ffc07fb9134018
 FN:1,foo6(int)

--- a/tests/nested/reference/standard/clang-10/coverage.lcov
+++ b/tests/nested/reference/standard/clang-10/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/nested/output/standard/subdir/A/C/D/File6.cpp
 FN:1,_Z4foo6i
 FNDA:1,_Z4foo6i

--- a/tests/nested/reference/standard/clang-12/coverage.lcov
+++ b/tests/nested/reference/standard/clang-12/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/nested/output/standard/subdir/A/C/D/File6.cpp
 FN:1,foo6(int)
 FNDA:1,foo6(int)

--- a/tests/nested/reference/standard/clang-17-Darwin/coverage.lcov
+++ b/tests/nested/reference/standard/clang-17-Darwin/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/nested/output/standard/subdir/A/C/D/File6.cpp
 FN:1,foo6(int)
 FNDA:1,foo6(int)

--- a/tests/nested/reference/standard/clang-18/coverage.lcov
+++ b/tests/nested/reference/standard/clang-18/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/nested/output/standard/subdir/A/C/D/File6.cpp
 FN:1,foo6(int)
 FNDA:1,foo6(int)

--- a/tests/nested/reference/standard/gcc-14/coverage.lcov
+++ b/tests/nested/reference/standard/gcc-14/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/nested/output/standard/subdir/A/C/D/File6.cpp
 FN:1,foo6(int)
 FNDA:1,foo6(int)

--- a/tests/nested/reference/standard/gcc-5/coverage.lcov
+++ b/tests/nested/reference/standard/gcc-5/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/nested/output/standard/subdir/A/C/D/File6.cpp
 FN:1,foo6(int)
 FNDA:1,foo6(int)

--- a/tests/no-branch/reference/clang-10/coverage.lcov
+++ b/tests/no-branch/reference/clang-10/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/no-branch/output/main.cpp
 VER:e3e6a5d78e81ea389bb54b2bd6c04e7d
 FN:1,main

--- a/tests/no-branch/reference/gcc-5/coverage.lcov
+++ b/tests/no-branch/reference/gcc-5/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/no-branch/output/main.cpp
 VER:e3e6a5d78e81ea389bb54b2bd6c04e7d
 FN:1,main

--- a/tests/several-functions-on-same-line/reference/clang-10/coverage.lcov
+++ b/tests/several-functions-on-same-line/reference/clang-10/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/several-functions-on-same-line/output/function.hpp
 VER:85bc1e5211f215b6cd6a1b54bf4cfbac
 FN:2,_Z6func_aii

--- a/tests/several-functions-on-same-line/reference/clang-12/coverage.lcov
+++ b/tests/several-functions-on-same-line/reference/clang-12/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/several-functions-on-same-line/output/function.hpp
 VER:85bc1e5211f215b6cd6a1b54bf4cfbac
 FN:2,func_a(int, int)

--- a/tests/several-functions-on-same-line/reference/clang-17-Darwin/coverage.lcov
+++ b/tests/several-functions-on-same-line/reference/clang-17-Darwin/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/several-functions-on-same-line/output/function.hpp
 VER:85bc1e5211f215b6cd6a1b54bf4cfbac
 FN:2,func_a(int, int)

--- a/tests/several-functions-on-same-line/reference/clang-18/coverage.lcov
+++ b/tests/several-functions-on-same-line/reference/clang-18/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/several-functions-on-same-line/output/function.hpp
 VER:85bc1e5211f215b6cd6a1b54bf4cfbac
 FN:2,func_a(int, int)

--- a/tests/several-functions-on-same-line/reference/gcc-14/coverage.lcov
+++ b/tests/several-functions-on-same-line/reference/gcc-14/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/several-functions-on-same-line/output/function.hpp
 VER:85bc1e5211f215b6cd6a1b54bf4cfbac
 FN:2,func_a(int, int)

--- a/tests/several-functions-on-same-line/reference/gcc-5/coverage.lcov
+++ b/tests/several-functions-on-same-line/reference/gcc-5/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/several-functions-on-same-line/output/function.hpp
 VER:85bc1e5211f215b6cd6a1b54bf4cfbac
 FN:2,func_a(int, int)

--- a/tests/several-functions-on-same-line/reference/gcc-8/coverage.lcov
+++ b/tests/several-functions-on-same-line/reference/gcc-8/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/several-functions-on-same-line/output/function.hpp
 VER:85bc1e5211f215b6cd6a1b54bf4cfbac
 FN:2,func_a(int, int)

--- a/tests/simple/reference/directory-output/clang-10/coverage.lcov
+++ b/tests/simple/reference/directory-output/clang-10/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/simple/output/directory-output/main.cpp
 VER:8a17fee4731f4aa369ea27803c70cc8a
 FN:3,_Z10not_calledv

--- a/tests/simple/reference/directory-output/clang-12/coverage.lcov
+++ b/tests/simple/reference/directory-output/clang-12/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/simple/output/directory-output/main.cpp
 VER:8a17fee4731f4aa369ea27803c70cc8a
 FN:3,not_called()

--- a/tests/simple/reference/directory-output/gcc-14/coverage.lcov
+++ b/tests/simple/reference/directory-output/gcc-14/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/simple/output/directory-output/main.cpp
 VER:8a17fee4731f4aa369ea27803c70cc8a
 FN:3,not_called()

--- a/tests/simple/reference/directory-output/gcc-5/coverage.lcov
+++ b/tests/simple/reference/directory-output/gcc-5/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/simple/output/directory-output/main.cpp
 VER:8a17fee4731f4aa369ea27803c70cc8a
 FN:3,not_called()

--- a/tests/simple/reference/directory-output/gcc-7/coverage.lcov
+++ b/tests/simple/reference/directory-output/gcc-7/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/simple/output/directory-output/main.cpp
 VER:8a17fee4731f4aa369ea27803c70cc8a
 FN:3,not_called()

--- a/tests/simple/reference/stdout/clang-10/coverage.lcov
+++ b/tests/simple/reference/stdout/clang-10/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/simple/output/stdout/main.cpp
 VER:8a17fee4731f4aa369ea27803c70cc8a
 FN:3,_Z10not_calledv

--- a/tests/simple/reference/stdout/clang-12/coverage.lcov
+++ b/tests/simple/reference/stdout/clang-12/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/simple/output/stdout/main.cpp
 VER:8a17fee4731f4aa369ea27803c70cc8a
 FN:3,not_called()

--- a/tests/simple/reference/stdout/gcc-14/coverage.lcov
+++ b/tests/simple/reference/stdout/gcc-14/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/simple/output/stdout/main.cpp
 VER:8a17fee4731f4aa369ea27803c70cc8a
 FN:3,not_called()

--- a/tests/simple/reference/stdout/gcc-5/coverage.lcov
+++ b/tests/simple/reference/stdout/gcc-5/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/simple/output/stdout/main.cpp
 VER:8a17fee4731f4aa369ea27803c70cc8a
 FN:3,not_called()

--- a/tests/simple/reference/stdout/gcc-7/coverage.lcov
+++ b/tests/simple/reference/stdout/gcc-7/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/simple/output/stdout/main.cpp
 VER:8a17fee4731f4aa369ea27803c70cc8a
 FN:3,not_called()

--- a/tests/split-signature/reference/clang-10/coverage.lcov
+++ b/tests/split-signature/reference/clang-10/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/split-signature/output/main.cpp
 VER:39030f47fbff470180d95246db4bac93
 FN:8,_ZN12_GLOBAL__N_13BarC2Ev

--- a/tests/split-signature/reference/clang-12/coverage.lcov
+++ b/tests/split-signature/reference/clang-12/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/split-signature/output/main.cpp
 VER:39030f47fbff470180d95246db4bac93
 FN:8,(anonymous namespace)::Bar::Bar()

--- a/tests/split-signature/reference/gcc-11/coverage.lcov
+++ b/tests/split-signature/reference/gcc-11/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/split-signature/output/main.cpp
 VER:39030f47fbff470180d95246db4bac93
 FN:8,(anonymous namespace)::Bar::Bar()

--- a/tests/split-signature/reference/gcc-14/coverage.lcov
+++ b/tests/split-signature/reference/gcc-14/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/split-signature/output/main.cpp
 VER:39030f47fbff470180d95246db4bac93
 FN:8,(anonymous namespace)::Bar::Bar()

--- a/tests/split-signature/reference/gcc-5/coverage.lcov
+++ b/tests/split-signature/reference/gcc-5/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/split-signature/output/main.cpp
 VER:39030f47fbff470180d95246db4bac93
 FN:8,(anonymous namespace)::Bar::Bar()

--- a/tests/template-function/reference/template-function/clang-10/coverage.lcov
+++ b/tests/template-function/reference/template-function/clang-10/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/template-function/output/template-function/main.cpp
 VER:50772fdb5b19353fa726392fd21699e0
 FN:5,_Z3fooIdEvT_

--- a/tests/template-function/reference/template-function/clang-10/coverage.merged.lcov
+++ b/tests/template-function/reference/template-function/clang-10/coverage.merged.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/template-function/output/template-function/main.cpp
 VER:50772fdb5b19353fa726392fd21699e0
 FN:5,_Z3fooIdEvT_

--- a/tests/template-function/reference/template-function/clang-11/coverage.lcov
+++ b/tests/template-function/reference/template-function/clang-11/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/template-function/output/template-function/main.cpp
 VER:50772fdb5b19353fa726392fd21699e0
 FN:5,_Z3fooIdEvT_

--- a/tests/template-function/reference/template-function/clang-11/coverage.merged.lcov
+++ b/tests/template-function/reference/template-function/clang-11/coverage.merged.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/template-function/output/template-function/main.cpp
 VER:50772fdb5b19353fa726392fd21699e0
 FN:5,_Z3fooIdEvT_

--- a/tests/template-function/reference/template-function/clang-12/coverage.lcov
+++ b/tests/template-function/reference/template-function/clang-12/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/template-function/output/template-function/main.cpp
 VER:50772fdb5b19353fa726392fd21699e0
 FN:5,void foo<double>(double)

--- a/tests/template-function/reference/template-function/clang-12/coverage.merged.lcov
+++ b/tests/template-function/reference/template-function/clang-12/coverage.merged.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/template-function/output/template-function/main.cpp
 VER:50772fdb5b19353fa726392fd21699e0
 FN:5,void foo<double>(double)

--- a/tests/template-function/reference/template-function/clang-17-Darwin/coverage.lcov
+++ b/tests/template-function/reference/template-function/clang-17-Darwin/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/template-function/output/template-function/main.cpp
 VER:50772fdb5b19353fa726392fd21699e0
 FN:5,void foo<double>(double)

--- a/tests/template-function/reference/template-function/clang-17-Darwin/coverage.merged.lcov
+++ b/tests/template-function/reference/template-function/clang-17-Darwin/coverage.merged.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/template-function/output/template-function/main.cpp
 VER:50772fdb5b19353fa726392fd21699e0
 FN:5,void foo<double>(double)

--- a/tests/template-function/reference/template-function/clang-18/coverage.lcov
+++ b/tests/template-function/reference/template-function/clang-18/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/template-function/output/template-function/main.cpp
 VER:50772fdb5b19353fa726392fd21699e0
 FN:5,void foo<double>(double)

--- a/tests/template-function/reference/template-function/clang-18/coverage.merged.lcov
+++ b/tests/template-function/reference/template-function/clang-18/coverage.merged.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/template-function/output/template-function/main.cpp
 VER:50772fdb5b19353fa726392fd21699e0
 FN:5,void foo<double>(double)

--- a/tests/template-function/reference/template-function/gcc-14/coverage.lcov
+++ b/tests/template-function/reference/template-function/gcc-14/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/template-function/output/template-function/main.cpp
 VER:50772fdb5b19353fa726392fd21699e0
 FN:5,void foo<double>(double)

--- a/tests/template-function/reference/template-function/gcc-14/coverage.merged.lcov
+++ b/tests/template-function/reference/template-function/gcc-14/coverage.merged.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/template-function/output/template-function/main.cpp
 VER:50772fdb5b19353fa726392fd21699e0
 FN:5,void foo<double>(double)

--- a/tests/template-function/reference/template-function/gcc-5/coverage.lcov
+++ b/tests/template-function/reference/template-function/gcc-5/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/template-function/output/template-function/main.cpp
 VER:50772fdb5b19353fa726392fd21699e0
 FN:5,void foo<double>(double)

--- a/tests/template-function/reference/template-function/gcc-5/coverage.merged.lcov
+++ b/tests/template-function/reference/template-function/gcc-5/coverage.merged.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/template-function/output/template-function/main.cpp
 VER:50772fdb5b19353fa726392fd21699e0
 FN:5,void foo<double>(double)

--- a/tests/template-function/reference/template-function/gcc-8/coverage.lcov
+++ b/tests/template-function/reference/template-function/gcc-8/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/template-function/output/template-function/main.cpp
 VER:50772fdb5b19353fa726392fd21699e0
 FN:5,void foo<double>(double)

--- a/tests/template-function/reference/template-function/gcc-8/coverage.merged.lcov
+++ b/tests/template-function/reference/template-function/gcc-8/coverage.merged.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/template-function/output/template-function/main.cpp
 VER:50772fdb5b19353fa726392fd21699e0
 FN:5,void foo<double>(double)

--- a/tests/virtual-classes/reference/clang-10/coverage.lcov
+++ b/tests/virtual-classes/reference/clang-10/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/virtual-classes/output/main.cpp
 VER:b886ade13bcdf26378ac76876e02cded
 FN:8,_ZN3ns14Bar1C2Ev

--- a/tests/virtual-classes/reference/clang-12/coverage.lcov
+++ b/tests/virtual-classes/reference/clang-12/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/virtual-classes/output/main.cpp
 VER:b886ade13bcdf26378ac76876e02cded
 FN:8,ns1::Bar1::Bar1()

--- a/tests/virtual-classes/reference/clang-15-Darwin/coverage.lcov
+++ b/tests/virtual-classes/reference/clang-15-Darwin/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/virtual-classes/output/main.cpp
 VER:b886ade13bcdf26378ac76876e02cded
 FN:8,ns1::Bar1::Bar1()

--- a/tests/virtual-classes/reference/clang-15/coverage.lcov
+++ b/tests/virtual-classes/reference/clang-15/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/virtual-classes/output/main.cpp
 VER:b886ade13bcdf26378ac76876e02cded
 FN:8,ns1::Bar1::Bar1()

--- a/tests/virtual-classes/reference/clang-17-Darwin/coverage.lcov
+++ b/tests/virtual-classes/reference/clang-17-Darwin/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/virtual-classes/output/main.cpp
 VER:b886ade13bcdf26378ac76876e02cded
 FN:8,ns1::Bar1::Bar1()

--- a/tests/virtual-classes/reference/gcc-11/coverage.lcov
+++ b/tests/virtual-classes/reference/gcc-11/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/virtual-classes/output/main.cpp
 VER:b886ade13bcdf26378ac76876e02cded
 FN:8,ns1::Bar1::Bar1()

--- a/tests/virtual-classes/reference/gcc-14-Windows/coverage.lcov
+++ b/tests/virtual-classes/reference/gcc-14-Windows/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/virtual-classes/output/main.cpp
 VER:b886ade13bcdf26378ac76876e02cded
 FN:8,ns1::Bar1::Bar1()

--- a/tests/virtual-classes/reference/gcc-14/coverage.lcov
+++ b/tests/virtual-classes/reference/gcc-14/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/virtual-classes/output/main.cpp
 VER:b886ade13bcdf26378ac76876e02cded
 FN:8,ns1::Bar1::Bar1()

--- a/tests/virtual-classes/reference/gcc-5/coverage.lcov
+++ b/tests/virtual-classes/reference/gcc-5/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/virtual-classes/output/main.cpp
 VER:b886ade13bcdf26378ac76876e02cded
 FN:8,ns1::Bar1::Bar1()

--- a/tests/virtual-classes/reference/gcc-6/coverage.lcov
+++ b/tests/virtual-classes/reference/gcc-6/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/virtual-classes/output/main.cpp
 VER:b886ade13bcdf26378ac76876e02cded
 FN:8,ns1::Bar1::Bar1()

--- a/tests/virtual-classes/reference/gcc-8/coverage.lcov
+++ b/tests/virtual-classes/reference/gcc-8/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/virtual-classes/output/main.cpp
 VER:b886ade13bcdf26378ac76876e02cded
 FN:8,ns1::Bar1::Bar1()

--- a/tests/windows/reference/drive-subst/gcc-14-Windows/coverage.lcov
+++ b/tests/windows/reference/drive-subst/gcc-14-Windows/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:
 VER:251395fea4d88bf2d3ffc4d00110a5ef
 FN:4,foo(int)

--- a/tests/wspace/reference/clang-10/coverage.lcov
+++ b/tests/wspace/reference/clang-10/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/wspace/output/src code/main.cpp
 VER:251395fea4d88bf2d3ffc4d00110a5ef
 FN:4,_Z3fooi

--- a/tests/wspace/reference/clang-12/coverage.lcov
+++ b/tests/wspace/reference/clang-12/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/wspace/output/src code/main.cpp
 VER:251395fea4d88bf2d3ffc4d00110a5ef
 FN:4,foo(int)

--- a/tests/wspace/reference/gcc-14/coverage.lcov
+++ b/tests/wspace/reference/gcc-14/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/wspace/output/src code/main.cpp
 VER:251395fea4d88bf2d3ffc4d00110a5ef
 FN:4,foo(int)

--- a/tests/wspace/reference/gcc-5/coverage.lcov
+++ b/tests/wspace/reference/gcc-5/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/wspace/output/src code/main.cpp
 VER:251395fea4d88bf2d3ffc4d00110a5ef
 FN:4,foo(int)

--- a/tests/wspace/reference/gcc-7/coverage.lcov
+++ b/tests/wspace/reference/gcc-7/coverage.lcov
@@ -1,4 +1,4 @@
-TN:GCOVR report
+TN:GCOVR_report
 SF:tests/wspace/output/src code/main.cpp
 VER:251395fea4d88bf2d3ffc4d00110a5ef
 FN:4,foo(int)


### PR DESCRIPTION
LCOV tool is complaining about spaces in test name. Test the value and raise a error if it contains a space.