### PR TITLE
Fix runtime issue with many functions in a single file

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,8 @@ New features and notable changes:
 
 Bug fixes and small improvements:
 
+- Fix runtime problem introduced with 8.4. (:issue:`1270`)
+
 Documentation:
 
 - Add section about ``gcov`` options which should not be used to FAQ. (:issue:`1237`)
@@ -40,6 +42,10 @@ Internal changes:
 
 8.6 (13 January 2026)
 ---------------------
+
+Known bugs:
+
+- :ref:`fix_1270`
 
 Breaking changes:
 
@@ -65,6 +71,7 @@ Known bugs:
 
 - :ref:`fix_1229`
 - :ref:`fix_1231`
+- :ref:`fix_1270`
 
 Breaking changes:
 
@@ -169,6 +176,7 @@ Known bugs:
 - :ref:`fix_1197`
 - :ref:`fix_1206_1`
 - :ref:`fix_1206_2`
+- :ref:`fix_1270`
 
 Breaking changes:
 

--- a/doc/source/known_bugs.rst
+++ b/doc/source/known_bugs.rst
@@ -9,6 +9,25 @@ Known bugs
 This list contains bugs for version 6.0 and newer, always check the latest
 version of this file available `here <https://gcovr.com/en/latest/known_bugs.html>`_.
 
+.. _fix_1270:
+
+Significant performance regression with many functions in a single file
+-----------------------------------------------------------------------
+
+.. list-table::
+
+   * - Introduced
+     - :ref:`release_8_4`
+
+   * - Fixed
+     - :ref:`next_release`, :issue:`1270`
+
+The runtime of ``gcovr`` increased significant if a file has many lines and functions.
+
+In :issue:`1268` the file had ~180.000 functions and ~600.000 lines from template
+expansion out of less than 100 code lines. The runtime increased from less than 1 minute to 4-5 hours.
+
+
 .. _fix_1231:
 
 Merge assertion error for functions defined in multiple lines

--- a/src/gcovr/data_model/coverage.py
+++ b/src/gcovr/data_model/coverage.py
@@ -2608,12 +2608,11 @@ class FileCoverage(CoverageBase):
                         min(functioncov.execution_count.keys()),
                         functioncov.name,
                     )
+
+                yield from sorted(self._functions.values(), key=key_func)
             else:
+                yield from sorted(self._functions.values(), key=key)
 
-                def key_func(functioncov: FunctionCoverage) -> Any:
-                    return key(functioncov)
-
-            yield from sorted(self._functions.values(), key=key_func)
         else:
             yield from self._functions.values()
 
@@ -2776,14 +2775,30 @@ class FileCoverage(CoverageBase):
 
         return functioncov
 
+    def __linecov_of_function(
+        self, functioncov: FunctionCoverage
+    ) -> Iterable[LineCoverage]:
+        """Iterate over the lines of a function."""
+        if (
+            functioncov.demangled_name is not None
+            and functioncov.demangled_name in self.__linecov_by_function
+        ):
+            yield from self.__linecov_by_function[functioncov.demangled_name]
+        if (
+            functioncov.mangled_name is not None
+            and functioncov.mangled_name in self.__linecov_by_function
+        ):
+            yield from self.__linecov_by_function[functioncov.mangled_name]
+
+        return
+
     def remove_function_coverage(self, functioncov: FunctionCoverage) -> None:
         """Remove line coverage objects."""
         # Remove function and exclude the related lines
         del self._functions[functioncov.key]
         # Iterate over a shallow copy
-        for linecov in list(self.linecov()):
-            if functioncov.is_function(linecov.function_name):
-                self.remove_line_coverage(linecov)
+        for linecov in list(self.__linecov_of_function(functioncov)):
+            self.remove_line_coverage(linecov)
 
     def filter_for_function(self, functioncov: FunctionCoverage) -> FileCoverage:
         """Get a file coverage object reduced to a single function"""
@@ -2795,17 +2810,12 @@ class FileCoverage(CoverageBase):
         # pylint: disable=protected-access
         filecov._functions[functioncov.key] = functioncov
 
-        def add_linecov_to_collection(linecov: LineCoverage) -> None:
-            """Add a new linecov item."""
+        for linecov in self.__linecov_of_function(functioncov):
             lineno = linecov.lineno
             filecov._lines[lineno] = LineCoverageCollection(
                 filecov, linecov.data_sources, lineno=lineno
             )
             filecov._lines[lineno][linecov.key] = linecov
-
-        for linecov in self.raw_linecov():
-            if functioncov.is_function(linecov.function_name):
-                add_linecov_to_collection(linecov)
 
         return filecov
 

--- a/src/gcovr/formats/html/write.py
+++ b/src/gcovr/formats/html/write.py
@@ -956,6 +956,7 @@ def get_file_data(
     functions = dict[tuple[FunctioncovKeyType, str, int], dict[str, Any]]()
     # Only use demangled names (containing a brace)
     for functioncov in filecov.functioncov(key=lambda functioncov: functioncov.key):
+        function_stats = filecov.filter_for_function(functioncov).stats
         for lineno in functioncov.linenos:
             f_data = dict[str, Any]()
             f_data["name"] = functioncov.name
@@ -965,7 +966,6 @@ def get_file_data(
             f_data["execution_count"] = functioncov.execution_count[lineno]
             f_data["blocks_percent"] = functioncov.blocks_percent[lineno]
             f_data["excluded"] = functioncov.excluded[lineno]
-            function_stats = filecov.filter_for_function(functioncov).stats
             f_data["line_coverage"] = function_stats.line.percent_or(100.0)
             f_data["branch_coverage"] = function_stats.branch.percent_or("-")
             f_data["condition_coverage"] = function_stats.condition.percent_or("-")


### PR DESCRIPTION
With #1194 a dictionary with the lines of a function was introduced. This dictionary wasn't used in filter_for_function.

Fixes #1268