### PR TITLE
Fix nested HTML report with missing coverage data

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,7 @@ Bug fixes and small improvements:
 - Fix text report for covered decisions. (:issue:`1192`)
 - Fix runtime problem introduced with 8.4. (:issue:`1194`)
 - Fix wrong entries in data source attribute of JSON report. (:issue:`1194`)
+- Fix nested HTML report without coverage data. (:issue:`1197`)
 
 Documentation:
 
@@ -80,6 +81,7 @@ Known bugs:
 - :ref:`fix_1192`
 - :ref:`fix_1194_1`
 - :ref:`fix_1194_2`
+- :ref:`fix_1197`
 
 Breaking changes:
 
@@ -192,6 +194,7 @@ Known bugs:
 - :ref:`fix_1138`
 - :ref:`fix_1171_1`
 - :ref:`fix_1176`
+- :ref:`fix_1197`
 
 Breaking changes:
 
@@ -255,6 +258,7 @@ Known bugs:
 - :ref:`fix_1130`
 - :ref:`fix_1138`
 - :ref:`fix_1171_1`
+- :ref:`fix_1197`
 
 Breaking changes:
 
@@ -283,6 +287,7 @@ Known bugs:
 - :ref:`fix_1130`
 - :ref:`fix_1138`
 - :ref:`fix_1171_1`
+- :ref:`fix_1197`
 
 Breaking changes:
 
@@ -315,6 +320,7 @@ Known bugs:
 - :ref:`fix_1130`
 - :ref:`fix_1138`
 - :ref:`fix_1171_1`
+- :ref:`fix_1197`
 
 Breaking changes:
 
@@ -395,6 +401,7 @@ Known bugs:
 - :ref:`fix_1037`
 - :ref:`fix_1089`.
 - :ref:`fix_1138`
+- :ref:`fix_1197`
 
 New features and notable changes:
 
@@ -429,6 +436,7 @@ Known bugs:
 - :ref:`fix_1022`
 - :ref:`fix_1037`
 - :ref:`fix_1089`
+- :ref:`fix_1197`
 
 Breaking changes:
 
@@ -530,6 +538,7 @@ Internal changes:
 Known bugs:
 
 - :ref:`fix_1037`
+- :ref:`fix_1197`
 
 Breaking changes:
 

--- a/doc/source/known_bugs.rst
+++ b/doc/source/known_bugs.rst
@@ -9,6 +9,39 @@ Known bugs
 This list contains bugs for version 6.0 and newer, always check the latest
 version of this file available `here <https://gcovr.com/en/latest/known_bugs.html>`_.
 
+.. _fix_1197:
+
+Nested HTML report without data can't be generated
+--------------------------------------------------
+
+.. list-table::
+
+   * - Introduced
+     - :ref:`release_6_0`
+
+   * - Fixed
+     - :ref:`next_release`, :issue:`1197`
+
+When generating a nested HTML report but there is no coverage data
+for :ref:`release_6_0` to :ref:`release_8_2` no root page is generated
+and no error is raised. Starting with :ref:`release_8_3` the following error occurs:
+
+.. code-block::
+
+  (ERROR) Error occurred while printing reports:
+  Traceback (most recent call last):
+    File "/gcovr/src/gcovr/__main__.py", line 426, in main
+      gcovr_formats.write_reports(covdata, options)
+    File "/gcovr/src/gcovr/formats/__init__.py", line 311, in write_reports
+      format_writer(covdata, output.abspath)
+    File "/gcovr/src/gcovr/formats/html/__init__.py", line 282, in write_report
+      write_report(covdata, output_file, self.options)
+    File "/gcovr/src/gcovr/formats/html/write.py", line 484, in write_report
+      write_directory_pages(
+    File "/gcovr/src/gcovr/formats/html/write.py", line 610, in write_directory_pages
+      root_key = next(iter(sorted([d.dirname for d in covdata.directories])))
+  StopIteration
+
 .. _fix_1194_1:
 
 Drastic increase of runtime with large projects

--- a/src/gcovr/formats/html/write.py
+++ b/src/gcovr/formats/html/write.py
@@ -480,7 +480,7 @@ def write_report(
             data,
         )
     else:
-        if options.html_nested:
+        if options.html_nested and covdata.directories:
             write_directory_pages(
                 options,
                 root_info,

--- a/tests/html/test_html.py
+++ b/tests/html/test_html.py
@@ -271,6 +271,13 @@ def test_encoding(
     gcovr_test_exec.compare_html(encoding=html_encoding)
 
 
+def test_empty_nested_report(gcovr_test_exec: "GcovrTestExec") -> None:
+    """Test HTML report generation without data files."""
+    gcovr_test_exec.gcovr(
+        "--html-nested=coverage.html",
+    )
+
+
 def test_file_not_found(gcovr_test_exec: "GcovrTestExec") -> None:
     """Test HTML output when file is not found, using tracefile."""
     # No compilation needed, just run gcovr with tracefile


### PR DESCRIPTION
For version 6.0 to 8.2 the root page of the report is missing and no error is thrown if there is no coverage data found. Version 8.3 and 8.4 are failing with a stack traceback:

```
  (ERROR) Error occurred while printing reports:
  Traceback (most recent call last):
    File "/gcovr/src/gcovr/__main__.py", line 426, in main
      gcovr_formats.write_reports(covdata, options)
    File "/gcovr/src/gcovr/formats/__init__.py", line 311, in write_reports
      format_writer(covdata, output.abspath)
    File "/gcovr/src/gcovr/formats/html/__init__.py", line 282, in write_report
      write_report(covdata, output_file, self.options)
    File "/gcovr/src/gcovr/formats/html/write.py", line 484, in write_report
      write_directory_pages(
    File "/gcovr/src/gcovr/formats/html/write.py", line 610, in write_directory_pages
      root_key = next(iter(sorted([d.dirname for d in covdata.directories])))
  StopIteration
```

