### PR TITLE
Skip mypy on PyPy implementation of python

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -71,6 +71,7 @@ Internal changes:
 - Use pyenv to install python independent from OS version in docker image for testing. (:issue:`1181`)
 - Reorganize docker images. Create one image per OS which contains several compiler versions to
   improve image build time and build cache size on local and CI systems. (:issue:`1184`, :issue:`1186`)
+- Do not run ``mypy`` on ``PyPy`` implementation of python. (:issue:`1209`)
 
 .. _release_8_4:
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -257,6 +257,11 @@ def pylint(session: nox.Session) -> None:
 @nox.session
 def mypy(session: nox.Session) -> None:
     """Run mypy command."""
+    if platform.python_implementation() == "PyPy":
+        session.skip(
+            "Skip mypy on PyPy due to https://github.com/python/mypy/issues/20329."
+        )
+
     install_dev_requirements(session, "mypy", "nox", "requests", "pytest", "yaxmldiff")
     session.install("-e", ".")
     if session.posargs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ dev = [
     "cmake",
     "coverage",
     "mypy",
-    "mypy!=1.19.0 ; platform_python_implementation == 'PyPy'",
     "nox",
     "pre-commit",
     "pygments==2.19.2",     # For reference compare


### PR DESCRIPTION
Mypy 1.19.0 is not working on PyPy implementation of Python.

Related https://github.com/python/mypy/issues/20329