### PR TITLE
Update action versions

### DIFF
--- a/.github/actions/setup-runner/action.yml
+++ b/.github/actions/setup-runner/action.yml
@@ -29,7 +29,7 @@ runs:
 
     # ------------------------------ Windows ------------------------------
     - if: ${{ startsWith(inputs.os,'windows-') }}
-      uses: msys2/setup-msys2@ddf331adaebd714795f1042345e6ca57bd66cea8
+      uses: msys2/setup-msys2@cafece8e6baf9247cf9b1bf95097b0b983cc558d
       with:
         install: gcc make
         cache: true
@@ -43,11 +43,11 @@ runs:
       shell: bash
 
     # ------------------------------ Python, all OS ------------------------------
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}
     - name: Restore pip cache
-      uses: re-actors/cache-python-deps@810325a232f2a28ea124dfba85c7c72fd1774b38
+      uses: re-actors/cache-python-deps@250500eea3c0986666ae8bbeba9b23f69ae6a7d3
       with:
         cache-key-for-dependency-files: ${{ hashFiles('noxfile.py', 'pyproject.toml', 'doc/requirements.txt') }}
     - run: python3 -m pip install --upgrade pip

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,7 +32,7 @@ jobs:
       tag_message: ${{ steps.changelog.outputs.tag_message || '' }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 75
       - run: git fetch --tags
@@ -80,11 +80,11 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install spellchecker
         run: |
           npm install -g cspell@8.19.4
-      - uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c  # v46
+      - uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323  # v47.0.5
         id: changed-files
         with:
           separator: ","
@@ -106,7 +106,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Copy coverage reports
         run: |
           mkdir -p /tmp/coverage-upload
@@ -116,7 +116,7 @@ jobs:
           # Patch the paths inside the coverage files
           find /tmp/coverage-upload -type f -name '*' -exec sed -e 's^output/^source/^g ; s^output^source^g ;' -i '' {} \;
       - name: Upload coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-reference
           path: /tmp/coverage-upload/*.*
@@ -150,7 +150,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 75
 
@@ -193,7 +193,7 @@ jobs:
             | tee --append $GITHUB_OUTPUT
 
       - name: Upload distribution 📦
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: python-package-distributions
           path: dist/**
@@ -209,7 +209,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 75
 
@@ -237,7 +237,7 @@ jobs:
           cat doc/build/job_summary.md >> $GITHUB_STEP_SUMMARY
 
       - name: Upload release notes
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: release-notes
           path: doc/build/release_notes.md
@@ -336,7 +336,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Print job variables
         run: echo '''${{ toJSON(needs) }}'''
@@ -371,7 +371,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Print job variables
         run: echo '''${{ toJSON(needs) }}'''
@@ -383,7 +383,7 @@ jobs:
           python-version: 3.12
 
       - name: Download artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           pattern: coverage-pytest-*
 
@@ -392,7 +392,7 @@ jobs:
           nox --non-interactive --session combine_coverage -- $(find . -name '.coverage_*')
 
       - name: Upload coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-merged
           path: |
@@ -421,14 +421,14 @@ jobs:
           jobs: ${{ toJSON(needs) }}
 
       - name: Download all applications
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: app-*
           path: build/
           merge-multiple: true
 
       - name: Download the release notes
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: release-notes
 
@@ -464,7 +464,7 @@ jobs:
           jobs: ${{ toJSON(needs) }}
 
       - name: Download all the distribution 📦
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: python-package-distributions
           path: dist/

--- a/.github/workflows/gcovr-ci-job.yml
+++ b/.github/workflows/gcovr-ci-job.yml
@@ -52,7 +52,7 @@ jobs:
         ${{ inputs.container && contains(fromJSON('["gcc-5", "gcc-6", "gcc-7", "gcc-8", "gcc-9", "clang-10"]'), inputs.gcc) }}
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 75
 
@@ -100,7 +100,7 @@ jobs:
           echo "CC=${{ inputs.gcc }}" >> $GITHUB_ENV
 
       - name: Expose GitHub Runtime for Docker cache
-        uses: crazy-max/ghaction-github-runtime@b3a9207c0e1ef41f4cf215303c976869d0c2c1c4
+        uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487
 
       - name: Build Docker
         if: ${{ inputs.container }}
@@ -123,7 +123,7 @@ jobs:
 
       - name: Upload pytest test results
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: >-
             diffs-
@@ -135,7 +135,7 @@ jobs:
 
       - name: Upload coverage
         if: ${{ env.USE_COVERAGE == 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: >-
             coverage-pytest-${{
@@ -170,7 +170,7 @@ jobs:
 
       - name: Upload app bundle artifacts
         if: ${{ inputs.upload-app == true }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: app-${{ inputs.os }}
           path: build/gcovr*

--- a/.github/workflows/upload_coverage.yml
+++ b/.github/workflows/upload_coverage.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download artifacts
         uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11


### PR DESCRIPTION
Update the action versions.

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@v4, actions/checkout@v4, actions/setup-python@v5, actions/upload-artifact@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

[no changelog]