### PR TITLE
Refactor data model from flat list to tree

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,9 @@ Documentation:
 Internal changes:
 
 - Add CSS and JS files to all folders where a HTML reference file is present. (:issue:`1241`)
+- Refactor internal data model from a flat list to a tree which matches the folder structure of the
+  source files. Also add a properties element which is cleared after each report format to store meta
+  data for the report generation and update the dicts in the HTML report to use it. (:issue:`1261`)
 
 .. _release_8_6:
 

--- a/src/gcovr/data_model/container.py
+++ b/src/gcovr/data_model/container.py
@@ -20,10 +20,9 @@
 from __future__ import annotations
 import os
 import re
-from typing import Any, ItemsView, Iterable, Iterator, Literal, ValuesView
+from typing import Any, Iterator, Literal, ValuesView, overload
 
 from ..filter import is_file_excluded
-
 from ..logging import LOGGER
 from ..options import Options
 from ..utils import commonpath, force_unix_separator
@@ -34,96 +33,27 @@ from .merging import MergeOptions
 from .stats import CoverageStat, DecisionCoverageStat, SummarizedStats
 
 
-class ContainerBase:
-    """Base class for coverage containers"""
-
-    def sort_coverage(
-        self,
-        sort_key: Literal["filename", "uncovered-number", "uncovered-percent"],
-        sort_reverse: bool,
-        by_metric: Literal["line", "branch", "decision"],
-        filename_uses_relative_pathname: bool = False,
-    ) -> list[str]:
-        """Sort a coverage dict.
-
-        covdata (dict): the coverage dictionary
-        sort_key ("filename", "uncovered-number", "uncovered-percent"): the values to sort by
-        sort_reverse (bool): reverse order if True
-        by_metric ("line", "branch", "decision"): select the metric to sort
-        filename_uses_relative_pathname (bool): for html, we break down a pathname to the
-            relative path, but not for other formats.
-
-        returns: the sorted keys
-        """
-
-        basedir = commonpath(list(self.data.keys()))
-
-        def key_filename(key: str) -> list[int | str]:
-            def convert_to_int_if_possible(text: str) -> int | str:
-                return int(text) if text.isdigit() else text
-
-            key = (
-                force_unix_separator(
-                    os.path.relpath(os.path.realpath(key), os.path.realpath(basedir))
-                )
-                if filename_uses_relative_pathname
-                else key
-            ).casefold()
-
-            return [
-                convert_to_int_if_possible(part) for part in re.split(r"([0-9]+)", key)
-            ]
-
-        def coverage_stat(key: str) -> CoverageStat:
-            cov: FileCoverage | CoverageContainerDirectory = self.data[key]
-            if by_metric == "branch":
-                return cov.branch_coverage()
-            if by_metric == "decision":
-                return cov.decision_coverage().to_coverage_stat
-            return cov.line_coverage()
-
-        def key_num_uncovered(key: str) -> int:
-            stat = coverage_stat(key)
-            uncovered = stat.total - stat.covered
-            return uncovered
-
-        def key_percent_uncovered(key: str) -> float:
-            stat = coverage_stat(key)
-            covered = stat.covered
-            total = stat.total
-
-            # No branches are always put directly after (or before when reversed)
-            # files with 100% coverage (by assigning such files 110% coverage)
-            return covered / total if total > 0 else 1.1
-
-        if sort_key == "uncovered-number":
-            # First sort filename alphabetical and then by the requested key
-            return sorted(
-                sorted(self.data, key=key_filename),
-                key=key_num_uncovered,
-                reverse=sort_reverse,
-            )
-        if sort_key == "uncovered-percent":
-            # First sort filename alphabetical and then by the requested key
-            return sorted(
-                sorted(self.data, key=key_filename),
-                key=key_percent_uncovered,
-                reverse=sort_reverse,
-            )
-
-        # By default, we sort by filename alphabetically
-        return sorted(self.data, key=key_filename, reverse=sort_reverse)
-
-
-class CoverageContainer(ContainerBase):
+class CoverageContainer:
     """Coverage container holding all the coverage data."""
 
-    def __init__(self) -> None:
-        self.data = CoverageDict[str, FileCoverage]()
-        self.directories = list[CoverageContainerDirectory]()
+    def __init__(self, dirname: str, parent: CoverageContainer | None = None) -> None:
+        self.data = CoverageDict[str, CoverageContainer | FileCoverage]()
+        self.dirname = os.path.abspath(dirname) + os.path.sep
+        self.parent = parent
+        self._properties = dict[str, Any]()
+        self._stats: SummarizedStats | None = None
 
-    def __getitem__(self, key: str) -> FileCoverage:
+    def __getitem__(self, key: str) -> CoverageContainer | FileCoverage:
         return self.data[key]
+
+    def __setitem__(
+        self, key: str, value: CoverageContainer | FileCoverage
+    ) -> CoverageContainer | FileCoverage:
+        self.data[key] = value
+        return value
+
+    def __delitem__(self, key: str) -> None:
+        del self.data[key]
 
     def __len__(self) -> int:
         return len(self.data)
@@ -131,24 +61,83 @@ class CoverageContainer(ContainerBase):
     def __contains__(self, key: str) -> bool:
         return key in self.data
 
-    def __iter__(self) -> Iterator[str]:
-        return iter(self.data)
+    def clear(
+        self,
+    ) -> None:
+        """Clear the file coverage data."""
+        self.data.clear()
 
-    def values(self) -> ValuesView[FileCoverage]:
+    def values(self) -> ValuesView[CoverageContainer | FileCoverage]:
         """Get the file coverage data objects."""
         return self.data.values()
 
-    def items(self) -> ItemsView[str, FileCoverage]:
-        """Get the file coverage data items."""
-        return self.data.items()
+    def filecov(self, recurse: bool = False) -> Iterator[FileCoverage]:
+        """Get the file coverage data objects."""
+        for value in self.values():
+            if isinstance(value, FileCoverage):
+                yield value
+            elif recurse:
+                yield from value.filecov(recurse=True)
+
+    def dircov(self, recurse: bool = False) -> Iterator[CoverageContainer]:
+        """Get the directory coverage data objects."""
+        for value in self.values():
+            if isinstance(value, CoverageContainer):
+                if recurse:
+                    yield from value.dircov(recurse=True)
+        yield self
+
+    def traverse(self) -> Iterator[CoverageContainer | FileCoverage]:
+        """Traverse the coverage data object tree."""
+        for value in self.values():
+            if isinstance(value, FileCoverage):
+                yield value
+            else:
+                yield from value.traverse()
+        yield self
+
+    def remove_container_with_single_item(self) -> None:
+        """Remove directory containers with only one file coverage item."""
+        # Iterate over a copy of the values to avoid modifying the dictionary while iterating
+        for value in list(self.values()):
+            if isinstance(value, CoverageContainer):
+                value.remove_container_with_single_item()
+
+        children = list(self.values())
+        if len(children) == 1:
+            child = children[0]
+            if isinstance(child, FileCoverage):
+                if self.parent is not None:
+                    LOGGER.debug(
+                        "   Move file %s to directory %s. %s",
+                        child.filename,
+                        self.parent.dirname,
+                        list(self.parent.data.keys()),
+                    )
+                    del self.parent[self.dirname]
+                    self.parent[child.filename] = child
+            else:
+                self.clear()
+                LOGGER.debug(
+                    "   Move content of %s to directory %s.",
+                    child.dirname,
+                    self.dirname,
+                )
+                for child_covdata in child.values():
+                    if isinstance(child_covdata, FileCoverage):
+                        LOGGER.debug("      Move file %s.", child_covdata.filename)
+                        self[child_covdata.filename] = child_covdata
+                    else:
+                        LOGGER.debug("      Move directory %s.", child_covdata.dirname)
+                        self[child_covdata.dirname] = child_covdata
+                        child_covdata.parent = self
 
     def serialize(self, options: Options) -> list[dict[str, Any]]:
         """Serialize the object."""
