### PR TITLE
 Add warning if coverage data is empty

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,7 +43,7 @@ Bug fixes and small improvements:
 - Fix runtime problem introduced with 8.4. (:issue:`1194`)
 - Fix wrong entries in data source attribute of JSON report. (:issue:`1194`)
 - Fix nested HTML report without coverage data. (:issue:`1197`)
-- Raise error if all coverage data is filtered out. (:issue:`1200`)
+- Add warning if coverage data is empty. (:issue:`1200`)
 
 Documentation:
 

--- a/src/gcovr/formats/__init__.py
+++ b/src/gcovr/formats/__init__.py
@@ -101,8 +101,8 @@ def read_reports(options: Options) -> CoverageContainer:
         covdata = GcovHandler(options).read_report()
 
     if not covdata:
-        raise RuntimeError(
-            "All coverage data is filtered out. Please check your filters."
+        LOGGER.warning(
+            "All coverage data is filtered out. Please check your paths and filters."
         )
 
     if options.include_search_filter:

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -545,7 +545,8 @@ def test_multiple_output_formats_to_stdout(caplog: pytest.LogCaptureFixture) -> 
             ("JSON summary", "--json-summary"),
             ("SonarQube", "--sonarqube"),
             ("Text", "--txt"),
-        ]
+        ],
+        start=1,
     ):
         format_name, option = text_fragments
         message = c.record_tuples[index]
@@ -586,7 +587,8 @@ def test_multiple_output_formats_to_stdout_1(caplog: pytest.LogCaptureFixture) -
             ("JSON summary", "--json-summary"),
             ("SonarQube", "--sonarqube"),
             ("Text", "--txt"),
-        ]
+        ],
+        start=1,
     ):
         format_name, option = text_fragments
         message = c.record_tuples[index]


### PR DESCRIPTION
If we have no coverage data after reading all inputs a warning is printed with a hint to check directories and filters.

Related #1166 