-        return [value.serialize(options) for _, value in sorted(self.items())]
-
-    def is_compare_info_available(self) -> bool:
-        """Check weather the data has compare information or not."""
-        return any(filecov.is_compare_info_available() for filecov in self.values())
+        data = list[dict[str, Any]]()
+        for value in sorted(self.filecov(recurse=True), key=lambda cov: cov.filename):
+            data.append(value.serialize(options))
+        return data
 
     @classmethod
     def deserialize(
@@ -159,7 +148,7 @@ class CoverageContainer(ContainerBase):
         merge_options: MergeOptions,
     ) -> CoverageContainer:
         """Serialize the object."""
-        covdata = CoverageContainer()
+        covdata = CoverageContainer(options.root)
         for gcovr_file in data_dicts_files:
             if (
                 filecov := FileCoverage.deserialize(
@@ -172,201 +161,287 @@ class CoverageContainer(ContainerBase):
                 )
         return covdata
 
-    def merge_lines(self, options: Options) -> None:
-        """Merge line coverage for same line number. Remove the function information on merged lines."""
-        for filecov in self.values():
-            filecov.merge_lines(
-                is_file_excluded(
-                    "trace",
-                    filecov.filename,
-                    options.trace_include_filter,
-                    options.trace_exclude_filter,
+    def is_compare_info_available(self) -> bool:
+        """Check weather the data has compare information or not."""
+        return any(
+            filecov.is_compare_info_available()
+            for filecov in self.filecov(recurse=True)
+        )
+
+    @overload
+    @classmethod
+    def __sorted(
+        cls,
+        covdata_list: list[FileCoverage],
+        sort_key: Literal["filename", "uncovered-number", "uncovered-percent"],
+        sort_reverse: bool,
+        by_metric: Literal["line", "branch", "decision"],
+        filename_uses_relative_pathname: bool,
+    ) -> list[FileCoverage]:
+        """Sort a list of FileCoverage objects."""
+
+    @overload
+    @classmethod
+    def __sorted(
+        cls,
+        covdata_list: list[CoverageContainer],
+        sort_key: Literal["filename", "uncovered-number", "uncovered-percent"],
+        sort_reverse: bool,
+        by_metric: Literal["line", "branch", "decision"],
+        filename_uses_relative_pathname: bool,
+    ) -> list[CoverageContainer]:
+        """Sort a list of CoverageContainer objects."""
+
+    @overload
+    @classmethod
+    def __sorted(
+        cls,
+        covdata_list: list[FileCoverage | CoverageContainer],
+        sort_key: Literal["filename", "uncovered-number", "uncovered-percent"],
+        sort_reverse: bool,
+        by_metric: Literal["line", "branch", "decision"],
+        filename_uses_relative_pathname: bool,
+    ) -> list[FileCoverage | CoverageContainer]:
+        """Sort a list of FileCoverage objects."""
+
+    @classmethod
+    def __sorted(
+        cls,
+        covdata_list: list[FileCoverage]
+        | list[CoverageContainer]
+        | list[FileCoverage | CoverageContainer],
+        sort_key: Literal["filename", "uncovered-number", "uncovered-percent"],
+        sort_reverse: bool,
+        by_metric: Literal["line", "branch", "decision"],
+        filename_uses_relative_pathname: bool,
+    ) -> (
+        list[FileCoverage]
+        | list[CoverageContainer]
+        | list[FileCoverage | CoverageContainer]
+    ):
+        """Sort a coverage dict.
+
+        covdata_list (list[CoverageContainer | FileCoverage]): The coverage list
+        sort_key ("filename", "uncovered-number", "uncovered-percent"): The values to sort by
+        sort_reverse (bool): Reverse order if True
+        by_metric ("line", "branch", "decision"): Select the metric to sort
+        filename_uses_relative_pathname (bool): For HTML, we break down a pathname to the
+            relative path, but not for other formats.
+
+        returns: the sorted keys
+        """
+
+        basedir = commonpath([covdata.filename for covdata in covdata_list])
+
+        def key_filename(covdata: CoverageContainer | FileCoverage) -> list[int | str]:
+            def convert_to_int_if_possible(text: str) -> int | str:
+                return int(text) if text.isdigit() else text
+
+            key = (
+                force_unix_separator(
+                    os.path.relpath(
+                        os.path.realpath(covdata.filename), os.path.realpath(basedir)
+                    )
                 )
+                if filename_uses_relative_pathname
+                else covdata.filename
+            ).casefold()
+
+            return [
+                convert_to_int_if_possible(part) for part in re.split(r"([0-9]+)", key)
+            ]
+
+        def coverage_stat(covdata: CoverageContainer | FileCoverage) -> CoverageStat:
+            if by_metric == "branch":
+                return covdata.branch_coverage()
+            if by_metric == "decision":
+                return covdata.decision_coverage().to_coverage_stat
+            return covdata.line_coverage()
+
+        def key_num_uncovered(covdata: CoverageContainer | FileCoverage) -> int:
+            stat = coverage_stat(covdata)
+            uncovered = stat.total - stat.covered
+            return uncovered
+
+        def key_percent_uncovered(covdata: CoverageContainer | FileCoverage) -> float:
+            stat = coverage_stat(covdata)
+            covered = stat.covered
+            total = stat.total
+
+            # No branches are always put directly after (or before when reversed)
+            # files with 100% coverage (by assigning such files 110% coverage)
+            return covered / total if total > 0 else 1.1
+
+        if sort_key == "uncovered-number":
+            # First sort filename alphabetical and then by the requested key
+            return sorted(
+                sorted(covdata_list, key=key_filename),
+                key=key_num_uncovered,
+                reverse=sort_reverse,
+            )
+        if sort_key == "uncovered-percent":
+            # First sort filename alphabetical and then by the requested key
+            return sorted(
+                sorted(covdata_list, key=key_filename),
+                key=key_percent_uncovered,
+                reverse=sort_reverse,
             )
 
-    def merge(self, other: CoverageContainer, options: MergeOptions) -> None:
-        """
-        Merge CoverageContainer information and clear directory statistics.
+        # By default, we sort by filename alphabetically
+        return sorted(covdata_list, key=key_filename, reverse=sort_reverse)
 
-        Do not use 'other' objects afterwards!
-        """
-        self.directories.clear()
-        other.directories.clear()
-        self.data.merge(other.data, options)
+    def sorted_filecov(
+        self,
+        sort_key: Literal["filename", "uncovered-number", "uncovered-percent"],
+        sort_reverse: bool,
+        by_metric: Literal["line", "branch", "decision"],
+        filename_uses_relative_pathname: bool = False,
+        recurse: bool = False,
+    ) -> list[FileCoverage]:
+        """Sort a coverage dict.
 
-    def insert_file_coverage(
-        self, filecov: FileCoverage, options: MergeOptions
-    ) -> FileCoverage:
-        """Add a file coverage item."""
-        self.directories.clear()
-        key = filecov.filename
-        if key in self.data:
-            self.data[key].merge(filecov, options)
-        else:
-            self.data[key] = filecov
+        sort_key ("filename", "uncovered-number", "uncovered-percent"): the values to sort by
+        sort_reverse (bool): reverse order if True
+        by_metric ("line", "branch", "decision"): select the metric to sort
+        filename_uses_relative_pathname (bool): for html, we break down a pathname to the
+            relative path, but not for other formats.
+        recurse (bool): whether to include file coverage from subdirectories
 
-        return filecov
-
-    @property
-    def stats(self) -> SummarizedStats:
-        """Create a coverage statistic from a coverage data object."""
-        stats = SummarizedStats.new_empty()
-        for filecov in self.values():
-            stats += filecov.stats
-        return stats
-
-    @staticmethod
-    def _get_dirname(filename: str) -> str | None:
-        """Get the directory name with a trailing path separator.
-
-        >>> import os
-        >>> CoverageContainer._get_dirname("bar/foobar.cpp".replace("/", os.sep)).replace(os.sep, "/")
-        'bar/'
-        >>> CoverageContainer._get_dirname("/foo/bar/A/B.cpp".replace("/", os.sep)).replace(os.sep, "/")
-        '/foo/bar/A/'
-        >>> CoverageContainer._get_dirname(os.sep) is None
-        True
-        """
-        if filename == os.sep:
-            return None
-        return str(os.path.dirname(filename.rstrip(os.sep))) + os.sep
-
-    def populate_directories(
-        self, sorted_keys: Iterable[str], root_filter: re.Pattern[str]
-    ) -> None:
-        r"""Populate the list of directories and add accumulated stats.
-
-        This function will accumulate statistics such that every directory
-        above it will know the statistics associated with all files deep within a
-        directory structure.
-
-        Args:
-            sorted_keys: The sorted keys for covdata
-            root_filter: Information about the filter used with the root directory
+        returns: the sorted keys
         """
 
-        # Get the directory coverage
-        subdirs = dict[str, CoverageContainerDirectory]()
-        for key in sorted_keys:
-            filecov = self[key]
-            dircov: CoverageContainerDirectory | None = None
-            dirname: str | None = (
-                os.path.dirname(filecov.filename)
-                .replace("\\", os.sep)
-                .replace("/", os.sep)
-                .rstrip(os.sep)
-            ) + os.sep
-            while dirname is not None and root_filter.search(dirname + os.sep):
-                if dirname not in subdirs:
-                    subdirs[dirname] = CoverageContainerDirectory(dirname)
-                if dircov is None:
-                    subdirs[dirname][filecov.filename] = filecov
-                else:
-                    subdirs[dirname].data[dircov.filename] = dircov
-                    subdirs[dircov.filename].parent_dirname = dirname
-                subdirs[dirname].stats += filecov.stats
-                dircov = subdirs[dirname]
-                dirname = CoverageContainer._get_dirname(dirname)
-
-        # Replace directories where only one sub container is available
-        # with the content this sub container
-        LOGGER.debug(
-            "Replace directories with only one sub element with the content of this."
+        return self.__sorted(
+            list(self.filecov(recurse=recurse)),
+            sort_key,
+            sort_reverse,
+            by_metric,
+            filename_uses_relative_pathname,
         )
-        subdirs_to_remove = set()
-        for dirname, covdata_dir in subdirs.items():
-            # There is exact one element, replace current element with referenced element
-            if len(covdata_dir) == 1:
-                # Get the orphan item
-                orphan_key, orphan_value = next(iter(covdata_dir.items()))
-                # The only child is a File object
-                if isinstance(orphan_value, FileCoverage):
-                    # Replace the reference to ourself with our content
-                    if covdata_dir.parent_dirname is not None:
-                        LOGGER.debug(
-                            "Move %s to %s.",
-                            orphan_key,
-                            covdata_dir.parent_dirname,
-                        )
-                        parent_covdata_dir = subdirs[covdata_dir.parent_dirname]
-                        parent_covdata_dir[orphan_key] = orphan_value
-                        del parent_covdata_dir[dirname]
-                        subdirs_to_remove.add(dirname)
-                else:
-                    LOGGER.debug(
-                        "Move content of %s to %s.",
-                        orphan_value.dirname,
-                        dirname,
-                    )
-                    # Replace the children with the orphan ones
-                    covdata_dir.data = orphan_value.data
-                    # Change the parent key of each new child element
-                    for new_child_value in covdata_dir.values():
-                        if isinstance(new_child_value, CoverageContainerDirectory):
-                            new_child_value.parent_dirname = dirname
-                    # Mark the key for removal.
-                    subdirs_to_remove.add(orphan_key)
 
-        for dirname in subdirs_to_remove:
-            del subdirs[dirname]
+    def sorted_coverage(
+        self,
+        sort_key: Literal["filename", "uncovered-number", "uncovered-percent"],
+        sort_reverse: bool,
+        by_metric: Literal["line", "branch", "decision"],
+        filename_uses_relative_pathname: bool = False,
+    ) -> list[CoverageContainer | FileCoverage]:
+        """Sort a coverage dict.
 
-        self.directories = list(subdirs.values())
+        sort_key ("filename", "uncovered-number", "uncovered-percent"): the values to sort by
+        sort_reverse (bool): reverse order if True
+        by_metric ("line", "branch", "decision"): select the metric to sort
+        filename_uses_relative_pathname (bool): for html, we break down a pathname to the
+            relative path, but not for other formats.
 
-
-class CoverageContainerDirectory(ContainerBase):
-    """Represent coverage information about a directory."""
-
-    __slots__ = "dirname", "parent_dirname", "data", "stats"
-
-    def __init__(self, dirname: str) -> None:
-        self.dirname: str = dirname
-        self.parent_dirname: str | None = None
-        self.data = CoverageDict[str, FileCoverage | CoverageContainerDirectory]()
-        self.stats: SummarizedStats = SummarizedStats.new_empty()
-
-    def __setitem__(
-        self, key: str, item: FileCoverage | CoverageContainerDirectory
-    ) -> None:
-        self.data[key] = item
-
-    def __getitem__(self, key: str) -> FileCoverage | CoverageContainerDirectory:
-        return self.data[key]
-
-    def __delitem__(self, key: str) -> None:
-        del self.data[key]
-
-    def __len__(self) -> int:
-        return len(self.data)
-
-    def values(self) -> ValuesView[FileCoverage | CoverageContainerDirectory]:
-        """Get the file coverage data objects."""
-        return self.data.values()
-
-    def items(self) -> ItemsView[str, FileCoverage | CoverageContainerDirectory]:
-        """Get the file coverage data items."""
-        return self.data.items()
-
-    def merge(self, other: CoverageContainerDirectory, options: MergeOptions) -> None:
+        returns: the sorted keys
         """
-        Merge CoverageContainerDirectory information and clear directory statistics.
 
-        Do not use 'other' objects afterwards!
-        """
-        self.data.merge(other.data, options)
+        return self.__sorted(
+            list(self.values()),
+            sort_key,
+            sort_reverse,
+            by_metric,
+            filename_uses_relative_pathname,
+        )
 
     @property
     def filename(self) -> str:
         """Helpful function for when we use this DirectoryCoverage in a union with FileCoverage"""
         return self.dirname
 
+    def merge_lines(self, options: Options) -> None:
+        """Merge line coverage for same line number. Remove the function information on merged lines."""
+        self._stats = None
+        for value in self.values():
+            if isinstance(value, FileCoverage):
+                value.merge_lines(
+                    is_file_excluded(
+                        "trace",
+                        value.filename,
+                        options.trace_include_filter,
+                        options.trace_exclude_filter,
+                    )
+                )
+            else:
+                value.merge_lines(options)
+
+    def merge(self, other: CoverageContainer, options: MergeOptions) -> None:
+        """
+        Merge CoverageContainer information.
+
+        Do not use 'other' objects afterwards!
+        """
+        self._stats = None
+        other._stats = None  # pylint: disable=protected-access
+        # Set parent of items before merging them
+        for item in other.values():
+            if isinstance(item, CoverageContainer):
+                item.parent = self
+        self.data.merge(other.data, options)
+
+    def insert_file_coverage(
+        self, filecov: FileCoverage, options: MergeOptions
+    ) -> None:
+        """Add a file coverage item."""
+        self._stats = None
+        dirname = os.path.dirname(filecov.filename) + os.path.sep
+        if dirname == self.dirname:
+            key = filecov.filename
+            if key in self.data:
+                value = self.data[key]
+                if not isinstance(value, FileCoverage):
+                    raise TypeError(
+                        f"Expected a FileCoverage object for key {key}, but got {type(value)}."
+                    )
+                value.merge(filecov, options)
+            else:
+                self.data[key] = filecov
+        else:
+            covdata_dirname = (
+                os.path.join(
+                    self.dirname,
+                    os.path.relpath(dirname, self.dirname).split(
+                        os.path.sep, maxsplit=1
+                    )[0],
+                )
+                + os.path.sep
+            )
+            if covdata_dirname in self.data:
+                covdata = self[covdata_dirname]
+            else:
+                covdata = self[covdata_dirname] = CoverageContainer(
+                    covdata_dirname,
+                    self,
+                )
+            if not isinstance(covdata, CoverageContainer):
+                raise TypeError(
+                    f"Expected a CoverageContainer object for key {covdata_dirname}, but got {type(covdata)}."
+                )
+            covdata.insert_file_coverage(filecov, options)
+
+    @property
+    def properties(self) -> dict[str, Any]:
+        """Get the user defined properties."""
+        return self._properties
+
+    @property
+    def stats(self) -> SummarizedStats:
+        """Create a coverage statistic from a coverage data object."""
+        if self._stats is None:
+            self._stats = SummarizedStats.new_empty()
+            for value in self.filecov(recurse=True):
+                self._stats += value.stats
+
+        return self._stats
+
     def line_coverage(self) -> CoverageStat:
-        """A simple wrapper function necessary for sort_coverage()."""
+        """A simple wrapper function necessary for sort_filecov()."""
         return self.stats.line
 
     def branch_coverage(self) -> CoverageStat:
-        """A simple wrapper function necessary for sort_coverage()."""
+        """A simple wrapper function necessary for sort_filecov()."""
         return self.stats.branch
 
     def decision_coverage(self) -> DecisionCoverageStat:
-        """A simple wrapper function necessary for sort_coverage()."""
+        """A simple wrapper function necessary for sort_filecov()."""
         return self.stats.decision

--- a/src/gcovr/data_model/coverage.py
+++ b/src/gcovr/data_model/coverage.py
@@ -2448,7 +2448,13 @@ class FunctionCoverage(CoverageBase):
 class FileCoverage(CoverageBase):
     """Represent coverage information about a file."""
 
-    __slots__ = "filename", "_functions", "_lines", "__linecov_by_function"
+    __slots__ = (
+        "filename",
+        "_functions",
+        "_lines",
+        "__properties",
+        "__linecov_by_function",
+    )
 
     def __init__(
         self,
@@ -2460,7 +2466,13 @@ class FileCoverage(CoverageBase):
         self.filename: str = filename
         self._functions = CoverageDict[FunctioncovKeyType, FunctionCoverage]()
         self._lines = CoverageDict[LinecovCollectionKeyType, LineCoverageCollection]()
+        self.__properties = dict[str, Any]()
         self.__linecov_by_function = CoverageDict[str, list[LineCoverage]]()
+
+    @property
+    def properties(self) -> dict[str, Any]:
+        """Get the user defined properties."""
+        return self.__properties
 
     def serialize(self, options: Options) -> dict[str, Any]:
         """Serialize the object."""

--- a/src/gcovr/formats/__init__.py
+++ b/src/gcovr/formats/__init__.py
@@ -104,9 +104,10 @@ def read_reports(options: Options) -> CoverageContainer:
 
     if any(
         filecov.diff is not filecov.CoverageDiff.UNDEFINED
-        for filecov in covdata.values()
+        for filecov in covdata.filecov(recurse=True)
     ) and any(
-        filecov.diff is filecov.CoverageDiff.UNDEFINED for filecov in covdata.values()
+        filecov.diff is filecov.CoverageDiff.UNDEFINED
+        for filecov in covdata.filecov(recurse=True)
     ):
         raise SanityCheckError("Some files have diff information, while others do not.")
 
@@ -140,6 +141,9 @@ def read_reports(options: Options) -> CoverageContainer:
 
     if options.merge_lines:
         covdata.merge_lines(options)
+
+    LOGGER.debug("Removing directories with only one child...")
+    covdata.remove_container_with_single_item()
 
     return covdata
 
@@ -323,6 +327,9 @@ def write_reports(covdata: CoverageContainer, options: Options) -> None:
                 default_output = None
         if output is not None:
             try:
+                # Clear the properties before calling each writer
+                for data in covdata.traverse():
+                    data.properties.clear()
                 format_writer(covdata, output.abspath)
             except RuntimeError as e:
                 writer_errors.append(str(e))

--- a/src/gcovr/formats/clover/write.py
+++ b/src/gcovr/formats/clover/write.py
@@ -50,7 +50,9 @@ def write_report(
     # Generate the coverage output (on a per-package basis)
     packages = dict[str, PackageData]()
 
-    for _, filecov in sorted(covdata.items()):
+    for filecov in sorted(
+        covdata.filecov(recurse=True), key=lambda filecov: filecov.filename
+    ):
         filename = filecov.presentable_filename(options.root_filter)
         if "/" in filename:
             directory, fname = filename.rsplit("/", 1)

--- a/src/gcovr/formats/cobertura/read.py
+++ b/src/gcovr/formats/cobertura/read.py
@@ -40,7 +40,7 @@ def read_report(options: Options) -> CoverageContainer:
     """merge a coverage from multiple reports in the format
     compatible with Cobertura"""
 
-    covdata = CoverageContainer()
+    covdata = CoverageContainer(options.root)
     if len(options.cobertura_tracefile) == 0:
         return covdata
 

--- a/src/gcovr/formats/cobertura/write.py
+++ b/src/gcovr/formats/cobertura/write.py
@@ -55,7 +55,9 @@ def write_report(
     packages_elem = etree.SubElement(root_elem, "packages")
     packages = dict[str, PackageData]()
 
-    for _, filecov in sorted(covdata.items()):
+    for filecov in sorted(
+        covdata.filecov(recurse=True), key=lambda filecov: filecov.filename
+    ):
         filename = filecov.presentable_filename(options.root_filter)
         if "/" in filename:
             directory, fname = filename.rsplit("/", 1)

--- a/src/gcovr/formats/coveralls/write.py
+++ b/src/gcovr/formats/coveralls/write.py
@@ -162,7 +162,9 @@ def write_report(
 
     # Loop through each coverage file collecting details
     json_dict["source_files"] = []
-    for _, filecov in sorted(covdata.items()):
+    for filecov in sorted(
+        covdata.filecov(recurse=True), key=lambda filecov: filecov.filename
+    ):
         # File data has been compiled
         json_dict["source_files"].append(_make_source_file(filecov, options))
 

--- a/src/gcovr/formats/csv/write.py
+++ b/src/gcovr/formats/csv/write.py
@@ -34,10 +34,11 @@ def write_report(
     # The CSV writer uses as default line endings "\r\n" (according to
     # https://datatracker.ietf.org/doc/html/rfc4180)
     with open_text_for_writing(output_file, "coverage.csv", newline="") as fh:
-        sorted_keys = covdata.sort_coverage(
+        filecov_list = covdata.sorted_filecov(
             sort_key=options.sort_key,
             sort_reverse=options.sort_reverse,
             by_metric="branch" if options.sort_branches else "line",
+            recurse=True,
         )
 
         writer = csv.writer(fh)
@@ -55,9 +56,9 @@ def write_report(
                 "function_percent",
             )
         )
-        for key in sorted_keys:
-            filename = covdata[key].presentable_filename(options.root_filter)
-            stats = covdata[key].stats
+        for filecov in filecov_list:
+            filename = filecov.presentable_filename(options.root_filter)
+            stats = filecov.stats
             writer.writerow(
                 [
                     filename,

--- a/src/gcovr/formats/gcov/read.py
+++ b/src/gcovr/formats/gcov/read.py
@@ -83,7 +83,11 @@ def read_report(options: Options) -> CoverageContainer:
     # Get coverage data
     with Workers(
         options.gcov_parallel,
-        lambda: {"covdata": CoverageContainer(), "to_erase": set(), "options": options},
+        lambda: {
+            "covdata": CoverageContainer(options.root),
+            "to_erase": set(),
+            "options": options,
+        },
     ) as pool:
         LOGGER.debug("Pool started with %d threads", pool.size())
         for filename in sorted(datafiles):
@@ -96,7 +100,7 @@ def read_report(options: Options) -> CoverageContainer:
             raise exc from None
 
     to_erase = set()
-    covdata = CoverageContainer()
+    covdata = CoverageContainer(options.root)
     for context in contexts:
         covdata.merge(context["covdata"], get_merge_mode_from_options(options))
         to_erase.update(context["to_erase"])

--- a/src/gcovr/formats/html/write.py
+++ b/src/gcovr/formats/html/write.py
@@ -43,7 +43,7 @@ from pygments.token import _TokenType, Token
 from pygments.style import Style
 from pygments.styles.default import DefaultStyle
 
-from ...data_model.container import CoverageContainer, CoverageContainerDirectory
+from ...data_model.container import CoverageContainer
 from ...data_model.coverage import (
     DecisionCoverageConditional,
     DecisionCoverageSwitch,
@@ -369,7 +369,10 @@ def write_report(
     data["SHOW_DECISION"] = show_decision
     data["SHOW_CALLS"] = show_calls
     data["SHOW_CONDITION_COVERAGE"] = any(
-        filter(lambda filecov: filecov.condition_coverage().total > 0, covdata.values())  # type: ignore [arg-type]
+        filter(
+            lambda filecov: filecov.condition_coverage().total > 0,  # type: ignore [arg-type]
+            covdata.filecov(recurse=True),
+        )
     )
     data["USE_BLOCK_IDS"] = options.html_block_ids
     data["COVERAGE_MED"] = medium_threshold
@@ -458,43 +461,52 @@ def write_report(
 
     # Generate the coverage output (on a per-package basis)
     # source_dirs = set()
-    files = []
-    filtered_fname = ""
-    sorted_keys = covdata.sort_coverage(
+    filecov_list = covdata.sorted_filecov(
         sort_key=options.sort_key,
         sort_reverse=options.sort_reverse,
         by_metric="branch" if options.sort_branches else "line",
         filename_uses_relative_pathname=True,
+        recurse=True,
     )
 
-    if options.html_nested:
-        covdata.populate_directories(sorted_keys, options.root_filter)
+    dircov_list = list(covdata.dircov(recurse=True)) if options.html_nested else []
 
-    cdata_fname = dict[str, str]()
-    cdata_sourcefile = dict[str, str | None]()
-    for fname in sorted_keys + [v.dirname for v in covdata.directories]:
-        filtered_fname = options.root_filter.sub("", fname)
-        if filtered_fname != "":
-            files.append(filtered_fname)
-        cdata_fname[fname] = force_unix_separator(filtered_fname)
+    files = []
+    sourcefiles = dict[str, str | None]()
+
+    def _store_filenames(cdata: CoverageContainer | FileCoverage) -> None:
+        """Store the filenames and the source file links for the report."""
+        filtered_name = options.root_filter.sub("", cdata.filename)
+        if filtered_name != "":
+            files.append(filtered_name)
+        cdata.properties["filtered_name"] = force_unix_separator(filtered_name)
         if options.html_details or options.html_nested or options.html_single_page:
-            if os.path.normpath(fname) == os.path.normpath(options.root_dir):
-                cdata_sourcefile[fname] = (
+            if os.path.normpath(cdata.filename) == os.path.normpath(options.root_dir):
+                cdata.properties["sourcefile"] = (
                     output_file[: -len(GZIP_SUFFIX)]
                     if output_file.endswith(GZIP_SUFFIX)
                     else output_file
                 )
             else:
-                cdata_sourcefile[fname] = _make_short_source_filename(
-                    output_file, filtered_fname.rstrip(os.sep)
+                cdata.properties["sourcefile"] = _make_short_source_filename(
+                    output_file, filtered_name.rstrip(os.sep)
                 )
-                if options.html_single_page and cdata_sourcefile[fname] is not None:
+                if (
+                    options.html_single_page
+                    and cdata.properties["sourcefile"] is not None
+                ):
                     # Remove the prefix to get shorter links
-                    cdata_sourcefile[fname] = str(cdata_sourcefile[fname]).split(
-                        ".", maxsplit=1
-                    )[1]
+                    cdata.properties["sourcefile"] = str(
+                        cdata.properties["sourcefile"]
+                    ).split(".", maxsplit=1)[1]
         else:
-            cdata_sourcefile[fname] = None
+            cdata.properties["sourcefile"] = None
+        sourcefiles[cdata.properties["filtered_name"]] = cdata.properties["sourcefile"]
+
+    for filecov in filecov_list:
+        _store_filenames(filecov)
+    for dircov in dircov_list:
+        _store_filenames(dircov)
 
     # Define the common root directory, which may differ from options.root_dir
     # when source files share a common prefix.
@@ -504,15 +516,17 @@ def write_report(
         if common_dir != "":
             root_directory = common_dir
     else:
-        directory, _ = os.path.split(filtered_fname)
+        directory, _ = os.path.split(
+            files[0] if files else options.root_filter.sub("", covdata.dirname)
+        )
         if directory != "":
             root_directory = str(directory) + os.sep
 
     previous_fname: str | None = None
     previous_link_report: str | None = None
-    for fname in sorted(cdata_sourcefile.keys()):
+    for fname in sorted(sourcefiles):
         root_info.navigation[fname] = (previous_link_report, None)
-        link_report = cdata_sourcefile[fname]
+        link_report = sourcefiles[fname]
         if link_report is not None:
             if root_info.relative_anchors or root_info.single_page:
                 link_report = os.path.basename(link_report)
@@ -532,20 +546,16 @@ def write_report(
             root_info,
             output_file,
             covdata,
-            sorted_keys,
-            cdata_fname,
-            cdata_sourcefile,
+            filecov_list,
             data,
         )
     else:
-        if options.html_nested and covdata.directories:
+        if dircov_list:
             write_directory_pages(
                 options,
                 root_info,
                 output_file,
                 covdata,
-                cdata_fname,
-                cdata_sourcefile,
                 data,
             )
         else:
@@ -553,11 +563,8 @@ def write_report(
                 options,
                 root_info,
                 output_file,
-                covdata,
-                cdata_fname,
-                cdata_sourcefile,
                 data,
-                sorted_keys,
+                filecov_list,
             )
             if not options.html_details:
                 return
@@ -567,8 +574,6 @@ def write_report(
             root_info,
             functions_output_file,
             covdata,
-            cdata_fname,
-            cdata_sourcefile,
             data,
         )
 
@@ -577,20 +582,13 @@ def write_root_page(
     options: Options,
     root_info: RootInfo,
     output_file: str,
-    covdata: CoverageContainer,
-    cdata_fname: dict[str, str],
-    cdata_sourcefile: dict[str, Any],
     data: dict[str, Any],
-    sorted_keys: list[str],
+    filecov_list: list[FileCoverage],
 ) -> None:
     """Generate the root HTML file that contains the high level report."""
     files = []
-    for fname in sorted_keys:
-        files.append(
-            get_coverage_data(
-                root_info, covdata[fname], cdata_sourcefile[fname], cdata_fname[fname]
-            )
-        )
+    for filecov in filecov_list:
+        files.append(get_coverage_data(root_info, filecov))
 
     html_string = (
         templates(options)
@@ -608,16 +606,16 @@ def write_source_pages(
     root_info: RootInfo,
     functions_output_file: str,
     covdata: CoverageContainer,
-    cdata_fname: dict[str, str],
-    cdata_sourcefile: dict[str, Any],
     data: dict[str, Any],
 ) -> None:
     """Write a page for each source file."""
     error_no_files_not_found = 0
     all_functions = {}
-    for fname, filecov in sorted(covdata.items()):
+    for filecov in sorted(
+        covdata.filecov(recurse=True), key=lambda filecov: filecov.filename
+    ):
         file_data, functions, file_not_found = get_file_data(
-            options, root_info, fname, cdata_fname, cdata_sourcefile, filecov
+            options, root_info, filecov
         )
         all_functions.update(functions)
         if file_not_found:
@@ -629,7 +627,7 @@ def write_source_pages(
             .render(**data, **file_data)
         )
         with open_text_for_writing(
-            cdata_sourcefile[fname],
+            filecov.properties["sourcefile"],
             encoding=options.html_encoding,
             errors="xmlcharrefreplace",
         ) as fh:
@@ -659,19 +657,13 @@ def write_directory_pages(
     root_info: RootInfo,
     output_file: str,
     covdata: CoverageContainer,
-    cdata_fname: dict[str, str],
-    cdata_sourcefile: dict[str, Any],
     data: dict[str, Any],
 ) -> None:
     """Write a page for each directory."""
-    # The first directory is the shortest one --> This is the root dir
-    root_key = next(iter(sorted([d.dirname for d in covdata.directories])))
+    root_key = covdata.dirname
 
-    directory_data = {}
-    for dircov in covdata.directories:
-        directory_data = get_directory_data(
-            options, root_info, cdata_fname, cdata_sourcefile, dircov
-        )
+    for dircov in covdata.dircov(recurse=True):
+        directory_data = get_directory_data(options, root_info, dircov)
         html_string = (
             templates(options)
             .get_template("directory_page.html")
@@ -680,13 +672,8 @@ def write_directory_pages(
         filename = None
         if dircov.dirname in [root_key, ""]:
             filename = output_file
-        elif dircov.dirname in cdata_sourcefile:
-            filename = cdata_sourcefile[dircov.dirname]
         else:
-            LOGGER.warning(
-                "There's a subdirectory %r that there's no source files within it",
-                dircov.dirname,
-            )
+            filename = dircov.properties["sourcefile"]
 
         if filename:
             with open_text_for_writing(
@@ -700,18 +687,18 @@ def write_single_page(
     root_info: RootInfo,
     output_file: str,
     covdata: CoverageContainer,
-    sorted_keys: list[str],
-    cdata_fname: dict[str, str],
-    cdata_sourcefile: dict[str, Any],
+    filecov_list: list[FileCoverage],
     data: dict[str, Any],
 ) -> None:
     """Write a single page HTML report."""
     error_no_files_not_found = 0
     files = []
     all_functions = {}
-    for fname, filecov in sorted(covdata.items()):
+    for filecov in sorted(
+        covdata.filecov(recurse=True), key=lambda filecov: filecov.filename
+    ):
         file_data, functions, file_not_found = get_file_data(
-            options, root_info, fname, cdata_fname, cdata_sourcefile, filecov
+            options, root_info, filecov
         )
         all_functions.update(functions)
         if file_not_found:
@@ -720,20 +707,12 @@ def write_single_page(
         files.append(file_data)
 
     all_files = []
-    for fname in sorted_keys:
-        all_files.append(
-            get_coverage_data(
-                root_info, covdata[fname], cdata_sourcefile[fname], cdata_fname[fname]
-            )
-        )
+    for filecov in filecov_list:
+        all_files.append(get_coverage_data(root_info, filecov))
     directories = list[dict[str, Any]]([{"entries": all_files}])
-    if not root_info.static_report:
-        for dircov in covdata.directories:
-            directories.append(
-                get_directory_data(
-                    options, root_info, cdata_fname, cdata_sourcefile, dircov
-                )
-            )
+    if not root_info.static_report and options.html_nested:
+        for dircov in covdata.dircov(recurse=True):
+            directories.append(get_directory_data(options, root_info, dircov))
     if len(directories) == 1:
         directories[0]["dirname"] = "/"  # We need this to have a correct id in HTML.
 
@@ -760,9 +739,7 @@ def write_single_page(
 
 def get_coverage_data(
     root_info: RootInfo,
-    cdata: CoverageContainerDirectory | FileCoverage,
-    link_report: str,
-    cdata_fname: str,
+    cdata: CoverageContainer | FileCoverage,
     relative_path: str = "",
 ) -> dict[str, Any]:
     """Get the coverage data"""
@@ -852,7 +829,7 @@ def get_coverage_data(
     }
     display_filename = force_unix_separator(
         os.path.relpath(
-            os.path.realpath(cdata_fname),
+            os.path.realpath(cdata.properties["filtered_name"]),
             os.path.realpath(
                 os.path.join(root_info.directory, relative_path)
                 if relative_path
@@ -861,9 +838,10 @@ def get_coverage_data(
         )
     )
 
-    if link_report is not None:
+    link_report = None
+    if cdata.properties["sourcefile"] is not None:
         if root_info.relative_anchors or root_info.single_page:
-            link_report = os.path.basename(link_report)
+            link_report = os.path.basename(cdata.properties["sourcefile"])
 
     return {
         "filename": display_filename,
@@ -881,12 +859,10 @@ def get_coverage_data(
 def get_directory_data(
     options: Options,
     root_info: RootInfo,
-    cdata_fname: dict[str, str],
-    cdata_sourcefile: dict[str, str],
-    covdata_dir: CoverageContainerDirectory,
+    covdata: CoverageContainer,
 ) -> dict[str, Any]:
     """Get the data for a directory to generate the HTML"""
-    relative_path = cdata_fname[covdata_dir.dirname]
+    relative_path = covdata.properties["filtered_name"]
     if relative_path == ".":
         relative_path = ""
     elif relative_path.startswith(root_info.directory):
@@ -894,15 +870,15 @@ def get_directory_data(
     directory_data = dict[str, Any](
         {
             "dirname": (
-                cdata_sourcefile[covdata_dir.dirname]
-                if cdata_fname[covdata_dir.dirname]
+                covdata.properties["sourcefile"]
+                if covdata.properties["filtered_name"]
                 else "/"
             ),
             "relative_path": relative_path,
         }
     )
 
-    sorted_keys = covdata_dir.sort_coverage(
+    covdata_list = covdata.sorted_coverage(
         sort_key=options.sort_key,
         sort_reverse=options.sort_reverse,
         by_metric="branch" if options.sort_branches else "line",
@@ -910,17 +886,8 @@ def get_directory_data(
     )
 
     files = []
-    for key in sorted_keys:
-        fname = covdata_dir[key].filename
-        files.append(
-            get_coverage_data(
-                root_info,
-                covdata_dir[key],
-                cdata_sourcefile[fname],
-                cdata_fname[fname],
-                relative_path,
-            )
-        )
+    for cdata in covdata_list:
+        files.append(get_coverage_data(root_info, cdata, relative_path))
 
     directory_data["entries"] = files
 
@@ -930,9 +897,6 @@ def get_directory_data(
 def get_file_data(
     options: Options,
     root_info: RootInfo,
-    filename: str,
-    cdata_fname: dict[str, str],
-    cdata_sourcefile: dict[str, str],
     filecov: FileCoverage,
 ) -> tuple[dict[str, Any], dict[tuple[str, str, int], dict[str, Any]], bool]:
     """Get the data for a file to generate the HTML"""
@@ -940,16 +904,17 @@ def get_file_data(
 
     file_data = dict[str, Any](
         {
-            "fname": filename,
-            "filename": cdata_fname[filename],
-            "html_filename": os.path.basename(cdata_sourcefile[filename]),
+            "fname": filecov.properties["filtered_name"],
+            "filename": filecov.properties["filtered_name"],
+            "html_filename": os.path.basename(filecov.properties["sourcefile"]),
             "source_lines": [],
             "function_list": [],
         }
     )
     file_data.update(
         get_coverage_data(
-            root_info, filecov, cdata_sourcefile[filename], cdata_fname[filename]
+            root_info,
+            filecov,
         )
     )
     if filecov.diff != filecov.CoverageDiff.UNDEFINED:
@@ -960,8 +925,8 @@ def get_file_data(
         for lineno in functioncov.linenos:
             f_data = dict[str, Any]()
             f_data["name"] = functioncov.name
-            f_data["filename"] = cdata_fname[filename]
-            f_data["html_filename"] = os.path.basename(cdata_sourcefile[filename])
+            f_data["filename"] = filecov.properties["filtered_name"]
+            f_data["html_filename"] = os.path.basename(filecov.properties["sourcefile"])
             f_data["line"] = lineno
             f_data["execution_count"] = functioncov.execution_count[lineno]
             f_data["blocks_percent"] = functioncov.blocks_percent[lineno]
@@ -993,13 +958,15 @@ def get_file_data(
         file_not_found = True
         try:
             with open(
-                filename,
+                filecov.filename,
                 "r",
                 encoding=options.source_encoding,
                 errors="replace",
             ) as source_file:
                 file_not_found = False
-                lines = formatter.highlighter_for_file(filename)(source_file.read())
+                lines = formatter.highlighter_for_file(filecov.filename)(
+                    source_file.read()
+                )
                 lineno = 0
                 for lineno, line in enumerate(lines, 1):
                     file_data["source_lines"].append(
@@ -1013,12 +980,12 @@ def get_file_data(
                 if lineno < max_line_from_cdata:
                     LOGGER.warning(
                         "File %s has %d line(s) but coverage data has %d line(s).",
-                        filename,
+                        filecov.filename,
                         lineno,
                         max_line_from_cdata,
                     )
         except OSError as e:
-            if filename.endswith("<stdin>"):
+            if filecov.filename.endswith("<stdin>"):
                 file_not_found = False
                 file_info = "!!! File from stdin !!!"
             else:

--- a/src/gcovr/formats/jacoco/write.py
+++ b/src/gcovr/formats/jacoco/write.py
@@ -37,7 +37,9 @@ def write_report(
     # Generate the coverage output (on a per-package basis)
     packages = dict[str, PackageData]()
 
-    for _, filecov in sorted(covdata.items()):
+    for filecov in sorted(
+        covdata.filecov(recurse=True), key=lambda filecov: filecov.filename
+    ):
         filename = filecov.presentable_filename(options.root_filter)
         if "/" in filename:
             directory, fname = filename.rsplit("/", 1)

--- a/src/gcovr/formats/json/read.py
+++ b/src/gcovr/formats/json/read.py
@@ -38,7 +38,7 @@ from ...utils import GZIP_SUFFIX
 def read_report(options: Options) -> CoverageContainer:
     """Read trace files into internal data model."""
 
-    covdata = CoverageContainer()
+    covdata = CoverageContainer(options.root)
     if len(options.json_tracefile) != 0:
         datafiles = list[str]()
 

--- a/src/gcovr/formats/json/write.py
+++ b/src/gcovr/formats/json/write.py
@@ -66,21 +66,22 @@ def write_summary_report(
     json_dict["files"] = files
 
     # Data
-    sorted_keys = covdata.sort_coverage(
+    filecov_list = covdata.sorted_filecov(
         sort_key=options.sort_key,
         sort_reverse=options.sort_reverse,
         by_metric="branch" if options.sort_branches else "line",
+        recurse=True,
     )
 
-    for key in sorted_keys:
-        filename = covdata[key].presentable_filename(options.root_filter)
+    for filecov in filecov_list:
+        filename = filecov.presentable_filename(options.root_filter)
         if options.json_base:
             filename = "/".join([options.json_base, filename])
 
         files.append(
             {
                 "filename": filename,
-                **covdata[key].stats.serialize(None, options),
+                **filecov.stats.serialize(None, options),
             }
         )
 

--- a/src/gcovr/formats/lcov/write.py
+++ b/src/gcovr/formats/lcov/write.py
@@ -37,10 +37,11 @@ def write_report(
     """produce gcovr csv report"""
 
     with open_text_for_writing(output_file, "coverage.lcov") as fh:
-        sorted_keys = covdata.sort_coverage(
+        filecov_list = covdata.sorted_filecov(
             sort_key=options.sort_key,
             sort_reverse=options.sort_reverse,
             by_metric="branch" if options.sort_branches else "line",
+            recurse=True,
         )
         if options.lcov_comment is not None:
             # #comment_string
@@ -51,8 +52,7 @@ def write_report(
         def suffix() -> str:
             return f"_{lineno}" if len(linenos) > 1 else ""
 
-        for key in sorted_keys:
-            filecov = covdata[key]
+        for filecov in filecov_list:
             filename = force_unix_separator(filecov.filename)
 
             # SF:<path to the source file>

--- a/src/gcovr/formats/llvm/read.py
+++ b/src/gcovr/formats/llvm/read.py
@@ -76,7 +76,7 @@ def read_report(options: Options) -> CoverageContainer:
             if profraw_file not in profraw_files:
                 profraw_files.append(profraw_file)
 
-    covdata = CoverageContainer()
+    covdata = CoverageContainer(options.root)
 
     merge_options = get_merge_mode_from_options(options)
     for profraw_file in profraw_files:
@@ -118,7 +118,7 @@ def read_report(options: Options) -> CoverageContainer:
             for profraw_file in profraw_files:
                 os.unlink(profraw_file)
 
-    for filecov in covdata.values():
+    for filecov in covdata.filecov(recurse=True):
         source_lines = read_source_file(
             options.source_encoding,
             filecov.filename,
@@ -255,7 +255,7 @@ def read_json(
     version: tuple[int, ...],
 ) -> CoverageContainer:
     """Read one clang JSON coverage report."""
-    covdata = CoverageContainer()
+    covdata = CoverageContainer(options.root)
     for data in json_data["data"]:
         if any(
             "mcdc_records" in entry
@@ -269,7 +269,7 @@ def read_json(
         read_json_files(data_source, data, options, merge_options, covdata, version)
         read_json_functions(data_source, data, options, merge_options, covdata)
 
-    for filecov in covdata.values():
+    for filecov in covdata.filecov(recurse=True):
         activate_trace_logging = not is_file_excluded(
             "trace",
             filecov.filename,

--- a/src/gcovr/formats/markdown/write.py
+++ b/src/gcovr/formats/markdown/write.py
@@ -56,15 +56,16 @@ def write_report(
         "summary": _summary_from_stats(covdata.stats, options),
     }
 
-    sorted_keys = covdata.sort_coverage(
+    filecov_list = covdata.sorted_filecov(
         sort_key=options.sort_key,
         sort_reverse=options.sort_reverse,
         by_metric="branch" if options.sort_branches else "line",
+        recurse=True,
     )
     data["entries"] = list[dict[str, Any]]()
-    for key in sorted_keys:
-        summary = _summary_from_stats(covdata[key].stats, options)
-        summary["filename"] = covdata[key].presentable_filename(options.root_filter)
+    for filecov in filecov_list:
+        summary = _summary_from_stats(filecov.stats, options)
+        summary["filename"] = filecov.presentable_filename(options.root_filter)
         data["entries"].append(summary)
 
     markdown_string = templates().get_template("report_template.md.j2").render(**data)

--- a/src/gcovr/formats/sonarqube/write.py
+++ b/src/gcovr/formats/sonarqube/write.py
@@ -32,14 +32,19 @@ def write_report(
     """produce an XML report in the SonarQube generic coverage format"""
 
     if not any(
-        filter(lambda filecov: filecov.condition_coverage().total > 0, covdata.values())  # type: ignore [arg-type]
+        filter(
+            lambda filecov: filecov.condition_coverage().total > 0,  # type: ignore [arg-type]
+            covdata.filecov(recurse=True),
+        )
     ) and (options.sonarqube_metric == "condition"):
         LOGGER.warning("No condition coverage data found.")
 
     root_elem = etree.Element("coverage")
     root_elem.set("version", "1")
 
-    for _, filecov in sorted(covdata.items()):
+    for filecov in sorted(
+        covdata.filecov(recurse=True), key=lambda filecov: filecov.filename
+    ):
         filename = filecov.presentable_filename(options.root_filter)
 
         file_node = etree.Element("file")

--- a/src/gcovr/formats/txt/write.py
+++ b/src/gcovr/formats/txt/write.py
@@ -61,10 +61,11 @@ def write_report(
 
         fh.write("-" * LINE_WIDTH + "\n")
         # Data
-        sorted_keys = covdata.sort_coverage(
+        filecov_list = covdata.sorted_filecov(
             sort_key=options.sort_key,
             sort_reverse=options.sort_reverse,
             by_metric=options.txt_metric,
+            recurse=True,
         )
         if diff_report:
             fh.write(
@@ -73,8 +74,8 @@ def write_report(
                 + SEPARATOR
                 + "Lines\n"
             )
-            for key in sorted_keys:
-                txt = _diff_report_file(covdata[key], options)
+            for filecov in filecov_list:
+                txt = _diff_report_file(filecov, options)
                 fh.write(txt + "\n")
         else:
             if options.txt_metric == "branch":
@@ -101,8 +102,8 @@ def write_report(
             fh.write("-" * LINE_WIDTH + "\n")
 
             total_stat = CoverageStat.new_empty()
-            for key in sorted_keys:
-                (stat, txt) = _report_file(covdata[key], options)
+            for filecov in filecov_list:
+                (stat, txt) = _report_file(filecov, options)
                 total_stat += stat
                 fh.write(txt + "\n")
 
@@ -125,7 +126,7 @@ def write_summary_report(
             for current_diff in FileCoverage.CoverageDiff:
                 filecov_list = [
                     filecov
-                    for filecov in covdata.values()
+                    for filecov in covdata.filecov(recurse=True)
                     if filecov.diff == current_diff
                 ]
                 if filecov_list:

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -27,6 +27,7 @@ import re
 import pytest
 
 from gcovr.__main__ import main
+from gcovr.data_model.coverage import FileCoverage
 from gcovr.version import __version__
 from gcovr.data_model.version import FORMAT_VERSION
 
@@ -689,6 +690,7 @@ def test_import_valid_cobertura_file(tmp_path: Path) -> None:
             {
                 "cobertura_tracefile": [filename],
                 "include_filter": [re.compile(".")],
+                "root": str(tmp_path),
             }
         ]
     )
@@ -697,15 +699,16 @@ def test_import_valid_cobertura_file(tmp_path: Path) -> None:
     assert covdata is not None
     testfile = os.path.join(tmp_path, testfile)
     assert testfile in covdata
-    filecov = covdata[testfile]
-    assert len(list(filecov.lines())) == 10
+    cov = covdata[testfile]
+    assert isinstance(cov, FileCoverage)
+    assert len(list(cov.lines())) == 10
     for line, count, branches in [
         (7, 1, None),
         (9, 3, None),
         (16, 0, None),
         (13, 2, [1, 0]),
     ]:
-        linecovs = filecov.get_line(line)
+        linecovs = cov.get_line(line)
         assert linecovs is not None
         assert linecovs.count == count
         branchcov_list = list(linecovs[""].branches())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -23,7 +23,7 @@
 import io
 import re
 import textwrap
-from typing import Any, Iterable, Optional, Union
+from typing import Any, Iterable
 
 import pytest
 
@@ -160,7 +160,7 @@ def test_unknown_keys() -> None:
     ids=lambda test_spec: test_spec[0],
 )
 def test_option_with_boolean_values(
-    test_spec: tuple[str, str, str, Union[bool, int], Union[bool, int], bool],
+    test_spec: tuple[str, str, str, bool | int, bool | int, bool],
 ) -> None:
     r"""
     Boolean values need special consideration.
@@ -329,7 +329,7 @@ class Ref:
     This is useful to represent the presence of a value that may be None.
     """
 
-    def __init__(self, value: Union[Optional[str], list[str]]) -> None:
+    def __init__(self, value: None | str | list[str]) -> None:
         self.value = value
 
 
@@ -345,7 +345,7 @@ class Ref:
     ids=lambda test_spec: test_spec[0],
 )
 def test_namespace_merging_overwriting(
-    test_spec: tuple[str, list[Any], Optional[str]],
+    test_spec: tuple[str, list[Any], str | None],
 ) -> None:
     _, input_values, result = test_spec
 
@@ -380,7 +380,7 @@ def test_namespace_merging_overwriting(
     ids=lambda test_spec: test_spec[0],
 )
 def test_namespace_merging_appending(
-    test_spec: tuple[str, list[Any], Optional[list[str]]],
+    test_spec: tuple[str, list[Any], list[str] | None],
 ) -> None:
     _, input_values, result = test_spec
 


### PR DESCRIPTION
As a preparation for https://github.com/gcovr/gcovr/pull/1248#issuecomment-4072736178 the data model need to be restructured to create a data tree. The functionality is nearly the same like the function `populate_directories` did with a flat list.
Also add a properties element which is cleared after each report format to store meta data for the report generation and update the dicts in the HTML report to use it.