### PR TITLE
boost theme: fix issues related to optional data

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,7 +27,7 @@ Bug fixes and small improvements:
 
 - Fix runtime problem introduced with 8.4. (:issue:`1270`)
 - Fix boost HTML details and simple output. (:issue:`1274`)
-- Fix boost HTML optional data (conditions, decisions, calls) output support. (:issue:`1277`)
+- Fix boost HTML support for Conditions, Decisions and Calls optional stats. (:issue:`1277`)
 
 Documentation:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,7 @@ Bug fixes and small improvements:
 
 - Fix runtime problem introduced with 8.4. (:issue:`1270`)
 - Fix boost HTML details and simple output. (:issue:`1274`)
+- Fix boost HTML optional data (conditions, decisions, calls) output support. (:issue:`1277`)
 
 Documentation:
 

--- a/src/gcovr/formats/html/boost/directory_page.content.html
+++ b/src/gcovr/formats/html/boost/directory_page.content.html
@@ -2,10 +2,7 @@
 {# Check if we have any function or branch data #}
 {% set has_functions = entries | selectattr('functions.coverage', 'ne', '-') | list | length > 0 %}
 {% set has_branches = entries | selectattr('branches.coverage', 'ne', '-') | list | length > 0 %}
-{% set has_conditions = SHOW_CONDITION_COVERAGE and (entries | selectattr('conditions.coverage', 'ne', '-') | list | length > 0) %}
-{% set has_decisions = SHOW_DECISION and (entries | selectattr('decisions.coverage', 'ne', '-') | list | length > 0) %}
-{% set has_calls = SHOW_CALLS and (entries | selectattr('calls.coverage', 'ne', '-') | list | length > 0) %}
-<div class="file-list-container{% if not has_functions %} no-functions{% endif %}{% if not has_branches %} no-branches{% endif %}{% if not has_conditions %} no-conditions{% endif %}{% if not has_decisions %} no-decisions{% endif %}{% if not has_calls %} no-calls{% endif %}">
+<div class="file-list-container{% if not has_functions %} no-functions{% endif %}{% if not has_branches %} no-branches{% endif %}{% if not SHOW_CONDITION_COVERAGE %} no-conditions{% endif %}{% if not SHOW_DECISION %} no-decisions{% endif %}{% if not SHOW_CALLS %} no-calls{% endif %}">
   <div class="file-list-header">
     <div class="col-name sortable{% if info.sort_by == 'filename' %} {{info.sorted}}{% endif %}" data-sort="filename">
       Name
@@ -26,17 +23,17 @@
       Branches
     </div>
     {% endif %}
-    {% if has_conditions %}
+    {% if SHOW_CONDITION_COVERAGE %}
     <div class="col-conditions sortable" data-sort="conditions">
       Conditions
     </div>
     {% endif %}
-    {% if has_decisions %}
+    {% if SHOW_DECISION %}
     <div class="col-decisions sortable" data-sort="decisions">
       Decisions
     </div>
     {% endif %}
-    {% if has_calls %}
+    {% if SHOW_CALLS %}
     <div class="col-calls sortable" data-sort="calls">
       Calls
     </div>
@@ -117,17 +114,17 @@
         <span class="stat-value {{row.branches.class}}">{% if row.branches.coverage != '-' %}{{row.branches.coverage}}%{% else %}-{% endif %}</span>
       </div>
       {% endif %}
-      {% if has_conditions %}
+      {% if SHOW_CONDITION_COVERAGE %}
       <div class="col-conditions">
         <span class="stat-value {{row.conditions.class}}">{% if row.conditions.coverage != '-' %}{{row.conditions.coverage}}%{% else %}-{% endif %}</span>
       </div>
       {% endif %}
-      {% if has_decisions %}
+      {% if SHOW_DECISION %}
       <div class="col-decisions">
         <span class="stat-value {{row.decisions.class}}">{% if row.decisions.coverage != '-' %}{{row.decisions.coverage}}%{% else %}-{% endif %}</span>
       </div>
       {% endif %}
-      {% if has_calls %}
+      {% if SHOW_CALLS %}
       <div class="col-calls">
         <span class="stat-value {{row.calls.class}}">{% if row.calls.coverage != '-' %}{{row.calls.coverage}}%{% else %}-{% endif %}</span>
       </div>

--- a/src/gcovr/formats/html/boost/directory_page.summary.html
+++ b/src/gcovr/formats/html/boost/directory_page.summary.html
@@ -70,7 +70,88 @@
         </div>
         <div class="stat-row">
           <span class="stat-label">Total</span>
-          <span class="stat-value">{{info.branches.total - info.branches.excluded}}</span>
+          <span class="stat-value">{{info.branches.total - info.branches.excluded if info.branches.excluded != '-' else 0}}</span>
+        </div>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+
+  {% if SHOW_CONDITION_COVERAGE %}
+  <div class="summary-card">
+    <div class="summary-card-header">
+      <h3>Conditions</h3>
+    </div>
+    <div class="summary-card-body">
+      <div class="coverage-ring {{info.branches.class}}">
+        <svg viewBox="0 0 36 36">
+          <path class="ring-bg" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+          <path class="ring-fill" stroke-dasharray="{% if info.branches.coverage != '-' %}{{info.branches.coverage}}{% else %}0{% endif %}, 100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+        </svg>
+        <span class="ring-text">{{info.conditions.coverage}}%</span>
+      </div>
+      <div class="summary-stats">
+        <div class="stat-row">
+          <span class="stat-label">Hit</span>
+          <span class="stat-value">{{info.conditions.exec}}</span>
+        </div>
+        <div class="stat-row">
+          <span class="stat-label">Total</span>
+          <span class="stat-value">{{info.conditions.total - info.conditions.excluded if info.conditions.excluded != '-' else 0}}</span>
+        </div>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+
+  {% if SHOW_DECISION %}
+  <div class="summary-card">
+    <div class="summary-card-header">
+      <h3>Decisions</h3>
+    </div>
+    <div class="summary-card-body">
+      <div class="coverage-ring {{info.branches.class}}">
+        <svg viewBox="0 0 36 36">
+          <path class="ring-bg" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+          <path class="ring-fill" stroke-dasharray="{% if info.branches.coverage != '-' %}{{info.branches.coverage}}{% else %}0{% endif %}, 100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+        </svg>
+        <span class="ring-text">{{info.decisions.coverage}}%</span>
+      </div>
+      <div class="summary-stats">
+        <div class="stat-row">
+          <span class="stat-label">Hit</span>
+          <span class="stat-value">{{info.decisions.exec}}</span>
+        </div>
+        <div class="stat-row">
+          <span class="stat-label">Total</span>
+          <span class="stat-value">{{info.decisions.total}}</span>
+        </div>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+
+  {% if SHOW_CALLS %}
+  <div class="summary-card">
+    <div class="summary-card-header">
+      <h3>Calls</h3>
+    </div>
+    <div class="summary-card-body">
+      <div class="coverage-ring {{info.branches.class}}">
+        <svg viewBox="0 0 36 36">
+          <path class="ring-bg" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+          <path class="ring-fill" stroke-dasharray="{% if info.branches.coverage != '-' %}{{info.branches.coverage}}{% else %}0{% endif %}, 100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+        </svg>
+        <span class="ring-text">{{info.calls.coverage}}%</span>
+      </div>
+      <div class="summary-stats">
+        <div class="stat-row">
+          <span class="stat-label">Hit</span>
+          <span class="stat-value">{{info.calls.exec}}</span>
+        </div>
+        <div class="stat-row">
+          <span class="stat-label">Total</span>
+          <span class="stat-value">{{info.calls.total - info.calls.excluded if info.calls.excluded != '-' else 0}}</span>
         </div>
       </div>
     </div>

--- a/src/gcovr/formats/html/boost/directory_page.summary.html
+++ b/src/gcovr/formats/html/boost/directory_page.summary.html
@@ -83,10 +83,10 @@
       <h3>Conditions</h3>
     </div>
     <div class="summary-card-body">
-      <div class="coverage-ring {{info.branches.class}}">
+      <div class="coverage-ring {{info.conditions.class}}">
         <svg viewBox="0 0 36 36">
           <path class="ring-bg" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
-          <path class="ring-fill" stroke-dasharray="{% if info.branches.coverage != '-' %}{{info.branches.coverage}}{% else %}0{% endif %}, 100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+          <path class="ring-fill" stroke-dasharray="{% if info.conditions.coverage != '-' %}{{info.conditions.coverage}}{% else %}0{% endif %}, 100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
         </svg>
         <span class="ring-text">{{info.conditions.coverage}}%</span>
       </div>
@@ -110,10 +110,10 @@
       <h3>Decisions</h3>
     </div>
     <div class="summary-card-body">
-      <div class="coverage-ring {{info.branches.class}}">
+      <div class="coverage-ring {{info.decisions.class}}">
         <svg viewBox="0 0 36 36">
           <path class="ring-bg" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
-          <path class="ring-fill" stroke-dasharray="{% if info.branches.coverage != '-' %}{{info.branches.coverage}}{% else %}0{% endif %}, 100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+          <path class="ring-fill" stroke-dasharray="{% if info.decisions.coverage != '-' %}{{info.decisions.coverage}}{% else %}0{% endif %}, 100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
         </svg>
         <span class="ring-text">{{info.decisions.coverage}}%</span>
       </div>
@@ -137,10 +137,10 @@
       <h3>Calls</h3>
     </div>
     <div class="summary-card-body">
-      <div class="coverage-ring {{info.branches.class}}">
+      <div class="coverage-ring {{info.calls.class}}">
         <svg viewBox="0 0 36 36">
           <path class="ring-bg" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
-          <path class="ring-fill" stroke-dasharray="{% if info.branches.coverage != '-' %}{{info.branches.coverage}}{% else %}0{% endif %}, 100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+          <path class="ring-fill" stroke-dasharray="{% if info.calls.coverage != '-' %}{{info.calls.coverage}}{% else %}0{% endif %}, 100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
         </svg>
         <span class="ring-text">{{info.calls.coverage}}%</span>
       </div>

--- a/src/gcovr/formats/html/boost/directory_page.summary.html
+++ b/src/gcovr/formats/html/boost/directory_page.summary.html
@@ -76,8 +76,8 @@
     </div>
   </div>
   {% endif %}
-
   {% if SHOW_CONDITION_COVERAGE %}
+
   <div class="summary-card">
     <div class="summary-card-header">
       <h3>Conditions</h3>
@@ -103,8 +103,8 @@
     </div>
   </div>
   {% endif %}
-
   {% if SHOW_DECISION %}
+
   <div class="summary-card">
     <div class="summary-card-header">
       <h3>Decisions</h3>
@@ -130,8 +130,8 @@
     </div>
   </div>
   {% endif %}
-
   {% if SHOW_CALLS %}
+
   <div class="summary-card">
     <div class="summary-card-header">
       <h3>Calls</h3>

--- a/src/gcovr/formats/html/boost/functions_page.content.html
+++ b/src/gcovr/formats/html/boost/functions_page.content.html
@@ -12,6 +12,12 @@
       {% if SHOW_CONDITION_COVERAGE %}
       <div class="col-conditions{{class_sortable}}" data-sort="conditions">Conditions</div>
       {% endif %}
+      {% if SHOW_DECISION %}
+      <div class="col-decisions{{class_sortable}}" data-sort="decisions">Decisions</div>
+      {% endif %}
+      {% if SHOW_CALLS %}
+      <div class="col-calls{{class_sortable}}" data-sort="calls">Calls</div>
+      {% endif %}
     </div>
     <div class="functions-loading" id="functions-loading">
       <div class="functions-loading-spinner"></div>
@@ -33,7 +39,9 @@
     "excluded": {{ "true" if entry.excluded else "false" }},
     "line_coverage": "{{ entry.line_coverage }}",
     "branch_coverage": "{{ entry.branch_coverage }}",
-    "condition_coverage": "{{ entry.condition_coverage }}"
+    "condition_coverage": "{{ entry.condition_coverage }}",
+    "decision_coverage": "{{ entry.decision_coverage }}",
+    "call_coverage": "{{ entry.call_coverage }}"
   }
   {% endfor %}
 ]
@@ -43,6 +51,8 @@
     singlePage: {{ "true" if info.single_page else "false" }},
     htmlFilename: "{{ html_filename }}",
     showBranches: {{ "true" if info.branches.total > info.branches.excluded else "false" }},
-    showConditions: {{ "true" if SHOW_CONDITION_COVERAGE else "false" }}
+    showConditions: {{ "true" if SHOW_CONDITION_COVERAGE else "false" }},
+    showDecisions: {{ "true" if SHOW_DECISION else "false" }},
+    showCalls: {{ "true" if SHOW_CALLS else "false" }}
   };
 </script>

--- a/src/gcovr/formats/html/boost/functions_page.summary.html
+++ b/src/gcovr/formats/html/boost/functions_page.summary.html
@@ -18,19 +18,19 @@
   {% if SHOW_CONDITION_COVERAGE %}
   <div class="summary-stat">
     <span class="stat-label">Conditions:</span>
-    <span class="stat-value {{info.branches.class}}">{{info.conditions.coverage}}%</span>
+    <span class="stat-value {{info.conditions.class}}">{{info.conditions.coverage}}%</span>
   </div>
   {% endif %}
   {% if SHOW_DECISION %}
   <div class="summary-stat">
     <span class="stat-label">Decisions:</span>
-    <span class="stat-value {{info.branches.class}}">{{info.decisions.coverage}}%</span>
+    <span class="stat-value {{info.decisions.class}}">{{info.decisions.coverage}}%</span>
   </div>
   {% endif %}
   {% if SHOW_CALLS %}
   <div class="summary-stat">
     <span class="stat-label">Calls:</span>
-    <span class="stat-value {{info.branches.class}}">{{info.calls.coverage}}%</span>
+    <span class="stat-value {{info.calls.class}}">{{info.calls.coverage}}%</span>
   </div>
   {% endif %}
 </div>

--- a/src/gcovr/formats/html/boost/functions_page.summary.html
+++ b/src/gcovr/formats/html/boost/functions_page.summary.html
@@ -15,4 +15,22 @@
     <span class="stat-value {{info.branches.class}}">{{info.branches.coverage}}%</span>
   </div>
   {% endif %}
+  {% if SHOW_CONDITION_COVERAGE %}
+  <div class="summary-stat">
+    <span class="stat-label">Conditions:</span>
+    <span class="stat-value {{info.branches.class}}">{{info.conditions.coverage}}%</span>
+  </div>
+  {% endif %}
+  {% if SHOW_DECISION %}
+  <div class="summary-stat">
+    <span class="stat-label">Decisions:</span>
+    <span class="stat-value {{info.branches.class}}">{{info.decisions.coverage}}%</span>
+  </div>
+  {% endif %}
+  {% if SHOW_CALLS %}
+  <div class="summary-stat">
+    <span class="stat-label">Calls:</span>
+    <span class="stat-value {{info.branches.class}}">{{info.calls.coverage}}%</span>
+  </div>
+  {% endif %}
 </div>

--- a/src/gcovr/formats/html/boost/gcovr.js
+++ b/src/gcovr/formats/html/boost/gcovr.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/src/gcovr/formats/html/boost/source_page.content.html
+++ b/src/gcovr/formats/html/boost/source_page.content.html
@@ -34,6 +34,15 @@
       {% if has_branches %}
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="branch" title="Toggle Branch column">Branch</button>
       {% endif %}
+      {% if SHOW_CONDITION_COVERAGE %}
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
+      {% endif %}
+      {% if SHOW_DECISION %}
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="decision" title="Toggle Decision column">Decision</button>
+      {% endif %}
+      {% if SHOW_CALLS %}
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="call" title="Toggle Call column">Call</button>
+      {% endif %}
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/src/gcovr/formats/html/boost/source_page.summary.html
+++ b/src/gcovr/formats/html/boost/source_page.summary.html
@@ -16,6 +16,21 @@
         <strong>{{branches.coverage}}%</strong> Branches ({{branches.exec}}/{{branches.total - branches.excluded}})
       </span>
       {% endif %}
+      {% if SHOW_CONDITION_COVERAGE %}
+      <span class="stat {{conditions.class}}">
+        <strong>{{conditions.coverage}}%</strong> Conditions ({{conditions.exec}}/{{conditions.total - conditions.excluded}})
+      </span>
+      {% endif %}
+      {% if SHOW_DECISION %}
+      <span class="stat {{decisions.class}}">
+        <strong>{{decisions.coverage}}%</strong> Decisions ({{decisions.exec}}/{{decisions.total}})
+      </span>
+      {% endif %}
+      {% if SHOW_CALLS %}
+      <span class="stat {{calls.class}}">
+        <strong>{{calls.coverage}}%</strong> Calls ({{calls.exec}}/{{calls.total - calls.excluded}})
+      </span>
+      {% endif %}
     </div>
   </div>
   <div class="nav-hint">

--- a/src/gcovr/formats/html/boost/style.css
+++ b/src/gcovr/formats/html/boost/style.css
@@ -1290,17 +1290,17 @@ body.sidebar-resizing .main-content {
 /* Adjust grid when columns are hidden */
 .no-functions.no-branches .file-list-header,
 .no-functions.no-branches .file-row {
-  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px;
+  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px{% if SHOW_CONDITION_COVERAGE %} 116px{% endif %}{% if SHOW_DECISION %} 116px{% endif %}{% if SHOW_CALLS %} 116px{% endif %};
 }
 
 .no-functions:not(.no-branches) .file-list-header,
 .no-functions:not(.no-branches) .file-row {
-  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px 116px;
+  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px 116px{% if SHOW_CONDITION_COVERAGE %} 116px{% endif %}{% if SHOW_DECISION %} 116px{% endif %}{% if SHOW_CALLS %} 116px{% endif %};
 }
 
 .no-branches:not(.no-functions) .file-list-header,
 .no-branches:not(.no-functions) .file-row {
-  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px 116px;
+  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px 116px{% if SHOW_CONDITION_COVERAGE %} 116px{% endif %}{% if SHOW_DECISION %} 116px{% endif %}{% if SHOW_CALLS %} 116px{% endif %};
 }
 
 .file-row:nth-child(even) {
@@ -1708,6 +1708,18 @@ tr.source-line.nav-highlight > td {
   display: none;
 }
 
+.source-functions-list.hide-col-condition .col-conditions {
+  display: none;
+}
+
+.source-functions-list.hide-col-decision .col-decisions {
+  display: none;
+}
+
+.source-functions-list.hide-col-call .col-calls {
+  display: none;
+}
+
 .source-function-header {
   display: flex;
   align-items: center;
@@ -2069,6 +2081,9 @@ tr.source-line.nav-highlight > td {
 
 /* Column visibility toggle hide rules */
 .source-table.hide-col-branch .col-branch { display: none; }
+.source-table.hide-col-condition .col-condition { display: none; }
+.source-table.hide-col-decision .col-decision { display: none; }
+.source-table.hide-col-call .col-call { display: none; }
 .source-table.hide-col-tla .col-tla { display: none; }
 .source-table.hide-col-count .col-count { display: none; }
 
@@ -2298,7 +2313,7 @@ tr.source-line.nav-highlight > td {
 
 .functions-header {
   display: grid;
-  grid-template-columns: 1fr 90px 70px 90px{% if SHOW_CALLS %} 90px{% endif %};
+  grid-template-columns: 1fr 90px 70px 90px{% if SHOW_CONDITION_COVERAGE %} 90px{% endif %}{% if SHOW_DECISION %} 90px{% endif %}{% if SHOW_CALLS %} 90px{% endif %};
   gap: 0;
   padding: 0 16px;
   background: var(--bg-tertiary);
@@ -2342,7 +2357,7 @@ tr.source-line.nav-highlight > td {
 
 .function-row {
   display: grid;
-  grid-template-columns: 1fr 90px 70px 90px{% if SHOW_CALLS %} 90px{% endif %};
+  grid-template-columns: 1fr 90px 70px 90px{% if SHOW_CONDITION_COVERAGE %} 90px{% endif %}{% if SHOW_DECISION %} 90px{% endif %}{% if SHOW_CALLS %} 90px{% endif %};
   gap: 0;
   padding: 0 16px;
   border-bottom: 1px solid var(--border-muted);
@@ -2352,7 +2367,7 @@ tr.source-line.nav-highlight > td {
 
 .functions-container.no-branches .functions-header,
 .functions-container.no-branches .function-row {
-  grid-template-columns: 1fr 90px 70px{% if SHOW_CALLS %} 90px{% endif %};
+  grid-template-columns: 1fr 90px 70px{% if SHOW_CONDITION_COVERAGE %} 90px{% endif %}{% if SHOW_DECISION %} 90px{% endif %}{% if SHOW_CALLS %} 90px{% endif %};
 }
 
 .function-row > div:not(:first-child) {

--- a/src/gcovr/formats/html/default/directory_page.content.html
+++ b/src/gcovr/formats/html/default/directory_page.content.html
@@ -68,7 +68,7 @@
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="{{row.decisions.sort}}">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 {{row.decisions.class}}" style="width: 100%;">
         <div class="percent">{{row.decisions.coverage}}%</div>
-        <div class="counter" title="Exec / Excl / Total">{{row.decisions.exec}} / {{row.decisions.excluded}} / {{row.decisions.total}}</div>
+        <div class="counter" title="Exec / Excl / Total">{{row.decisions.exec}} / - / {{row.decisions.total}}</div>
       </div>
     </div>
     {% endif %}
@@ -90,4 +90,3 @@
   </div>
 {% endfor %}
 </div>
-

--- a/src/gcovr/formats/html/default/directory_page.content.html
+++ b/src/gcovr/formats/html/default/directory_page.content.html
@@ -90,3 +90,4 @@
   </div>
 {% endfor %}
 </div>
+

--- a/src/gcovr/formats/html/write.py
+++ b/src/gcovr/formats/html/write.py
@@ -985,6 +985,8 @@ def get_file_data(
             f_data["line_coverage"] = function_stats.line.percent_or(100.0)
             f_data["branch_coverage"] = function_stats.branch.percent_or("-")
             f_data["condition_coverage"] = function_stats.condition.percent_or("-")
+            f_data["decision_coverage"] = function_stats.decision.percent_or("-")
+            f_data["call_coverage"] = function_stats.call.percent_or("-")
 
             file_data["function_list"].append(f_data)
             functions[

--- a/tests/compare/reference/changed/clang-10/coverage.boost.css
+++ b/tests/compare/reference/changed/clang-10/coverage.boost.css
@@ -1708,6 +1708,18 @@ tr.source-line.nav-highlight > td {
   display: none;
 }
 
+.source-functions-list.hide-col-condition .col-conditions {
+  display: none;
+}
+
+.source-functions-list.hide-col-decision .col-decisions {
+  display: none;
+}
+
+.source-functions-list.hide-col-call .col-calls {
+  display: none;
+}
+
 .source-function-header {
   display: flex;
   align-items: center;
@@ -2069,6 +2081,9 @@ tr.source-line.nav-highlight > td {
 
 /* Column visibility toggle hide rules */
 .source-table.hide-col-branch .col-branch { display: none; }
+.source-table.hide-col-condition .col-condition { display: none; }
+.source-table.hide-col-decision .col-decision { display: none; }
+.source-table.hide-col-call .col-call { display: none; }
 .source-table.hide-col-tla .col-tla { display: none; }
 .source-table.hide-col-count .col-count { display: none; }
 

--- a/tests/compare/reference/changed/clang-10/coverage.boost.functions.html
+++ b/tests/compare/reference/changed/clang-10/coverage.boost.functions.html
@@ -155,7 +155,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z3fooi",
@@ -166,7 +168,9 @@
     "excluded": false,
     "line_coverage": "80.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z4bar_v",
@@ -177,7 +181,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z4foo5i",
@@ -188,7 +194,9 @@
     "excluded": false,
     "line_coverage": "80.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z4foo6i",
@@ -199,7 +207,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z6foobari",
@@ -210,7 +220,9 @@
     "excluded": false,
     "line_coverage": "80.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z8four_barv",
@@ -221,7 +233,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z9four_bar_v",
@@ -232,7 +246,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z9uncoveredv",
@@ -243,7 +259,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "main",
@@ -254,7 +272,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "25.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ]
 </script>
@@ -263,7 +283,9 @@
     singlePage: false,
     htmlFilename: "",
     showBranches: true,
-    showConditions: false
+    showConditions: false,
+    showDecisions: false,
+    showCalls: false
   };
 </script>          </section>
         </div>

--- a/tests/compare/reference/changed/clang-10/coverage.boost.js
+++ b/tests/compare/reference/changed/clang-10/coverage.boost.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/compare/reference/changed/clang-12/coverage.boost.css
+++ b/tests/compare/reference/changed/clang-12/coverage.boost.css
@@ -1708,6 +1708,18 @@ tr.source-line.nav-highlight > td {
   display: none;
 }
 
+.source-functions-list.hide-col-condition .col-conditions {
+  display: none;
+}
+
+.source-functions-list.hide-col-decision .col-decisions {
+  display: none;
+}
+
+.source-functions-list.hide-col-call .col-calls {
+  display: none;
+}
+
 .source-function-header {
   display: flex;
   align-items: center;
@@ -2069,6 +2081,9 @@ tr.source-line.nav-highlight > td {
 
 /* Column visibility toggle hide rules */
 .source-table.hide-col-branch .col-branch { display: none; }
+.source-table.hide-col-condition .col-condition { display: none; }
+.source-table.hide-col-decision .col-decision { display: none; }
+.source-table.hide-col-call .col-call { display: none; }
 .source-table.hide-col-tla .col-tla { display: none; }
 .source-table.hide-col-count .col-count { display: none; }
 

--- a/tests/compare/reference/changed/clang-12/coverage.boost.functions.html
+++ b/tests/compare/reference/changed/clang-12/coverage.boost.functions.html
@@ -155,7 +155,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "bar_()",
@@ -166,7 +168,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo(int)",
@@ -177,7 +181,9 @@
     "excluded": false,
     "line_coverage": "80.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo5(int)",
@@ -188,7 +194,9 @@
     "excluded": false,
     "line_coverage": "80.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo6(int)",
@@ -199,7 +207,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foobar(int)",
@@ -210,7 +220,9 @@
     "excluded": false,
     "line_coverage": "80.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "four_bar()",
@@ -221,7 +233,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "four_bar_()",
@@ -232,7 +246,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "main",
@@ -243,7 +259,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "25.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "uncovered()",
@@ -254,7 +272,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ]
 </script>
@@ -263,7 +283,9 @@
     singlePage: false,
     htmlFilename: "",
     showBranches: true,
-    showConditions: false
+    showConditions: false,
+    showDecisions: false,
+    showCalls: false
   };
 </script>          </section>
         </div>

--- a/tests/compare/reference/changed/clang-12/coverage.boost.js
+++ b/tests/compare/reference/changed/clang-12/coverage.boost.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/compare/reference/changed/gcc-11/coverage.boost.css
+++ b/tests/compare/reference/changed/gcc-11/coverage.boost.css
@@ -1708,6 +1708,18 @@ tr.source-line.nav-highlight > td {
   display: none;
 }
 
+.source-functions-list.hide-col-condition .col-conditions {
+  display: none;
+}
+
+.source-functions-list.hide-col-decision .col-decisions {
+  display: none;
+}
+
+.source-functions-list.hide-col-call .col-calls {
+  display: none;
+}
+
 .source-function-header {
   display: flex;
   align-items: center;
@@ -2069,6 +2081,9 @@ tr.source-line.nav-highlight > td {
 
 /* Column visibility toggle hide rules */
 .source-table.hide-col-branch .col-branch { display: none; }
+.source-table.hide-col-condition .col-condition { display: none; }
+.source-table.hide-col-decision .col-decision { display: none; }
+.source-table.hide-col-call .col-call { display: none; }
 .source-table.hide-col-tla .col-tla { display: none; }
 .source-table.hide-col-count .col-count { display: none; }
 

--- a/tests/compare/reference/changed/gcc-11/coverage.boost.js
+++ b/tests/compare/reference/changed/gcc-11/coverage.boost.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/compare/reference/changed/gcc-14-Windows/coverage.boost.js
+++ b/tests/compare/reference/changed/gcc-14-Windows/coverage.boost.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/compare/reference/changed/gcc-14/coverage.boost.A.01fd5d65b3a8149e812c7c9d89b472a7.html
+++ b/tests/compare/reference/changed/gcc-14/coverage.boost.A.01fd5d65b3a8149e812c7c9d89b472a7.html
@@ -209,6 +209,31 @@
       </div>
     </div>
   </div>
+
+  <div class="summary-card">
+    <div class="summary-card-header">
+      <h3>Conditions</h3>
+    </div>
+    <div class="summary-card-body">
+      <div class="coverage-ring coverage-low">
+        <svg viewBox="0 0 36 36">
+          <path class="ring-bg" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+          <path class="ring-fill" stroke-dasharray="28.6, 100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+        </svg>
+        <span class="ring-text">28.6%</span>
+      </div>
+      <div class="summary-stats">
+        <div class="stat-row">
+          <span class="stat-label">Hit</span>
+          <span class="stat-value">4</span>
+        </div>
+        <div class="stat-row">
+          <span class="stat-label">Total</span>
+          <span class="stat-value">14</span>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 
 <div class="coverage-legend">

--- a/tests/compare/reference/changed/gcc-14/coverage.boost.B.cec86a34c08f941fc92924df967d4300.html
+++ b/tests/compare/reference/changed/gcc-14/coverage.boost.B.cec86a34c08f941fc92924df967d4300.html
@@ -174,6 +174,31 @@
       </div>
     </div>
   </div>
+
+  <div class="summary-card">
+    <div class="summary-card-header">
+      <h3>Conditions</h3>
+    </div>
+    <div class="summary-card-body">
+      <div class="coverage-ring coverage-low">
+        <svg viewBox="0 0 36 36">
+          <path class="ring-bg" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+          <path class="ring-fill" stroke-dasharray="28.6, 100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+        </svg>
+        <span class="ring-text">28.6%</span>
+      </div>
+      <div class="summary-stats">
+        <div class="stat-row">
+          <span class="stat-label">Hit</span>
+          <span class="stat-value">4</span>
+        </div>
+        <div class="stat-row">
+          <span class="stat-label">Total</span>
+          <span class="stat-value">14</span>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 
 <div class="coverage-legend">

--- a/tests/compare/reference/changed/gcc-14/coverage.boost.C.fb14f49b815b3421ec3912f68f79c28c.html
+++ b/tests/compare/reference/changed/gcc-14/coverage.boost.C.fb14f49b815b3421ec3912f68f79c28c.html
@@ -181,6 +181,31 @@
       </div>
     </div>
   </div>
+
+  <div class="summary-card">
+    <div class="summary-card-header">
+      <h3>Conditions</h3>
+    </div>
+    <div class="summary-card-body">
+      <div class="coverage-ring coverage-low">
+        <svg viewBox="0 0 36 36">
+          <path class="ring-bg" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+          <path class="ring-fill" stroke-dasharray="28.6, 100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+        </svg>
+        <span class="ring-text">28.6%</span>
+      </div>
+      <div class="summary-stats">
+        <div class="stat-row">
+          <span class="stat-label">Hit</span>
+          <span class="stat-value">4</span>
+        </div>
+        <div class="stat-row">
+          <span class="stat-label">Total</span>
+          <span class="stat-value">14</span>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 
 <div class="coverage-legend">

--- a/tests/compare/reference/changed/gcc-14/coverage.boost.D.f26830d87b54e9f418a67752d418ba31.html
+++ b/tests/compare/reference/changed/gcc-14/coverage.boost.D.f26830d87b54e9f418a67752d418ba31.html
@@ -174,6 +174,31 @@
       </div>
     </div>
   </div>
+
+  <div class="summary-card">
+    <div class="summary-card-header">
+      <h3>Conditions</h3>
+    </div>
+    <div class="summary-card-body">
+      <div class="coverage-ring coverage-low">
+        <svg viewBox="0 0 36 36">
+          <path class="ring-bg" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+          <path class="ring-fill" stroke-dasharray="28.6, 100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+        </svg>
+        <span class="ring-text">28.6%</span>
+      </div>
+      <div class="summary-stats">
+        <div class="stat-row">
+          <span class="stat-label">Hit</span>
+          <span class="stat-value">4</span>
+        </div>
+        <div class="stat-row">
+          <span class="stat-label">Total</span>
+          <span class="stat-value">14</span>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 
 <div class="coverage-legend">

--- a/tests/compare/reference/changed/gcc-14/coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
+++ b/tests/compare/reference/changed/gcc-14/coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
@@ -125,6 +125,9 @@
       <span class="stat coverage-unknown">
         <strong>-%</strong> Branches (0/0)
       </span>
+      <span class="stat coverage-unknown">
+        <strong>-%</strong> Conditions (0/0)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -146,6 +149,7 @@
       </button>
     </div>
     <div class="source-column-filters">
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/compare/reference/changed/gcc-14/coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
+++ b/tests/compare/reference/changed/gcc-14/coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
@@ -125,6 +125,9 @@
       <span class="stat coverage-low">
         <strong>50.0%</strong> Branches (1/2)
       </span>
+      <span class="stat coverage-low">
+        <strong>50.0%</strong> Conditions (1/2)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -150,6 +153,7 @@
     </div>
     <div class="source-column-filters">
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="branch" title="Toggle Branch column">Branch</button>
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/compare/reference/changed/gcc-14/coverage.boost.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
+++ b/tests/compare/reference/changed/gcc-14/coverage.boost.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
@@ -125,6 +125,9 @@
       <span class="stat coverage-none">
         <strong>0.0%</strong> Branches (0/2)
       </span>
+      <span class="stat coverage-none">
+        <strong>0.0%</strong> Conditions (0/2)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -146,6 +149,7 @@
       </button>
     </div>
     <div class="source-column-filters">
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/compare/reference/changed/gcc-14/coverage.boost.css
+++ b/tests/compare/reference/changed/gcc-14/coverage.boost.css
@@ -1290,17 +1290,17 @@ body.sidebar-resizing .main-content {
 /* Adjust grid when columns are hidden */
 .no-functions.no-branches .file-list-header,
 .no-functions.no-branches .file-row {
-  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px;
+  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px 116px;
 }
 
 .no-functions:not(.no-branches) .file-list-header,
 .no-functions:not(.no-branches) .file-row {
-  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px 116px;
+  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px 116px 116px;
 }
 
 .no-branches:not(.no-functions) .file-list-header,
 .no-branches:not(.no-functions) .file-row {
-  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px 116px;
+  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px 116px 116px;
 }
 
 .file-row:nth-child(even) {
@@ -1708,6 +1708,18 @@ tr.source-line.nav-highlight > td {
   display: none;
 }
 
+.source-functions-list.hide-col-condition .col-conditions {
+  display: none;
+}
+
+.source-functions-list.hide-col-decision .col-decisions {
+  display: none;
+}
+
+.source-functions-list.hide-col-call .col-calls {
+  display: none;
+}
+
 .source-function-header {
   display: flex;
   align-items: center;
@@ -2069,6 +2081,9 @@ tr.source-line.nav-highlight > td {
 
 /* Column visibility toggle hide rules */
 .source-table.hide-col-branch .col-branch { display: none; }
+.source-table.hide-col-condition .col-condition { display: none; }
+.source-table.hide-col-decision .col-decision { display: none; }
+.source-table.hide-col-call .col-call { display: none; }
 .source-table.hide-col-tla .col-tla { display: none; }
 .source-table.hide-col-count .col-count { display: none; }
 
@@ -2298,7 +2313,7 @@ tr.source-line.nav-highlight > td {
 
 .functions-header {
   display: grid;
-  grid-template-columns: 1fr 90px 70px 90px;
+  grid-template-columns: 1fr 90px 70px 90px 90px;
   gap: 0;
   padding: 0 16px;
   background: var(--bg-tertiary);
@@ -2342,7 +2357,7 @@ tr.source-line.nav-highlight > td {
 
 .function-row {
   display: grid;
-  grid-template-columns: 1fr 90px 70px 90px;
+  grid-template-columns: 1fr 90px 70px 90px 90px;
   gap: 0;
   padding: 0 16px;
   border-bottom: 1px solid var(--border-muted);
@@ -2352,7 +2367,7 @@ tr.source-line.nav-highlight > td {
 
 .functions-container.no-branches .functions-header,
 .functions-container.no-branches .function-row {
-  grid-template-columns: 1fr 90px 70px;
+  grid-template-columns: 1fr 90px 70px 90px;
 }
 
 .function-row > div:not(:first-child) {

--- a/tests/compare/reference/changed/gcc-14/coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
+++ b/tests/compare/reference/changed/gcc-14/coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
@@ -125,6 +125,9 @@
       <span class="stat coverage-low">
         <strong>50.0%</strong> Branches (1/2)
       </span>
+      <span class="stat coverage-low">
+        <strong>50.0%</strong> Conditions (1/2)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -150,6 +153,7 @@
     </div>
     <div class="source-column-filters">
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="branch" title="Toggle Branch column">Branch</button>
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/compare/reference/changed/gcc-14/coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
+++ b/tests/compare/reference/changed/gcc-14/coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
@@ -125,6 +125,9 @@
       <span class="stat coverage-none">
         <strong>0.0%</strong> Branches (0/2)
       </span>
+      <span class="stat coverage-none">
+        <strong>0.0%</strong> Conditions (0/2)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -146,6 +149,7 @@
       </button>
     </div>
     <div class="source-column-filters">
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/compare/reference/changed/gcc-14/coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
+++ b/tests/compare/reference/changed/gcc-14/coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
@@ -125,6 +125,9 @@
       <span class="stat coverage-low">
         <strong>50.0%</strong> Branches (1/2)
       </span>
+      <span class="stat coverage-low">
+        <strong>50.0%</strong> Conditions (1/2)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -150,6 +153,7 @@
     </div>
     <div class="source-column-filters">
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="branch" title="Toggle Branch column">Branch</button>
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/compare/reference/changed/gcc-14/coverage.boost.functions.html
+++ b/tests/compare/reference/changed/gcc-14/coverage.boost.functions.html
@@ -126,6 +126,10 @@
     <span class="stat-label">Branches:</span>
     <span class="stat-value coverage-low">28.6%</span>
   </div>
+  <div class="summary-stat">
+    <span class="stat-label">Conditions:</span>
+    <span class="stat-value coverage-low">28.6%</span>
+  </div>
 </div>          </section>
 
           <section class="main-section">
@@ -156,7 +160,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "bar_()",
@@ -167,7 +173,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo(int)",
@@ -178,7 +186,9 @@
     "excluded": false,
     "line_coverage": "75.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "50.0"
+    "condition_coverage": "50.0",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo5(int)",
@@ -189,7 +199,9 @@
     "excluded": false,
     "line_coverage": "75.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "50.0"
+    "condition_coverage": "50.0",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo6(int)",
@@ -200,7 +212,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "0.0"
+    "condition_coverage": "0.0",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foobar(int)",
@@ -211,7 +225,9 @@
     "excluded": false,
     "line_coverage": "75.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "50.0"
+    "condition_coverage": "50.0",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "four_bar()",
@@ -222,7 +238,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "four_bar_()",
@@ -233,7 +251,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "0.0"
+    "condition_coverage": "0.0",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "main",
@@ -244,7 +264,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "25.0",
-    "condition_coverage": "25.0"
+    "condition_coverage": "25.0",
+    "decision_coverage": "-",
+    "call_coverage": "83.3"
   }
 ,  {
     "name": "uncovered()",
@@ -255,7 +277,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ]
 </script>
@@ -264,7 +288,9 @@
     singlePage: false,
     htmlFilename: "",
     showBranches: true,
-    showConditions: true
+    showConditions: true,
+    showDecisions: false,
+    showCalls: false
   };
 </script>          </section>
         </div>

--- a/tests/compare/reference/changed/gcc-14/coverage.boost.html
+++ b/tests/compare/reference/changed/gcc-14/coverage.boost.html
@@ -181,6 +181,31 @@
       </div>
     </div>
   </div>
+
+  <div class="summary-card">
+    <div class="summary-card-header">
+      <h3>Conditions</h3>
+    </div>
+    <div class="summary-card-body">
+      <div class="coverage-ring coverage-low">
+        <svg viewBox="0 0 36 36">
+          <path class="ring-bg" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+          <path class="ring-fill" stroke-dasharray="28.6, 100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+        </svg>
+        <span class="ring-text">28.6%</span>
+      </div>
+      <div class="summary-stats">
+        <div class="stat-row">
+          <span class="stat-label">Hit</span>
+          <span class="stat-value">4</span>
+        </div>
+        <div class="stat-row">
+          <span class="stat-label">Total</span>
+          <span class="stat-value">14</span>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 
 <div class="coverage-legend">

--- a/tests/compare/reference/changed/gcc-14/coverage.boost.js
+++ b/tests/compare/reference/changed/gcc-14/coverage.boost.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/compare/reference/changed/gcc-14/coverage.boost.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/tests/compare/reference/changed/gcc-14/coverage.boost.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -125,6 +125,9 @@
       <span class="stat coverage-low">
         <strong>25.0%</strong> Branches (1/4)
       </span>
+      <span class="stat coverage-low">
+        <strong>25.0%</strong> Conditions (1/4)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -150,6 +153,7 @@
     </div>
     <div class="source-column-filters">
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="branch" title="Toggle Branch column">Branch</button>
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/compare/reference/changed/gcc-15-Windows/coverage.boost.js
+++ b/tests/compare/reference/changed/gcc-15-Windows/coverage.boost.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/compare/reference/changed/gcc-5/coverage.boost.css
+++ b/tests/compare/reference/changed/gcc-5/coverage.boost.css
@@ -1708,6 +1708,18 @@ tr.source-line.nav-highlight > td {
   display: none;
 }
 
+.source-functions-list.hide-col-condition .col-conditions {
+  display: none;
+}
+
+.source-functions-list.hide-col-decision .col-decisions {
+  display: none;
+}
+
+.source-functions-list.hide-col-call .col-calls {
+  display: none;
+}
+
 .source-function-header {
   display: flex;
   align-items: center;
@@ -2069,6 +2081,9 @@ tr.source-line.nav-highlight > td {
 
 /* Column visibility toggle hide rules */
 .source-table.hide-col-branch .col-branch { display: none; }
+.source-table.hide-col-condition .col-condition { display: none; }
+.source-table.hide-col-decision .col-decision { display: none; }
+.source-table.hide-col-call .col-call { display: none; }
 .source-table.hide-col-tla .col-tla { display: none; }
 .source-table.hide-col-count .col-count { display: none; }
 

--- a/tests/compare/reference/changed/gcc-5/coverage.boost.functions.html
+++ b/tests/compare/reference/changed/gcc-5/coverage.boost.functions.html
@@ -155,7 +155,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "bar_()",
@@ -166,7 +168,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo(int)",
@@ -177,7 +181,9 @@
     "excluded": false,
     "line_coverage": "75.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo5(int)",
@@ -188,7 +194,9 @@
     "excluded": false,
     "line_coverage": "75.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo6(int)",
@@ -199,7 +207,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foobar(int)",
@@ -210,7 +220,9 @@
     "excluded": false,
     "line_coverage": "75.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "four_bar()",
@@ -221,7 +233,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "four_bar_()",
@@ -232,7 +246,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "main",
@@ -243,7 +259,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "25.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "83.3"
   }
 ,  {
     "name": "uncovered()",
@@ -254,7 +272,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ]
 </script>
@@ -263,7 +283,9 @@
     singlePage: false,
     htmlFilename: "",
     showBranches: true,
-    showConditions: false
+    showConditions: false,
+    showDecisions: false,
+    showCalls: false
   };
 </script>          </section>
         </div>

--- a/tests/compare/reference/changed/gcc-5/coverage.boost.js
+++ b/tests/compare/reference/changed/gcc-5/coverage.boost.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/compare/reference/changed/gcc-9/coverage.boost.css
+++ b/tests/compare/reference/changed/gcc-9/coverage.boost.css
@@ -1708,6 +1708,18 @@ tr.source-line.nav-highlight > td {
   display: none;
 }
 
+.source-functions-list.hide-col-condition .col-conditions {
+  display: none;
+}
+
+.source-functions-list.hide-col-decision .col-decisions {
+  display: none;
+}
+
+.source-functions-list.hide-col-call .col-calls {
+  display: none;
+}
+
 .source-function-header {
   display: flex;
   align-items: center;
@@ -2069,6 +2081,9 @@ tr.source-line.nav-highlight > td {
 
 /* Column visibility toggle hide rules */
 .source-table.hide-col-branch .col-branch { display: none; }
+.source-table.hide-col-condition .col-condition { display: none; }
+.source-table.hide-col-decision .col-decision { display: none; }
+.source-table.hide-col-call .col-call { display: none; }
 .source-table.hide-col-tla .col-tla { display: none; }
 .source-table.hide-col-count .col-count { display: none; }
 

--- a/tests/compare/reference/changed/gcc-9/coverage.boost.js
+++ b/tests/compare/reference/changed/gcc-9/coverage.boost.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/compare/reference/equal/clang-10/coverage.boost.css
+++ b/tests/compare/reference/equal/clang-10/coverage.boost.css
@@ -1708,6 +1708,18 @@ tr.source-line.nav-highlight > td {
   display: none;
 }
 
+.source-functions-list.hide-col-condition .col-conditions {
+  display: none;
+}
+
+.source-functions-list.hide-col-decision .col-decisions {
+  display: none;
+}
+
+.source-functions-list.hide-col-call .col-calls {
+  display: none;
+}
+
 .source-function-header {
   display: flex;
   align-items: center;
@@ -2069,6 +2081,9 @@ tr.source-line.nav-highlight > td {
 
 /* Column visibility toggle hide rules */
 .source-table.hide-col-branch .col-branch { display: none; }
+.source-table.hide-col-condition .col-condition { display: none; }
+.source-table.hide-col-decision .col-decision { display: none; }
+.source-table.hide-col-call .col-call { display: none; }
 .source-table.hide-col-tla .col-tla { display: none; }
 .source-table.hide-col-count .col-count { display: none; }
 

--- a/tests/compare/reference/equal/clang-10/coverage.boost.functions.html
+++ b/tests/compare/reference/equal/clang-10/coverage.boost.functions.html
@@ -155,7 +155,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z3fooi",
@@ -166,7 +168,9 @@
     "excluded": false,
     "line_coverage": "80.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z4bar_v",
@@ -177,7 +181,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z4foo5i",
@@ -188,7 +194,9 @@
     "excluded": false,
     "line_coverage": "80.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z4foo6i",
@@ -199,7 +207,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z6foobari",
@@ -210,7 +220,9 @@
     "excluded": false,
     "line_coverage": "80.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z8four_barv",
@@ -221,7 +233,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z9four_bar_v",
@@ -232,7 +246,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z9uncoveredv",
@@ -243,7 +259,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "main",
@@ -254,7 +272,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "25.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ]
 </script>
@@ -263,7 +283,9 @@
     singlePage: false,
     htmlFilename: "",
     showBranches: true,
-    showConditions: false
+    showConditions: false,
+    showDecisions: false,
+    showCalls: false
   };
 </script>          </section>
         </div>

--- a/tests/compare/reference/equal/clang-10/coverage.boost.js
+++ b/tests/compare/reference/equal/clang-10/coverage.boost.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/compare/reference/equal/clang-12/coverage.boost.css
+++ b/tests/compare/reference/equal/clang-12/coverage.boost.css
@@ -1708,6 +1708,18 @@ tr.source-line.nav-highlight > td {
   display: none;
 }
 
+.source-functions-list.hide-col-condition .col-conditions {
+  display: none;
+}
+
+.source-functions-list.hide-col-decision .col-decisions {
+  display: none;
+}
+
+.source-functions-list.hide-col-call .col-calls {
+  display: none;
+}
+
 .source-function-header {
   display: flex;
   align-items: center;
@@ -2069,6 +2081,9 @@ tr.source-line.nav-highlight > td {
 
 /* Column visibility toggle hide rules */
 .source-table.hide-col-branch .col-branch { display: none; }
+.source-table.hide-col-condition .col-condition { display: none; }
+.source-table.hide-col-decision .col-decision { display: none; }
+.source-table.hide-col-call .col-call { display: none; }
 .source-table.hide-col-tla .col-tla { display: none; }
 .source-table.hide-col-count .col-count { display: none; }
 

--- a/tests/compare/reference/equal/clang-12/coverage.boost.functions.html
+++ b/tests/compare/reference/equal/clang-12/coverage.boost.functions.html
@@ -155,7 +155,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "bar_()",
@@ -166,7 +168,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo(int)",
@@ -177,7 +181,9 @@
     "excluded": false,
     "line_coverage": "80.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo5(int)",
@@ -188,7 +194,9 @@
     "excluded": false,
     "line_coverage": "80.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo6(int)",
@@ -199,7 +207,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foobar(int)",
@@ -210,7 +220,9 @@
     "excluded": false,
     "line_coverage": "80.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "four_bar()",
@@ -221,7 +233,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "four_bar_()",
@@ -232,7 +246,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "main",
@@ -243,7 +259,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "25.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "uncovered()",
@@ -254,7 +272,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ]
 </script>
@@ -263,7 +283,9 @@
     singlePage: false,
     htmlFilename: "",
     showBranches: true,
-    showConditions: false
+    showConditions: false,
+    showDecisions: false,
+    showCalls: false
   };
 </script>          </section>
         </div>

--- a/tests/compare/reference/equal/clang-12/coverage.boost.js
+++ b/tests/compare/reference/equal/clang-12/coverage.boost.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/compare/reference/equal/gcc-11/coverage.boost.css
+++ b/tests/compare/reference/equal/gcc-11/coverage.boost.css
@@ -1708,6 +1708,18 @@ tr.source-line.nav-highlight > td {
   display: none;
 }
 
+.source-functions-list.hide-col-condition .col-conditions {
+  display: none;
+}
+
+.source-functions-list.hide-col-decision .col-decisions {
+  display: none;
+}
+
+.source-functions-list.hide-col-call .col-calls {
+  display: none;
+}
+
 .source-function-header {
   display: flex;
   align-items: center;
@@ -2069,6 +2081,9 @@ tr.source-line.nav-highlight > td {
 
 /* Column visibility toggle hide rules */
 .source-table.hide-col-branch .col-branch { display: none; }
+.source-table.hide-col-condition .col-condition { display: none; }
+.source-table.hide-col-decision .col-decision { display: none; }
+.source-table.hide-col-call .col-call { display: none; }
 .source-table.hide-col-tla .col-tla { display: none; }
 .source-table.hide-col-count .col-count { display: none; }
 

--- a/tests/compare/reference/equal/gcc-11/coverage.boost.js
+++ b/tests/compare/reference/equal/gcc-11/coverage.boost.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/compare/reference/equal/gcc-14-Windows/coverage.boost.js
+++ b/tests/compare/reference/equal/gcc-14-Windows/coverage.boost.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/compare/reference/equal/gcc-14/coverage.boost.A.01fd5d65b3a8149e812c7c9d89b472a7.html
+++ b/tests/compare/reference/equal/gcc-14/coverage.boost.A.01fd5d65b3a8149e812c7c9d89b472a7.html
@@ -209,6 +209,31 @@
       </div>
     </div>
   </div>
+
+  <div class="summary-card">
+    <div class="summary-card-header">
+      <h3>Conditions</h3>
+    </div>
+    <div class="summary-card-body">
+      <div class="coverage-ring coverage-low">
+        <svg viewBox="0 0 36 36">
+          <path class="ring-bg" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+          <path class="ring-fill" stroke-dasharray="28.6, 100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+        </svg>
+        <span class="ring-text">28.6%</span>
+      </div>
+      <div class="summary-stats">
+        <div class="stat-row">
+          <span class="stat-label">Hit</span>
+          <span class="stat-value">4</span>
+        </div>
+        <div class="stat-row">
+          <span class="stat-label">Total</span>
+          <span class="stat-value">14</span>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 
 <div class="coverage-legend">

--- a/tests/compare/reference/equal/gcc-14/coverage.boost.B.cec86a34c08f941fc92924df967d4300.html
+++ b/tests/compare/reference/equal/gcc-14/coverage.boost.B.cec86a34c08f941fc92924df967d4300.html
@@ -174,6 +174,31 @@
       </div>
     </div>
   </div>
+
+  <div class="summary-card">
+    <div class="summary-card-header">
+      <h3>Conditions</h3>
+    </div>
+    <div class="summary-card-body">
+      <div class="coverage-ring coverage-low">
+        <svg viewBox="0 0 36 36">
+          <path class="ring-bg" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+          <path class="ring-fill" stroke-dasharray="28.6, 100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+        </svg>
+        <span class="ring-text">28.6%</span>
+      </div>
+      <div class="summary-stats">
+        <div class="stat-row">
+          <span class="stat-label">Hit</span>
+          <span class="stat-value">4</span>
+        </div>
+        <div class="stat-row">
+          <span class="stat-label">Total</span>
+          <span class="stat-value">14</span>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 
 <div class="coverage-legend">

--- a/tests/compare/reference/equal/gcc-14/coverage.boost.C.fb14f49b815b3421ec3912f68f79c28c.html
+++ b/tests/compare/reference/equal/gcc-14/coverage.boost.C.fb14f49b815b3421ec3912f68f79c28c.html
@@ -181,6 +181,31 @@
       </div>
     </div>
   </div>
+
+  <div class="summary-card">
+    <div class="summary-card-header">
+      <h3>Conditions</h3>
+    </div>
+    <div class="summary-card-body">
+      <div class="coverage-ring coverage-low">
+        <svg viewBox="0 0 36 36">
+          <path class="ring-bg" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+          <path class="ring-fill" stroke-dasharray="28.6, 100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+        </svg>
+        <span class="ring-text">28.6%</span>
+      </div>
+      <div class="summary-stats">
+        <div class="stat-row">
+          <span class="stat-label">Hit</span>
+          <span class="stat-value">4</span>
+        </div>
+        <div class="stat-row">
+          <span class="stat-label">Total</span>
+          <span class="stat-value">14</span>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 
 <div class="coverage-legend">

--- a/tests/compare/reference/equal/gcc-14/coverage.boost.D.f26830d87b54e9f418a67752d418ba31.html
+++ b/tests/compare/reference/equal/gcc-14/coverage.boost.D.f26830d87b54e9f418a67752d418ba31.html
@@ -174,6 +174,31 @@
       </div>
     </div>
   </div>
+
+  <div class="summary-card">
+    <div class="summary-card-header">
+      <h3>Conditions</h3>
+    </div>
+    <div class="summary-card-body">
+      <div class="coverage-ring coverage-low">
+        <svg viewBox="0 0 36 36">
+          <path class="ring-bg" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+          <path class="ring-fill" stroke-dasharray="28.6, 100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+        </svg>
+        <span class="ring-text">28.6%</span>
+      </div>
+      <div class="summary-stats">
+        <div class="stat-row">
+          <span class="stat-label">Hit</span>
+          <span class="stat-value">4</span>
+        </div>
+        <div class="stat-row">
+          <span class="stat-label">Total</span>
+          <span class="stat-value">14</span>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 
 <div class="coverage-legend">

--- a/tests/compare/reference/equal/gcc-14/coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
+++ b/tests/compare/reference/equal/gcc-14/coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
@@ -125,6 +125,9 @@
       <span class="stat coverage-unknown">
         <strong>-%</strong> Branches (0/0)
       </span>
+      <span class="stat coverage-unknown">
+        <strong>-%</strong> Conditions (0/0)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -146,6 +149,7 @@
       </button>
     </div>
     <div class="source-column-filters">
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/compare/reference/equal/gcc-14/coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
+++ b/tests/compare/reference/equal/gcc-14/coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
@@ -125,6 +125,9 @@
       <span class="stat coverage-low">
         <strong>50.0%</strong> Branches (1/2)
       </span>
+      <span class="stat coverage-low">
+        <strong>50.0%</strong> Conditions (1/2)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -150,6 +153,7 @@
     </div>
     <div class="source-column-filters">
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="branch" title="Toggle Branch column">Branch</button>
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/compare/reference/equal/gcc-14/coverage.boost.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
+++ b/tests/compare/reference/equal/gcc-14/coverage.boost.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
@@ -125,6 +125,9 @@
       <span class="stat coverage-none">
         <strong>0.0%</strong> Branches (0/2)
       </span>
+      <span class="stat coverage-none">
+        <strong>0.0%</strong> Conditions (0/2)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -146,6 +149,7 @@
       </button>
     </div>
     <div class="source-column-filters">
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/compare/reference/equal/gcc-14/coverage.boost.css
+++ b/tests/compare/reference/equal/gcc-14/coverage.boost.css
@@ -1290,17 +1290,17 @@ body.sidebar-resizing .main-content {
 /* Adjust grid when columns are hidden */
 .no-functions.no-branches .file-list-header,
 .no-functions.no-branches .file-row {
-  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px;
+  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px 116px;
 }
 
 .no-functions:not(.no-branches) .file-list-header,
 .no-functions:not(.no-branches) .file-row {
-  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px 116px;
+  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px 116px 116px;
 }
 
 .no-branches:not(.no-functions) .file-list-header,
 .no-branches:not(.no-functions) .file-row {
-  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px 116px;
+  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px 116px 116px;
 }
 
 .file-row:nth-child(even) {
@@ -1708,6 +1708,18 @@ tr.source-line.nav-highlight > td {
   display: none;
 }
 
+.source-functions-list.hide-col-condition .col-conditions {
+  display: none;
+}
+
+.source-functions-list.hide-col-decision .col-decisions {
+  display: none;
+}
+
+.source-functions-list.hide-col-call .col-calls {
+  display: none;
+}
+
 .source-function-header {
   display: flex;
   align-items: center;
@@ -2069,6 +2081,9 @@ tr.source-line.nav-highlight > td {
 
 /* Column visibility toggle hide rules */
 .source-table.hide-col-branch .col-branch { display: none; }
+.source-table.hide-col-condition .col-condition { display: none; }
+.source-table.hide-col-decision .col-decision { display: none; }
+.source-table.hide-col-call .col-call { display: none; }
 .source-table.hide-col-tla .col-tla { display: none; }
 .source-table.hide-col-count .col-count { display: none; }
 
@@ -2298,7 +2313,7 @@ tr.source-line.nav-highlight > td {
 
 .functions-header {
   display: grid;
-  grid-template-columns: 1fr 90px 70px 90px;
+  grid-template-columns: 1fr 90px 70px 90px 90px;
   gap: 0;
   padding: 0 16px;
   background: var(--bg-tertiary);
@@ -2342,7 +2357,7 @@ tr.source-line.nav-highlight > td {
 
 .function-row {
   display: grid;
-  grid-template-columns: 1fr 90px 70px 90px;
+  grid-template-columns: 1fr 90px 70px 90px 90px;
   gap: 0;
   padding: 0 16px;
   border-bottom: 1px solid var(--border-muted);
@@ -2352,7 +2367,7 @@ tr.source-line.nav-highlight > td {
 
 .functions-container.no-branches .functions-header,
 .functions-container.no-branches .function-row {
-  grid-template-columns: 1fr 90px 70px;
+  grid-template-columns: 1fr 90px 70px 90px;
 }
 
 .function-row > div:not(:first-child) {

--- a/tests/compare/reference/equal/gcc-14/coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
+++ b/tests/compare/reference/equal/gcc-14/coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
@@ -125,6 +125,9 @@
       <span class="stat coverage-low">
         <strong>50.0%</strong> Branches (1/2)
       </span>
+      <span class="stat coverage-low">
+        <strong>50.0%</strong> Conditions (1/2)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -150,6 +153,7 @@
     </div>
     <div class="source-column-filters">
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="branch" title="Toggle Branch column">Branch</button>
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/compare/reference/equal/gcc-14/coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
+++ b/tests/compare/reference/equal/gcc-14/coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
@@ -125,6 +125,9 @@
       <span class="stat coverage-none">
         <strong>0.0%</strong> Branches (0/2)
       </span>
+      <span class="stat coverage-none">
+        <strong>0.0%</strong> Conditions (0/2)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -146,6 +149,7 @@
       </button>
     </div>
     <div class="source-column-filters">
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/compare/reference/equal/gcc-14/coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
+++ b/tests/compare/reference/equal/gcc-14/coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
@@ -125,6 +125,9 @@
       <span class="stat coverage-low">
         <strong>50.0%</strong> Branches (1/2)
       </span>
+      <span class="stat coverage-low">
+        <strong>50.0%</strong> Conditions (1/2)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -150,6 +153,7 @@
     </div>
     <div class="source-column-filters">
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="branch" title="Toggle Branch column">Branch</button>
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/compare/reference/equal/gcc-14/coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
+++ b/tests/compare/reference/equal/gcc-14/coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
@@ -125,6 +125,9 @@
       <span class="stat coverage-unknown">
         <strong>-%</strong> Branches (0/0)
       </span>
+      <span class="stat coverage-unknown">
+        <strong>-%</strong> Conditions (0/0)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -146,6 +149,7 @@
       </button>
     </div>
     <div class="source-column-filters">
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/compare/reference/equal/gcc-14/coverage.boost.functions.html
+++ b/tests/compare/reference/equal/gcc-14/coverage.boost.functions.html
@@ -126,6 +126,10 @@
     <span class="stat-label">Branches:</span>
     <span class="stat-value coverage-low">28.6%</span>
   </div>
+  <div class="summary-stat">
+    <span class="stat-label">Conditions:</span>
+    <span class="stat-value coverage-low">28.6%</span>
+  </div>
 </div>          </section>
 
           <section class="main-section">
@@ -156,7 +160,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "bar_()",
@@ -167,7 +173,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo(int)",
@@ -178,7 +186,9 @@
     "excluded": false,
     "line_coverage": "75.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "50.0"
+    "condition_coverage": "50.0",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo5(int)",
@@ -189,7 +199,9 @@
     "excluded": false,
     "line_coverage": "75.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "50.0"
+    "condition_coverage": "50.0",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo6(int)",
@@ -200,7 +212,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "0.0"
+    "condition_coverage": "0.0",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foobar(int)",
@@ -211,7 +225,9 @@
     "excluded": false,
     "line_coverage": "75.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "50.0"
+    "condition_coverage": "50.0",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "four_bar()",
@@ -222,7 +238,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "four_bar_()",
@@ -233,7 +251,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "0.0"
+    "condition_coverage": "0.0",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "main",
@@ -244,7 +264,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "25.0",
-    "condition_coverage": "25.0"
+    "condition_coverage": "25.0",
+    "decision_coverage": "-",
+    "call_coverage": "83.3"
   }
 ,  {
     "name": "uncovered()",
@@ -255,7 +277,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ]
 </script>
@@ -264,7 +288,9 @@
     singlePage: false,
     htmlFilename: "",
     showBranches: true,
-    showConditions: true
+    showConditions: true,
+    showDecisions: false,
+    showCalls: false
   };
 </script>          </section>
         </div>

--- a/tests/compare/reference/equal/gcc-14/coverage.boost.html
+++ b/tests/compare/reference/equal/gcc-14/coverage.boost.html
@@ -181,6 +181,31 @@
       </div>
     </div>
   </div>
+
+  <div class="summary-card">
+    <div class="summary-card-header">
+      <h3>Conditions</h3>
+    </div>
+    <div class="summary-card-body">
+      <div class="coverage-ring coverage-low">
+        <svg viewBox="0 0 36 36">
+          <path class="ring-bg" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+          <path class="ring-fill" stroke-dasharray="28.6, 100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+        </svg>
+        <span class="ring-text">28.6%</span>
+      </div>
+      <div class="summary-stats">
+        <div class="stat-row">
+          <span class="stat-label">Hit</span>
+          <span class="stat-value">4</span>
+        </div>
+        <div class="stat-row">
+          <span class="stat-label">Total</span>
+          <span class="stat-value">14</span>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 
 <div class="coverage-legend">

--- a/tests/compare/reference/equal/gcc-14/coverage.boost.js
+++ b/tests/compare/reference/equal/gcc-14/coverage.boost.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/compare/reference/equal/gcc-14/coverage.boost.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/tests/compare/reference/equal/gcc-14/coverage.boost.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -125,6 +125,9 @@
       <span class="stat coverage-low">
         <strong>25.0%</strong> Branches (1/4)
       </span>
+      <span class="stat coverage-low">
+        <strong>25.0%</strong> Conditions (1/4)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -150,6 +153,7 @@
     </div>
     <div class="source-column-filters">
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="branch" title="Toggle Branch column">Branch</button>
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/compare/reference/equal/gcc-15-Windows/coverage.boost.js
+++ b/tests/compare/reference/equal/gcc-15-Windows/coverage.boost.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/compare/reference/equal/gcc-5/coverage.boost.css
+++ b/tests/compare/reference/equal/gcc-5/coverage.boost.css
@@ -1708,6 +1708,18 @@ tr.source-line.nav-highlight > td {
   display: none;
 }
 
+.source-functions-list.hide-col-condition .col-conditions {
+  display: none;
+}
+
+.source-functions-list.hide-col-decision .col-decisions {
+  display: none;
+}
+
+.source-functions-list.hide-col-call .col-calls {
+  display: none;
+}
+
 .source-function-header {
   display: flex;
   align-items: center;
@@ -2069,6 +2081,9 @@ tr.source-line.nav-highlight > td {
 
 /* Column visibility toggle hide rules */
 .source-table.hide-col-branch .col-branch { display: none; }
+.source-table.hide-col-condition .col-condition { display: none; }
+.source-table.hide-col-decision .col-decision { display: none; }
+.source-table.hide-col-call .col-call { display: none; }
 .source-table.hide-col-tla .col-tla { display: none; }
 .source-table.hide-col-count .col-count { display: none; }
 

--- a/tests/compare/reference/equal/gcc-5/coverage.boost.functions.html
+++ b/tests/compare/reference/equal/gcc-5/coverage.boost.functions.html
@@ -155,7 +155,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "bar_()",
@@ -166,7 +168,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo(int)",
@@ -177,7 +181,9 @@
     "excluded": false,
     "line_coverage": "75.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo5(int)",
@@ -188,7 +194,9 @@
     "excluded": false,
     "line_coverage": "75.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo6(int)",
@@ -199,7 +207,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foobar(int)",
@@ -210,7 +220,9 @@
     "excluded": false,
     "line_coverage": "75.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "four_bar()",
@@ -221,7 +233,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "four_bar_()",
@@ -232,7 +246,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "main",
@@ -243,7 +259,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "25.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "83.3"
   }
 ,  {
     "name": "uncovered()",
@@ -254,7 +272,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ]
 </script>
@@ -263,7 +283,9 @@
     singlePage: false,
     htmlFilename: "",
     showBranches: true,
-    showConditions: false
+    showConditions: false,
+    showDecisions: false,
+    showCalls: false
   };
 </script>          </section>
         </div>

--- a/tests/compare/reference/equal/gcc-5/coverage.boost.js
+++ b/tests/compare/reference/equal/gcc-5/coverage.boost.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/compare/reference/equal/gcc-9/coverage.boost.css
+++ b/tests/compare/reference/equal/gcc-9/coverage.boost.css
@@ -1708,6 +1708,18 @@ tr.source-line.nav-highlight > td {
   display: none;
 }
 
+.source-functions-list.hide-col-condition .col-conditions {
+  display: none;
+}
+
+.source-functions-list.hide-col-decision .col-decisions {
+  display: none;
+}
+
+.source-functions-list.hide-col-call .col-calls {
+  display: none;
+}
+
 .source-function-header {
   display: flex;
   align-items: center;
@@ -2069,6 +2081,9 @@ tr.source-line.nav-highlight > td {
 
 /* Column visibility toggle hide rules */
 .source-table.hide-col-branch .col-branch { display: none; }
+.source-table.hide-col-condition .col-condition { display: none; }
+.source-table.hide-col-decision .col-decision { display: none; }
+.source-table.hide-col-call .col-call { display: none; }
 .source-table.hide-col-tla .col-tla { display: none; }
 .source-table.hide-col-count .col-count { display: none; }
 

--- a/tests/compare/reference/equal/gcc-9/coverage.boost.js
+++ b/tests/compare/reference/equal/gcc-9/coverage.boost.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/decisions/reference/decisions-neg-delta/clang-10/coverage.html
+++ b/tests/decisions/reference/decisions-neg-delta/clang-10/coverage.html
@@ -113,7 +113,7 @@
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="75.0">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-medium" style="width: 100%;">
         <div class="percent">75.0%</div>
-        <div class="counter" title="Exec / Excl / Total">3 /  / 4</div>
+        <div class="counter" title="Exec / Excl / Total">3 / - / 4</div>
       </div>
     </div>
   </div>

--- a/tests/decisions/reference/decisions-neg-delta/gcc-11/coverage.html
+++ b/tests/decisions/reference/decisions-neg-delta/gcc-11/coverage.html
@@ -113,7 +113,7 @@
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="75.0">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-medium" style="width: 100%;">
         <div class="percent">75.0%</div>
-        <div class="counter" title="Exec / Excl / Total">3 /  / 4</div>
+        <div class="counter" title="Exec / Excl / Total">3 / - / 4</div>
       </div>
     </div>
   </div>

--- a/tests/decisions/reference/decisions-neg-delta/gcc-14/coverage.html
+++ b/tests/decisions/reference/decisions-neg-delta/gcc-14/coverage.html
@@ -125,7 +125,7 @@
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="75.0">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-medium" style="width: 100%;">
         <div class="percent">75.0%</div>
-        <div class="counter" title="Exec / Excl / Total">3 /  / 4</div>
+        <div class="counter" title="Exec / Excl / Total">3 / - / 4</div>
       </div>
     </div>
   </div>

--- a/tests/decisions/reference/decisions-neg-delta/gcc-5/coverage.html
+++ b/tests/decisions/reference/decisions-neg-delta/gcc-5/coverage.html
@@ -113,7 +113,7 @@
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="75.0">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-medium" style="width: 100%;">
         <div class="percent">75.0%</div>
-        <div class="counter" title="Exec / Excl / Total">3 /  / 4</div>
+        <div class="counter" title="Exec / Excl / Total">3 / - / 4</div>
       </div>
     </div>
   </div>

--- a/tests/decisions/reference/decisions/clang-10/coverage.html
+++ b/tests/decisions/reference/decisions/clang-10/coverage.html
@@ -113,7 +113,7 @@
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="50.7">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-low" style="width: 100%;">
         <div class="percent">50.7%</div>
-        <div class="counter" title="Exec / Excl / Total">35 /  / 69</div>
+        <div class="counter" title="Exec / Excl / Total">35 / - / 69</div>
       </div>
     </div>
   </div>
@@ -149,7 +149,7 @@
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="-">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-unknown" style="width: 100%;">
         <div class="percent">-%</div>
-        <div class="counter" title="Exec / Excl / Total">0 /  / 0</div>
+        <div class="counter" title="Exec / Excl / Total">0 / - / 0</div>
       </div>
     </div>
   </div>
@@ -185,7 +185,7 @@
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="33.3">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-low" style="width: 100%;">
         <div class="percent">33.3%</div>
-        <div class="counter" title="Exec / Excl / Total">1 /  / 3</div>
+        <div class="counter" title="Exec / Excl / Total">1 / - / 3</div>
       </div>
     </div>
   </div>

--- a/tests/decisions/reference/decisions/clang-12/coverage.html
+++ b/tests/decisions/reference/decisions/clang-12/coverage.html
@@ -113,7 +113,7 @@
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="50.7">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-low" style="width: 100%;">
         <div class="percent">50.7%</div>
-        <div class="counter" title="Exec / Excl / Total">35 /  / 69</div>
+        <div class="counter" title="Exec / Excl / Total">35 / - / 69</div>
       </div>
     </div>
   </div>
@@ -149,7 +149,7 @@
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="-">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-unknown" style="width: 100%;">
         <div class="percent">-%</div>
-        <div class="counter" title="Exec / Excl / Total">0 /  / 0</div>
+        <div class="counter" title="Exec / Excl / Total">0 / - / 0</div>
       </div>
     </div>
   </div>
@@ -185,7 +185,7 @@
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="33.3">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-low" style="width: 100%;">
         <div class="percent">33.3%</div>
-        <div class="counter" title="Exec / Excl / Total">1 /  / 3</div>
+        <div class="counter" title="Exec / Excl / Total">1 / - / 3</div>
       </div>
     </div>
   </div>

--- a/tests/decisions/reference/decisions/gcc-11/coverage.html
+++ b/tests/decisions/reference/decisions/gcc-11/coverage.html
@@ -113,7 +113,7 @@
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="50.7">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-low" style="width: 100%;">
         <div class="percent">50.7%</div>
-        <div class="counter" title="Exec / Excl / Total">35 /  / 69</div>
+        <div class="counter" title="Exec / Excl / Total">35 / - / 69</div>
       </div>
     </div>
   </div>
@@ -149,7 +149,7 @@
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="-">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-unknown" style="width: 100%;">
         <div class="percent">-%</div>
-        <div class="counter" title="Exec / Excl / Total">0 /  / 0</div>
+        <div class="counter" title="Exec / Excl / Total">0 / - / 0</div>
       </div>
     </div>
   </div>
@@ -185,7 +185,7 @@
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="33.3">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-low" style="width: 100%;">
         <div class="percent">33.3%</div>
-        <div class="counter" title="Exec / Excl / Total">1 /  / 3</div>
+        <div class="counter" title="Exec / Excl / Total">1 / - / 3</div>
       </div>
     </div>
   </div>

--- a/tests/decisions/reference/decisions/gcc-12/coverage.html
+++ b/tests/decisions/reference/decisions/gcc-12/coverage.html
@@ -113,7 +113,7 @@
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="50.7">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-low" style="width: 100%;">
         <div class="percent">50.7%</div>
-        <div class="counter" title="Exec / Excl / Total">35 /  / 69</div>
+        <div class="counter" title="Exec / Excl / Total">35 / - / 69</div>
       </div>
     </div>
   </div>
@@ -149,7 +149,7 @@
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="-">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-unknown" style="width: 100%;">
         <div class="percent">-%</div>
-        <div class="counter" title="Exec / Excl / Total">0 /  / 0</div>
+        <div class="counter" title="Exec / Excl / Total">0 / - / 0</div>
       </div>
     </div>
   </div>
@@ -185,7 +185,7 @@
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="33.3">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-low" style="width: 100%;">
         <div class="percent">33.3%</div>
-        <div class="counter" title="Exec / Excl / Total">1 /  / 3</div>
+        <div class="counter" title="Exec / Excl / Total">1 / - / 3</div>
       </div>
     </div>
   </div>

--- a/tests/decisions/reference/decisions/gcc-14/coverage.html
+++ b/tests/decisions/reference/decisions/gcc-14/coverage.html
@@ -125,7 +125,7 @@
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="50.7">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-low" style="width: 100%;">
         <div class="percent">50.7%</div>
-        <div class="counter" title="Exec / Excl / Total">35 /  / 69</div>
+        <div class="counter" title="Exec / Excl / Total">35 / - / 69</div>
       </div>
     </div>
   </div>
@@ -167,7 +167,7 @@
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="-">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-unknown" style="width: 100%;">
         <div class="percent">-%</div>
-        <div class="counter" title="Exec / Excl / Total">0 /  / 0</div>
+        <div class="counter" title="Exec / Excl / Total">0 / - / 0</div>
       </div>
     </div>
   </div>
@@ -209,7 +209,7 @@
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="33.3">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-low" style="width: 100%;">
         <div class="percent">33.3%</div>
-        <div class="counter" title="Exec / Excl / Total">1 /  / 3</div>
+        <div class="counter" title="Exec / Excl / Total">1 / - / 3</div>
       </div>
     </div>
   </div>

--- a/tests/decisions/reference/decisions/gcc-5/coverage.html
+++ b/tests/decisions/reference/decisions/gcc-5/coverage.html
@@ -113,7 +113,7 @@
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="50.7">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-low" style="width: 100%;">
         <div class="percent">50.7%</div>
-        <div class="counter" title="Exec / Excl / Total">35 /  / 69</div>
+        <div class="counter" title="Exec / Excl / Total">35 / - / 69</div>
       </div>
     </div>
   </div>

--- a/tests/decisions/reference/decisions/gcc-6/coverage.html
+++ b/tests/decisions/reference/decisions/gcc-6/coverage.html
@@ -113,7 +113,7 @@
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="50.7">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-low" style="width: 100%;">
         <div class="percent">50.7%</div>
-        <div class="counter" title="Exec / Excl / Total">35 /  / 69</div>
+        <div class="counter" title="Exec / Excl / Total">35 / - / 69</div>
       </div>
     </div>
   </div>
@@ -149,7 +149,7 @@
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="-">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-unknown" style="width: 100%;">
         <div class="percent">-%</div>
-        <div class="counter" title="Exec / Excl / Total">0 /  / 0</div>
+        <div class="counter" title="Exec / Excl / Total">0 / - / 0</div>
       </div>
     </div>
   </div>
@@ -185,7 +185,7 @@
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="33.3">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-low" style="width: 100%;">
         <div class="percent">33.3%</div>
-        <div class="counter" title="Exec / Excl / Total">1 /  / 3</div>
+        <div class="counter" title="Exec / Excl / Total">1 / - / 3</div>
       </div>
     </div>
   </div>

--- a/tests/decisions/reference/decisions/gcc-7/coverage.html
+++ b/tests/decisions/reference/decisions/gcc-7/coverage.html
@@ -113,7 +113,7 @@
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="50.7">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-low" style="width: 100%;">
         <div class="percent">50.7%</div>
-        <div class="counter" title="Exec / Excl / Total">35 /  / 69</div>
+        <div class="counter" title="Exec / Excl / Total">35 / - / 69</div>
       </div>
     </div>
   </div>
@@ -149,7 +149,7 @@
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="-">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-unknown" style="width: 100%;">
         <div class="percent">-%</div>
-        <div class="counter" title="Exec / Excl / Total">0 /  / 0</div>
+        <div class="counter" title="Exec / Excl / Total">0 / - / 0</div>
       </div>
     </div>
   </div>
@@ -185,7 +185,7 @@
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="33.3">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-low" style="width: 100%;">
         <div class="percent">33.3%</div>
-        <div class="counter" title="Exec / Excl / Total">1 /  / 3</div>
+        <div class="counter" title="Exec / Excl / Total">1 / - / 3</div>
       </div>
     </div>
   </div>

--- a/tests/decisions/reference/decisions/gcc-8/coverage.html
+++ b/tests/decisions/reference/decisions/gcc-8/coverage.html
@@ -113,7 +113,7 @@
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="50.7">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-low" style="width: 100%;">
         <div class="percent">50.7%</div>
-        <div class="counter" title="Exec / Excl / Total">35 /  / 69</div>
+        <div class="counter" title="Exec / Excl / Total">35 / - / 69</div>
       </div>
     </div>
   </div>
@@ -149,7 +149,7 @@
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="-">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-unknown" style="width: 100%;">
         <div class="percent">-%</div>
-        <div class="counter" title="Exec / Excl / Total">0 /  / 0</div>
+        <div class="counter" title="Exec / Excl / Total">0 / - / 0</div>
       </div>
     </div>
   </div>
@@ -185,7 +185,7 @@
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="33.3">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-low" style="width: 100%;">
         <div class="percent">33.3%</div>
-        <div class="counter" title="Exec / Excl / Total">1 /  / 3</div>
+        <div class="counter" title="Exec / Excl / Total">1 / - / 3</div>
       </div>
     </div>
   </div>

--- a/tests/html/reference/details-theme-boost-blue/clang-10/coverage_details.css
+++ b/tests/html/reference/details-theme-boost-blue/clang-10/coverage_details.css
@@ -1708,6 +1708,18 @@ tr.source-line.nav-highlight > td {
   display: none;
 }
 
+.source-functions-list.hide-col-condition .col-conditions {
+  display: none;
+}
+
+.source-functions-list.hide-col-decision .col-decisions {
+  display: none;
+}
+
+.source-functions-list.hide-col-call .col-calls {
+  display: none;
+}
+
 .source-function-header {
   display: flex;
   align-items: center;
@@ -2069,6 +2081,9 @@ tr.source-line.nav-highlight > td {
 
 /* Column visibility toggle hide rules */
 .source-table.hide-col-branch .col-branch { display: none; }
+.source-table.hide-col-condition .col-condition { display: none; }
+.source-table.hide-col-decision .col-decision { display: none; }
+.source-table.hide-col-call .col-call { display: none; }
 .source-table.hide-col-tla .col-tla { display: none; }
 .source-table.hide-col-count .col-count { display: none; }
 

--- a/tests/html/reference/details-theme-boost-blue/clang-10/coverage_details.functions.html
+++ b/tests/html/reference/details-theme-boost-blue/clang-10/coverage_details.functions.html
@@ -94,7 +94,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z3fooi",
@@ -105,7 +107,9 @@
     "excluded": false,
     "line_coverage": "80.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z4bar_v",
@@ -116,7 +120,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z4foo5i",
@@ -127,7 +133,9 @@
     "excluded": false,
     "line_coverage": "80.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z4foo6i",
@@ -138,7 +146,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z6foobari",
@@ -149,7 +159,9 @@
     "excluded": false,
     "line_coverage": "80.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z8four_barv",
@@ -160,7 +172,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z9four_bar_v",
@@ -171,7 +185,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z9uncoveredv",
@@ -182,7 +198,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ]
 </script>
@@ -191,7 +209,9 @@
     singlePage: false,
     htmlFilename: "",
     showBranches: true,
-    showConditions: false
+    showConditions: false,
+    showDecisions: false,
+    showCalls: false
   };
 </script>          </section>
         </div>

--- a/tests/html/reference/details-theme-boost-blue/clang-10/coverage_details.js
+++ b/tests/html/reference/details-theme-boost-blue/clang-10/coverage_details.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/html/reference/details-theme-boost-blue/clang-12/coverage_details.css
+++ b/tests/html/reference/details-theme-boost-blue/clang-12/coverage_details.css
@@ -1708,6 +1708,18 @@ tr.source-line.nav-highlight > td {
   display: none;
 }
 
+.source-functions-list.hide-col-condition .col-conditions {
+  display: none;
+}
+
+.source-functions-list.hide-col-decision .col-decisions {
+  display: none;
+}
+
+.source-functions-list.hide-col-call .col-calls {
+  display: none;
+}
+
 .source-function-header {
   display: flex;
   align-items: center;
@@ -2069,6 +2081,9 @@ tr.source-line.nav-highlight > td {
 
 /* Column visibility toggle hide rules */
 .source-table.hide-col-branch .col-branch { display: none; }
+.source-table.hide-col-condition .col-condition { display: none; }
+.source-table.hide-col-decision .col-decision { display: none; }
+.source-table.hide-col-call .col-call { display: none; }
 .source-table.hide-col-tla .col-tla { display: none; }
 .source-table.hide-col-count .col-count { display: none; }
 

--- a/tests/html/reference/details-theme-boost-blue/clang-12/coverage_details.functions.html
+++ b/tests/html/reference/details-theme-boost-blue/clang-12/coverage_details.functions.html
@@ -94,7 +94,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "bar_()",
@@ -105,7 +107,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo(int)",
@@ -116,7 +120,9 @@
     "excluded": false,
     "line_coverage": "80.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo5(int)",
@@ -127,7 +133,9 @@
     "excluded": false,
     "line_coverage": "80.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo6(int)",
@@ -138,7 +146,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foobar(int)",
@@ -149,7 +159,9 @@
     "excluded": false,
     "line_coverage": "80.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "four_bar()",
@@ -160,7 +172,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "four_bar_()",
@@ -171,7 +185,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "uncovered()",
@@ -182,7 +198,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ]
 </script>
@@ -191,7 +209,9 @@
     singlePage: false,
     htmlFilename: "",
     showBranches: true,
-    showConditions: false
+    showConditions: false,
+    showDecisions: false,
+    showCalls: false
   };
 </script>          </section>
         </div>

--- a/tests/html/reference/details-theme-boost-blue/clang-12/coverage_details.js
+++ b/tests/html/reference/details-theme-boost-blue/clang-12/coverage_details.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/html/reference/details-theme-boost-blue/gcc-14/coverage_details.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html
+++ b/tests/html/reference/details-theme-boost-blue/gcc-14/coverage_details.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html
@@ -64,6 +64,9 @@
       <span class="stat coverage-unknown">
         <strong>-%</strong> Branches (0/0)
       </span>
+      <span class="stat coverage-unknown">
+        <strong>-%</strong> Conditions (0/0)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -85,6 +88,7 @@
       </button>
     </div>
     <div class="source-column-filters">
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/html/reference/details-theme-boost-blue/gcc-14/coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/details-theme-boost-blue/gcc-14/coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -64,6 +64,9 @@
       <span class="stat coverage-low">
         <strong>50.0%</strong> Branches (1/2)
       </span>
+      <span class="stat coverage-low">
+        <strong>50.0%</strong> Conditions (1/2)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -89,6 +92,7 @@
     </div>
     <div class="source-column-filters">
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="branch" title="Toggle Branch column">Branch</button>
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/html/reference/details-theme-boost-blue/gcc-14/coverage_details.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
+++ b/tests/html/reference/details-theme-boost-blue/gcc-14/coverage_details.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
@@ -64,6 +64,9 @@
       <span class="stat coverage-none">
         <strong>0.0%</strong> Branches (0/2)
       </span>
+      <span class="stat coverage-none">
+        <strong>0.0%</strong> Conditions (0/2)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -85,6 +88,7 @@
       </button>
     </div>
     <div class="source-column-filters">
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/html/reference/details-theme-boost-blue/gcc-14/coverage_details.css
+++ b/tests/html/reference/details-theme-boost-blue/gcc-14/coverage_details.css
@@ -1290,17 +1290,17 @@ body.sidebar-resizing .main-content {
 /* Adjust grid when columns are hidden */
 .no-functions.no-branches .file-list-header,
 .no-functions.no-branches .file-row {
-  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px;
+  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px 116px;
 }
 
 .no-functions:not(.no-branches) .file-list-header,
 .no-functions:not(.no-branches) .file-row {
-  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px 116px;
+  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px 116px 116px;
 }
 
 .no-branches:not(.no-functions) .file-list-header,
 .no-branches:not(.no-functions) .file-row {
-  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px 116px;
+  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px 116px 116px;
 }
 
 .file-row:nth-child(even) {
@@ -1708,6 +1708,18 @@ tr.source-line.nav-highlight > td {
   display: none;
 }
 
+.source-functions-list.hide-col-condition .col-conditions {
+  display: none;
+}
+
+.source-functions-list.hide-col-decision .col-decisions {
+  display: none;
+}
+
+.source-functions-list.hide-col-call .col-calls {
+  display: none;
+}
+
 .source-function-header {
   display: flex;
   align-items: center;
@@ -2069,6 +2081,9 @@ tr.source-line.nav-highlight > td {
 
 /* Column visibility toggle hide rules */
 .source-table.hide-col-branch .col-branch { display: none; }
+.source-table.hide-col-condition .col-condition { display: none; }
+.source-table.hide-col-decision .col-decision { display: none; }
+.source-table.hide-col-call .col-call { display: none; }
 .source-table.hide-col-tla .col-tla { display: none; }
 .source-table.hide-col-count .col-count { display: none; }
 
@@ -2298,7 +2313,7 @@ tr.source-line.nav-highlight > td {
 
 .functions-header {
   display: grid;
-  grid-template-columns: 1fr 90px 70px 90px;
+  grid-template-columns: 1fr 90px 70px 90px 90px;
   gap: 0;
   padding: 0 16px;
   background: var(--bg-tertiary);
@@ -2342,7 +2357,7 @@ tr.source-line.nav-highlight > td {
 
 .function-row {
   display: grid;
-  grid-template-columns: 1fr 90px 70px 90px;
+  grid-template-columns: 1fr 90px 70px 90px 90px;
   gap: 0;
   padding: 0 16px;
   border-bottom: 1px solid var(--border-muted);
@@ -2352,7 +2367,7 @@ tr.source-line.nav-highlight > td {
 
 .functions-container.no-branches .functions-header,
 .functions-container.no-branches .function-row {
-  grid-template-columns: 1fr 90px 70px;
+  grid-template-columns: 1fr 90px 70px 90px;
 }
 
 .function-row > div:not(:first-child) {

--- a/tests/html/reference/details-theme-boost-blue/gcc-14/coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/details-theme-boost-blue/gcc-14/coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -64,6 +64,9 @@
       <span class="stat coverage-low">
         <strong>50.0%</strong> Branches (1/2)
       </span>
+      <span class="stat coverage-low">
+        <strong>50.0%</strong> Conditions (1/2)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -89,6 +92,7 @@
     </div>
     <div class="source-column-filters">
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="branch" title="Toggle Branch column">Branch</button>
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/html/reference/details-theme-boost-blue/gcc-14/coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/details-theme-boost-blue/gcc-14/coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -64,6 +64,9 @@
       <span class="stat coverage-none">
         <strong>0.0%</strong> Branches (0/2)
       </span>
+      <span class="stat coverage-none">
+        <strong>0.0%</strong> Conditions (0/2)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -85,6 +88,7 @@
       </button>
     </div>
     <div class="source-column-filters">
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/html/reference/details-theme-boost-blue/gcc-14/coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/details-theme-boost-blue/gcc-14/coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -64,6 +64,9 @@
       <span class="stat coverage-low">
         <strong>50.0%</strong> Branches (1/2)
       </span>
+      <span class="stat coverage-low">
+        <strong>50.0%</strong> Conditions (1/2)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -89,6 +92,7 @@
     </div>
     <div class="source-column-filters">
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="branch" title="Toggle Branch column">Branch</button>
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/html/reference/details-theme-boost-blue/gcc-14/coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/details-theme-boost-blue/gcc-14/coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -64,6 +64,9 @@
       <span class="stat coverage-unknown">
         <strong>-%</strong> Branches (0/0)
       </span>
+      <span class="stat coverage-unknown">
+        <strong>-%</strong> Conditions (0/0)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -85,6 +88,7 @@
       </button>
     </div>
     <div class="source-column-filters">
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/html/reference/details-theme-boost-blue/gcc-14/coverage_details.functions.html
+++ b/tests/html/reference/details-theme-boost-blue/gcc-14/coverage_details.functions.html
@@ -65,6 +65,10 @@
     <span class="stat-label">Branches:</span>
     <span class="stat-value coverage-low">30.0%</span>
   </div>
+  <div class="summary-stat">
+    <span class="stat-label">Conditions:</span>
+    <span class="stat-value coverage-low">30.0%</span>
+  </div>
 </div>          </section>
 
           <section class="main-section">
@@ -95,7 +99,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "bar_()",
@@ -106,7 +112,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo(int)",
@@ -117,7 +125,9 @@
     "excluded": false,
     "line_coverage": "75.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "50.0"
+    "condition_coverage": "50.0",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo5(int)",
@@ -128,7 +138,9 @@
     "excluded": false,
     "line_coverage": "75.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "50.0"
+    "condition_coverage": "50.0",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo6(int)",
@@ -139,7 +151,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "0.0"
+    "condition_coverage": "0.0",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foobar(int)",
@@ -150,7 +164,9 @@
     "excluded": false,
     "line_coverage": "75.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "50.0"
+    "condition_coverage": "50.0",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "four_bar()",
@@ -161,7 +177,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "four_bar_()",
@@ -172,7 +190,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "0.0"
+    "condition_coverage": "0.0",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "uncovered()",
@@ -183,7 +203,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ]
 </script>
@@ -192,7 +214,9 @@
     singlePage: false,
     htmlFilename: "",
     showBranches: true,
-    showConditions: true
+    showConditions: true,
+    showDecisions: false,
+    showCalls: false
   };
 </script>          </section>
         </div>

--- a/tests/html/reference/details-theme-boost-blue/gcc-14/coverage_details.html
+++ b/tests/html/reference/details-theme-boost-blue/gcc-14/coverage_details.html
@@ -126,6 +126,31 @@
       </div>
     </div>
   </div>
+
+  <div class="summary-card">
+    <div class="summary-card-header">
+      <h3>Conditions</h3>
+    </div>
+    <div class="summary-card-body">
+      <div class="coverage-ring coverage-low">
+        <svg viewBox="0 0 36 36">
+          <path class="ring-bg" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+          <path class="ring-fill" stroke-dasharray="30.0, 100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+        </svg>
+        <span class="ring-text">30.0%</span>
+      </div>
+      <div class="summary-stats">
+        <div class="stat-row">
+          <span class="stat-label">Hit</span>
+          <span class="stat-value">3</span>
+        </div>
+        <div class="stat-row">
+          <span class="stat-label">Total</span>
+          <span class="stat-value">10</span>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 
 <div class="coverage-legend">

--- a/tests/html/reference/details-theme-boost-blue/gcc-14/coverage_details.js
+++ b/tests/html/reference/details-theme-boost-blue/gcc-14/coverage_details.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/html/reference/details-theme-boost-blue/gcc-5/coverage_details.css
+++ b/tests/html/reference/details-theme-boost-blue/gcc-5/coverage_details.css
@@ -1708,6 +1708,18 @@ tr.source-line.nav-highlight > td {
   display: none;
 }
 
+.source-functions-list.hide-col-condition .col-conditions {
+  display: none;
+}
+
+.source-functions-list.hide-col-decision .col-decisions {
+  display: none;
+}
+
+.source-functions-list.hide-col-call .col-calls {
+  display: none;
+}
+
 .source-function-header {
   display: flex;
   align-items: center;
@@ -2069,6 +2081,9 @@ tr.source-line.nav-highlight > td {
 
 /* Column visibility toggle hide rules */
 .source-table.hide-col-branch .col-branch { display: none; }
+.source-table.hide-col-condition .col-condition { display: none; }
+.source-table.hide-col-decision .col-decision { display: none; }
+.source-table.hide-col-call .col-call { display: none; }
 .source-table.hide-col-tla .col-tla { display: none; }
 .source-table.hide-col-count .col-count { display: none; }
 

--- a/tests/html/reference/details-theme-boost-blue/gcc-5/coverage_details.functions.html
+++ b/tests/html/reference/details-theme-boost-blue/gcc-5/coverage_details.functions.html
@@ -94,7 +94,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "bar_()",
@@ -105,7 +107,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo(int)",
@@ -116,7 +120,9 @@
     "excluded": false,
     "line_coverage": "75.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo5(int)",
@@ -127,7 +133,9 @@
     "excluded": false,
     "line_coverage": "75.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo6(int)",
@@ -138,7 +146,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foobar(int)",
@@ -149,7 +159,9 @@
     "excluded": false,
     "line_coverage": "75.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "four_bar()",
@@ -160,7 +172,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "four_bar_()",
@@ -171,7 +185,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "uncovered()",
@@ -182,7 +198,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ]
 </script>
@@ -191,7 +209,9 @@
     singlePage: false,
     htmlFilename: "",
     showBranches: true,
-    showConditions: false
+    showConditions: false,
+    showDecisions: false,
+    showCalls: false
   };
 </script>          </section>
         </div>

--- a/tests/html/reference/details-theme-boost-blue/gcc-5/coverage_details.js
+++ b/tests/html/reference/details-theme-boost-blue/gcc-5/coverage_details.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/html/reference/details-theme-boost-green/clang-10/coverage_details.css
+++ b/tests/html/reference/details-theme-boost-green/clang-10/coverage_details.css
@@ -1708,6 +1708,18 @@ tr.source-line.nav-highlight > td {
   display: none;
 }
 
+.source-functions-list.hide-col-condition .col-conditions {
+  display: none;
+}
+
+.source-functions-list.hide-col-decision .col-decisions {
+  display: none;
+}
+
+.source-functions-list.hide-col-call .col-calls {
+  display: none;
+}
+
 .source-function-header {
   display: flex;
   align-items: center;
@@ -2069,6 +2081,9 @@ tr.source-line.nav-highlight > td {
 
 /* Column visibility toggle hide rules */
 .source-table.hide-col-branch .col-branch { display: none; }
+.source-table.hide-col-condition .col-condition { display: none; }
+.source-table.hide-col-decision .col-decision { display: none; }
+.source-table.hide-col-call .col-call { display: none; }
 .source-table.hide-col-tla .col-tla { display: none; }
 .source-table.hide-col-count .col-count { display: none; }
 

--- a/tests/html/reference/details-theme-boost-green/clang-10/coverage_details.functions.html
+++ b/tests/html/reference/details-theme-boost-green/clang-10/coverage_details.functions.html
@@ -94,7 +94,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z3fooi",
@@ -105,7 +107,9 @@
     "excluded": false,
     "line_coverage": "80.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z4bar_v",
@@ -116,7 +120,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z4foo5i",
@@ -127,7 +133,9 @@
     "excluded": false,
     "line_coverage": "80.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z4foo6i",
@@ -138,7 +146,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z6foobari",
@@ -149,7 +159,9 @@
     "excluded": false,
     "line_coverage": "80.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z8four_barv",
@@ -160,7 +172,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z9four_bar_v",
@@ -171,7 +185,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z9uncoveredv",
@@ -182,7 +198,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ]
 </script>
@@ -191,7 +209,9 @@
     singlePage: false,
     htmlFilename: "",
     showBranches: true,
-    showConditions: false
+    showConditions: false,
+    showDecisions: false,
+    showCalls: false
   };
 </script>          </section>
         </div>

--- a/tests/html/reference/details-theme-boost-green/clang-10/coverage_details.js
+++ b/tests/html/reference/details-theme-boost-green/clang-10/coverage_details.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/html/reference/details-theme-boost-green/clang-12/coverage_details.css
+++ b/tests/html/reference/details-theme-boost-green/clang-12/coverage_details.css
@@ -1708,6 +1708,18 @@ tr.source-line.nav-highlight > td {
   display: none;
 }
 
+.source-functions-list.hide-col-condition .col-conditions {
+  display: none;
+}
+
+.source-functions-list.hide-col-decision .col-decisions {
+  display: none;
+}
+
+.source-functions-list.hide-col-call .col-calls {
+  display: none;
+}
+
 .source-function-header {
   display: flex;
   align-items: center;
@@ -2069,6 +2081,9 @@ tr.source-line.nav-highlight > td {
 
 /* Column visibility toggle hide rules */
 .source-table.hide-col-branch .col-branch { display: none; }
+.source-table.hide-col-condition .col-condition { display: none; }
+.source-table.hide-col-decision .col-decision { display: none; }
+.source-table.hide-col-call .col-call { display: none; }
 .source-table.hide-col-tla .col-tla { display: none; }
 .source-table.hide-col-count .col-count { display: none; }
 

--- a/tests/html/reference/details-theme-boost-green/clang-12/coverage_details.functions.html
+++ b/tests/html/reference/details-theme-boost-green/clang-12/coverage_details.functions.html
@@ -94,7 +94,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "bar_()",
@@ -105,7 +107,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo(int)",
@@ -116,7 +120,9 @@
     "excluded": false,
     "line_coverage": "80.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo5(int)",
@@ -127,7 +133,9 @@
     "excluded": false,
     "line_coverage": "80.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo6(int)",
@@ -138,7 +146,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foobar(int)",
@@ -149,7 +159,9 @@
     "excluded": false,
     "line_coverage": "80.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "four_bar()",
@@ -160,7 +172,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "four_bar_()",
@@ -171,7 +185,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "uncovered()",
@@ -182,7 +198,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ]
 </script>
@@ -191,7 +209,9 @@
     singlePage: false,
     htmlFilename: "",
     showBranches: true,
-    showConditions: false
+    showConditions: false,
+    showDecisions: false,
+    showCalls: false
   };
 </script>          </section>
         </div>

--- a/tests/html/reference/details-theme-boost-green/clang-12/coverage_details.js
+++ b/tests/html/reference/details-theme-boost-green/clang-12/coverage_details.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/html/reference/details-theme-boost-green/gcc-14/coverage_details.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html
+++ b/tests/html/reference/details-theme-boost-green/gcc-14/coverage_details.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html
@@ -64,6 +64,9 @@
       <span class="stat coverage-unknown">
         <strong>-%</strong> Branches (0/0)
       </span>
+      <span class="stat coverage-unknown">
+        <strong>-%</strong> Conditions (0/0)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -85,6 +88,7 @@
       </button>
     </div>
     <div class="source-column-filters">
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/html/reference/details-theme-boost-green/gcc-14/coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/details-theme-boost-green/gcc-14/coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -64,6 +64,9 @@
       <span class="stat coverage-low">
         <strong>50.0%</strong> Branches (1/2)
       </span>
+      <span class="stat coverage-low">
+        <strong>50.0%</strong> Conditions (1/2)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -89,6 +92,7 @@
     </div>
     <div class="source-column-filters">
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="branch" title="Toggle Branch column">Branch</button>
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/html/reference/details-theme-boost-green/gcc-14/coverage_details.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
+++ b/tests/html/reference/details-theme-boost-green/gcc-14/coverage_details.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
@@ -64,6 +64,9 @@
       <span class="stat coverage-none">
         <strong>0.0%</strong> Branches (0/2)
       </span>
+      <span class="stat coverage-none">
+        <strong>0.0%</strong> Conditions (0/2)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -85,6 +88,7 @@
       </button>
     </div>
     <div class="source-column-filters">
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/html/reference/details-theme-boost-green/gcc-14/coverage_details.css
+++ b/tests/html/reference/details-theme-boost-green/gcc-14/coverage_details.css
@@ -1290,17 +1290,17 @@ body.sidebar-resizing .main-content {
 /* Adjust grid when columns are hidden */
 .no-functions.no-branches .file-list-header,
 .no-functions.no-branches .file-row {
-  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px;
+  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px 116px;
 }
 
 .no-functions:not(.no-branches) .file-list-header,
 .no-functions:not(.no-branches) .file-row {
-  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px 116px;
+  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px 116px 116px;
 }
 
 .no-branches:not(.no-functions) .file-list-header,
 .no-branches:not(.no-functions) .file-row {
-  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px 116px;
+  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px 116px 116px;
 }
 
 .file-row:nth-child(even) {
@@ -1708,6 +1708,18 @@ tr.source-line.nav-highlight > td {
   display: none;
 }
 
+.source-functions-list.hide-col-condition .col-conditions {
+  display: none;
+}
+
+.source-functions-list.hide-col-decision .col-decisions {
+  display: none;
+}
+
+.source-functions-list.hide-col-call .col-calls {
+  display: none;
+}
+
 .source-function-header {
   display: flex;
   align-items: center;
@@ -2069,6 +2081,9 @@ tr.source-line.nav-highlight > td {
 
 /* Column visibility toggle hide rules */
 .source-table.hide-col-branch .col-branch { display: none; }
+.source-table.hide-col-condition .col-condition { display: none; }
+.source-table.hide-col-decision .col-decision { display: none; }
+.source-table.hide-col-call .col-call { display: none; }
 .source-table.hide-col-tla .col-tla { display: none; }
 .source-table.hide-col-count .col-count { display: none; }
 
@@ -2298,7 +2313,7 @@ tr.source-line.nav-highlight > td {
 
 .functions-header {
   display: grid;
-  grid-template-columns: 1fr 90px 70px 90px;
+  grid-template-columns: 1fr 90px 70px 90px 90px;
   gap: 0;
   padding: 0 16px;
   background: var(--bg-tertiary);
@@ -2342,7 +2357,7 @@ tr.source-line.nav-highlight > td {
 
 .function-row {
   display: grid;
-  grid-template-columns: 1fr 90px 70px 90px;
+  grid-template-columns: 1fr 90px 70px 90px 90px;
   gap: 0;
   padding: 0 16px;
   border-bottom: 1px solid var(--border-muted);
@@ -2352,7 +2367,7 @@ tr.source-line.nav-highlight > td {
 
 .functions-container.no-branches .functions-header,
 .functions-container.no-branches .function-row {
-  grid-template-columns: 1fr 90px 70px;
+  grid-template-columns: 1fr 90px 70px 90px;
 }
 
 .function-row > div:not(:first-child) {

--- a/tests/html/reference/details-theme-boost-green/gcc-14/coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/details-theme-boost-green/gcc-14/coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -64,6 +64,9 @@
       <span class="stat coverage-low">
         <strong>50.0%</strong> Branches (1/2)
       </span>
+      <span class="stat coverage-low">
+        <strong>50.0%</strong> Conditions (1/2)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -89,6 +92,7 @@
     </div>
     <div class="source-column-filters">
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="branch" title="Toggle Branch column">Branch</button>
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/html/reference/details-theme-boost-green/gcc-14/coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/details-theme-boost-green/gcc-14/coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -64,6 +64,9 @@
       <span class="stat coverage-none">
         <strong>0.0%</strong> Branches (0/2)
       </span>
+      <span class="stat coverage-none">
+        <strong>0.0%</strong> Conditions (0/2)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -85,6 +88,7 @@
       </button>
     </div>
     <div class="source-column-filters">
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/html/reference/details-theme-boost-green/gcc-14/coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/details-theme-boost-green/gcc-14/coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -64,6 +64,9 @@
       <span class="stat coverage-low">
         <strong>50.0%</strong> Branches (1/2)
       </span>
+      <span class="stat coverage-low">
+        <strong>50.0%</strong> Conditions (1/2)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -89,6 +92,7 @@
     </div>
     <div class="source-column-filters">
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="branch" title="Toggle Branch column">Branch</button>
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/html/reference/details-theme-boost-green/gcc-14/coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/details-theme-boost-green/gcc-14/coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -64,6 +64,9 @@
       <span class="stat coverage-unknown">
         <strong>-%</strong> Branches (0/0)
       </span>
+      <span class="stat coverage-unknown">
+        <strong>-%</strong> Conditions (0/0)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -85,6 +88,7 @@
       </button>
     </div>
     <div class="source-column-filters">
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/html/reference/details-theme-boost-green/gcc-14/coverage_details.functions.html
+++ b/tests/html/reference/details-theme-boost-green/gcc-14/coverage_details.functions.html
@@ -65,6 +65,10 @@
     <span class="stat-label">Branches:</span>
     <span class="stat-value coverage-low">30.0%</span>
   </div>
+  <div class="summary-stat">
+    <span class="stat-label">Conditions:</span>
+    <span class="stat-value coverage-low">30.0%</span>
+  </div>
 </div>          </section>
 
           <section class="main-section">
@@ -95,7 +99,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "bar_()",
@@ -106,7 +112,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo(int)",
@@ -117,7 +125,9 @@
     "excluded": false,
     "line_coverage": "75.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "50.0"
+    "condition_coverage": "50.0",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo5(int)",
@@ -128,7 +138,9 @@
     "excluded": false,
     "line_coverage": "75.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "50.0"
+    "condition_coverage": "50.0",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo6(int)",
@@ -139,7 +151,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "0.0"
+    "condition_coverage": "0.0",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foobar(int)",
@@ -150,7 +164,9 @@
     "excluded": false,
     "line_coverage": "75.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "50.0"
+    "condition_coverage": "50.0",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "four_bar()",
@@ -161,7 +177,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "four_bar_()",
@@ -172,7 +190,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "0.0"
+    "condition_coverage": "0.0",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "uncovered()",
@@ -183,7 +203,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ]
 </script>
@@ -192,7 +214,9 @@
     singlePage: false,
     htmlFilename: "",
     showBranches: true,
-    showConditions: true
+    showConditions: true,
+    showDecisions: false,
+    showCalls: false
   };
 </script>          </section>
         </div>

--- a/tests/html/reference/details-theme-boost-green/gcc-14/coverage_details.html
+++ b/tests/html/reference/details-theme-boost-green/gcc-14/coverage_details.html
@@ -126,6 +126,31 @@
       </div>
     </div>
   </div>
+
+  <div class="summary-card">
+    <div class="summary-card-header">
+      <h3>Conditions</h3>
+    </div>
+    <div class="summary-card-body">
+      <div class="coverage-ring coverage-low">
+        <svg viewBox="0 0 36 36">
+          <path class="ring-bg" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+          <path class="ring-fill" stroke-dasharray="30.0, 100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+        </svg>
+        <span class="ring-text">30.0%</span>
+      </div>
+      <div class="summary-stats">
+        <div class="stat-row">
+          <span class="stat-label">Hit</span>
+          <span class="stat-value">3</span>
+        </div>
+        <div class="stat-row">
+          <span class="stat-label">Total</span>
+          <span class="stat-value">10</span>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 
 <div class="coverage-legend">

--- a/tests/html/reference/details-theme-boost-green/gcc-14/coverage_details.js
+++ b/tests/html/reference/details-theme-boost-green/gcc-14/coverage_details.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/html/reference/details-theme-boost-green/gcc-5/coverage_details.css
+++ b/tests/html/reference/details-theme-boost-green/gcc-5/coverage_details.css
@@ -1708,6 +1708,18 @@ tr.source-line.nav-highlight > td {
   display: none;
 }
 
+.source-functions-list.hide-col-condition .col-conditions {
+  display: none;
+}
+
+.source-functions-list.hide-col-decision .col-decisions {
+  display: none;
+}
+
+.source-functions-list.hide-col-call .col-calls {
+  display: none;
+}
+
 .source-function-header {
   display: flex;
   align-items: center;
@@ -2069,6 +2081,9 @@ tr.source-line.nav-highlight > td {
 
 /* Column visibility toggle hide rules */
 .source-table.hide-col-branch .col-branch { display: none; }
+.source-table.hide-col-condition .col-condition { display: none; }
+.source-table.hide-col-decision .col-decision { display: none; }
+.source-table.hide-col-call .col-call { display: none; }
 .source-table.hide-col-tla .col-tla { display: none; }
 .source-table.hide-col-count .col-count { display: none; }
 

--- a/tests/html/reference/details-theme-boost-green/gcc-5/coverage_details.functions.html
+++ b/tests/html/reference/details-theme-boost-green/gcc-5/coverage_details.functions.html
@@ -94,7 +94,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "bar_()",
@@ -105,7 +107,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo(int)",
@@ -116,7 +120,9 @@
     "excluded": false,
     "line_coverage": "75.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo5(int)",
@@ -127,7 +133,9 @@
     "excluded": false,
     "line_coverage": "75.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo6(int)",
@@ -138,7 +146,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foobar(int)",
@@ -149,7 +159,9 @@
     "excluded": false,
     "line_coverage": "75.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "four_bar()",
@@ -160,7 +172,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "four_bar_()",
@@ -171,7 +185,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "uncovered()",
@@ -182,7 +198,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ]
 </script>
@@ -191,7 +209,9 @@
     singlePage: false,
     htmlFilename: "",
     showBranches: true,
-    showConditions: false
+    showConditions: false,
+    showDecisions: false,
+    showCalls: false
   };
 </script>          </section>
         </div>

--- a/tests/html/reference/details-theme-boost-green/gcc-5/coverage_details.js
+++ b/tests/html/reference/details-theme-boost-green/gcc-5/coverage_details.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/html/reference/nested-theme-boost-blue/clang-10/coverage_nested.css
+++ b/tests/html/reference/nested-theme-boost-blue/clang-10/coverage_nested.css
@@ -1708,6 +1708,18 @@ tr.source-line.nav-highlight > td {
   display: none;
 }
 
+.source-functions-list.hide-col-condition .col-conditions {
+  display: none;
+}
+
+.source-functions-list.hide-col-decision .col-decisions {
+  display: none;
+}
+
+.source-functions-list.hide-col-call .col-calls {
+  display: none;
+}
+
 .source-function-header {
   display: flex;
   align-items: center;
@@ -2069,6 +2081,9 @@ tr.source-line.nav-highlight > td {
 
 /* Column visibility toggle hide rules */
 .source-table.hide-col-branch .col-branch { display: none; }
+.source-table.hide-col-condition .col-condition { display: none; }
+.source-table.hide-col-decision .col-decision { display: none; }
+.source-table.hide-col-call .col-call { display: none; }
 .source-table.hide-col-tla .col-tla { display: none; }
 .source-table.hide-col-count .col-count { display: none; }
 

--- a/tests/html/reference/nested-theme-boost-blue/clang-10/coverage_nested.functions.html
+++ b/tests/html/reference/nested-theme-boost-blue/clang-10/coverage_nested.functions.html
@@ -155,7 +155,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z3fooi",
@@ -166,7 +168,9 @@
     "excluded": false,
     "line_coverage": "80.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z4bar_v",
@@ -177,7 +181,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z4foo5i",
@@ -188,7 +194,9 @@
     "excluded": false,
     "line_coverage": "80.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z4foo6i",
@@ -199,7 +207,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z6foobari",
@@ -210,7 +220,9 @@
     "excluded": false,
     "line_coverage": "80.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z8four_barv",
@@ -221,7 +233,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z9four_bar_v",
@@ -232,7 +246,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z9uncoveredv",
@@ -243,7 +259,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "main",
@@ -254,7 +272,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "25.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ]
 </script>
@@ -263,7 +283,9 @@
     singlePage: false,
     htmlFilename: "",
     showBranches: true,
-    showConditions: false
+    showConditions: false,
+    showDecisions: false,
+    showCalls: false
   };
 </script>          </section>
         </div>

--- a/tests/html/reference/nested-theme-boost-blue/clang-10/coverage_nested.js
+++ b/tests/html/reference/nested-theme-boost-blue/clang-10/coverage_nested.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/html/reference/nested-theme-boost-blue/clang-12/coverage_nested.css
+++ b/tests/html/reference/nested-theme-boost-blue/clang-12/coverage_nested.css
@@ -1708,6 +1708,18 @@ tr.source-line.nav-highlight > td {
   display: none;
 }
 
+.source-functions-list.hide-col-condition .col-conditions {
+  display: none;
+}
+
+.source-functions-list.hide-col-decision .col-decisions {
+  display: none;
+}
+
+.source-functions-list.hide-col-call .col-calls {
+  display: none;
+}
+
 .source-function-header {
   display: flex;
   align-items: center;
@@ -2069,6 +2081,9 @@ tr.source-line.nav-highlight > td {
 
 /* Column visibility toggle hide rules */
 .source-table.hide-col-branch .col-branch { display: none; }
+.source-table.hide-col-condition .col-condition { display: none; }
+.source-table.hide-col-decision .col-decision { display: none; }
+.source-table.hide-col-call .col-call { display: none; }
 .source-table.hide-col-tla .col-tla { display: none; }
 .source-table.hide-col-count .col-count { display: none; }
 

--- a/tests/html/reference/nested-theme-boost-blue/clang-12/coverage_nested.functions.html
+++ b/tests/html/reference/nested-theme-boost-blue/clang-12/coverage_nested.functions.html
@@ -155,7 +155,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "bar_()",
@@ -166,7 +168,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo(int)",
@@ -177,7 +181,9 @@
     "excluded": false,
     "line_coverage": "80.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo5(int)",
@@ -188,7 +194,9 @@
     "excluded": false,
     "line_coverage": "80.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo6(int)",
@@ -199,7 +207,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foobar(int)",
@@ -210,7 +220,9 @@
     "excluded": false,
     "line_coverage": "80.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "four_bar()",
@@ -221,7 +233,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "four_bar_()",
@@ -232,7 +246,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "main",
@@ -243,7 +259,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "25.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "uncovered()",
@@ -254,7 +272,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ]
 </script>
@@ -263,7 +283,9 @@
     singlePage: false,
     htmlFilename: "",
     showBranches: true,
-    showConditions: false
+    showConditions: false,
+    showDecisions: false,
+    showCalls: false
   };
 </script>          </section>
         </div>

--- a/tests/html/reference/nested-theme-boost-blue/clang-12/coverage_nested.js
+++ b/tests/html/reference/nested-theme-boost-blue/clang-12/coverage_nested.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/html/reference/nested-theme-boost-blue/gcc-11/coverage_nested.css
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-11/coverage_nested.css
@@ -1708,6 +1708,18 @@ tr.source-line.nav-highlight > td {
   display: none;
 }
 
+.source-functions-list.hide-col-condition .col-conditions {
+  display: none;
+}
+
+.source-functions-list.hide-col-decision .col-decisions {
+  display: none;
+}
+
+.source-functions-list.hide-col-call .col-calls {
+  display: none;
+}
+
 .source-function-header {
   display: flex;
   align-items: center;
@@ -2069,6 +2081,9 @@ tr.source-line.nav-highlight > td {
 
 /* Column visibility toggle hide rules */
 .source-table.hide-col-branch .col-branch { display: none; }
+.source-table.hide-col-condition .col-condition { display: none; }
+.source-table.hide-col-decision .col-decision { display: none; }
+.source-table.hide-col-call .col-call { display: none; }
 .source-table.hide-col-tla .col-tla { display: none; }
 .source-table.hide-col-count .col-count { display: none; }
 

--- a/tests/html/reference/nested-theme-boost-blue/gcc-11/coverage_nested.js
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-11/coverage_nested.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.A.7fc56270e7a70fa81a5935b72eacbe29.html
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.A.7fc56270e7a70fa81a5935b72eacbe29.html
@@ -209,6 +209,31 @@
       </div>
     </div>
   </div>
+
+  <div class="summary-card">
+    <div class="summary-card-header">
+      <h3>Conditions</h3>
+    </div>
+    <div class="summary-card-body">
+      <div class="coverage-ring coverage-low">
+        <svg viewBox="0 0 36 36">
+          <path class="ring-bg" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+          <path class="ring-fill" stroke-dasharray="28.6, 100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+        </svg>
+        <span class="ring-text">28.6%</span>
+      </div>
+      <div class="summary-stats">
+        <div class="stat-row">
+          <span class="stat-label">Hit</span>
+          <span class="stat-value">4</span>
+        </div>
+        <div class="stat-row">
+          <span class="stat-label">Total</span>
+          <span class="stat-value">14</span>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 
 <div class="coverage-legend">

--- a/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.B.9d5ed678fe57bcca610140957afab571.html
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.B.9d5ed678fe57bcca610140957afab571.html
@@ -174,6 +174,31 @@
       </div>
     </div>
   </div>
+
+  <div class="summary-card">
+    <div class="summary-card-header">
+      <h3>Conditions</h3>
+    </div>
+    <div class="summary-card-body">
+      <div class="coverage-ring coverage-low">
+        <svg viewBox="0 0 36 36">
+          <path class="ring-bg" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+          <path class="ring-fill" stroke-dasharray="28.6, 100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+        </svg>
+        <span class="ring-text">28.6%</span>
+      </div>
+      <div class="summary-stats">
+        <div class="stat-row">
+          <span class="stat-label">Hit</span>
+          <span class="stat-value">4</span>
+        </div>
+        <div class="stat-row">
+          <span class="stat-label">Total</span>
+          <span class="stat-value">14</span>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 
 <div class="coverage-legend">

--- a/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.C.65c6818f1beed0acac61ab4a271ddda2.html
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.C.65c6818f1beed0acac61ab4a271ddda2.html
@@ -181,6 +181,31 @@
       </div>
     </div>
   </div>
+
+  <div class="summary-card">
+    <div class="summary-card-header">
+      <h3>Conditions</h3>
+    </div>
+    <div class="summary-card-body">
+      <div class="coverage-ring coverage-low">
+        <svg viewBox="0 0 36 36">
+          <path class="ring-bg" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+          <path class="ring-fill" stroke-dasharray="28.6, 100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+        </svg>
+        <span class="ring-text">28.6%</span>
+      </div>
+      <div class="summary-stats">
+        <div class="stat-row">
+          <span class="stat-label">Hit</span>
+          <span class="stat-value">4</span>
+        </div>
+        <div class="stat-row">
+          <span class="stat-label">Total</span>
+          <span class="stat-value">14</span>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 
 <div class="coverage-legend">

--- a/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.D.de4bee21461092ca61985814ef11fc54.html
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.D.de4bee21461092ca61985814ef11fc54.html
@@ -174,6 +174,31 @@
       </div>
     </div>
   </div>
+
+  <div class="summary-card">
+    <div class="summary-card-header">
+      <h3>Conditions</h3>
+    </div>
+    <div class="summary-card-body">
+      <div class="coverage-ring coverage-low">
+        <svg viewBox="0 0 36 36">
+          <path class="ring-bg" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+          <path class="ring-fill" stroke-dasharray="28.6, 100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+        </svg>
+        <span class="ring-text">28.6%</span>
+      </div>
+      <div class="summary-stats">
+        <div class="stat-row">
+          <span class="stat-label">Hit</span>
+          <span class="stat-value">4</span>
+        </div>
+        <div class="stat-row">
+          <span class="stat-label">Total</span>
+          <span class="stat-value">14</span>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 
 <div class="coverage-legend">

--- a/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html
@@ -125,6 +125,9 @@
       <span class="stat coverage-unknown">
         <strong>-%</strong> Branches (0/0)
       </span>
+      <span class="stat coverage-unknown">
+        <strong>-%</strong> Conditions (0/0)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -146,6 +149,7 @@
       </button>
     </div>
     <div class="source-column-filters">
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -125,6 +125,9 @@
       <span class="stat coverage-low">
         <strong>50.0%</strong> Branches (1/2)
       </span>
+      <span class="stat coverage-low">
+        <strong>50.0%</strong> Conditions (1/2)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -150,6 +153,7 @@
     </div>
     <div class="source-column-filters">
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="branch" title="Toggle Branch column">Branch</button>
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
@@ -125,6 +125,9 @@
       <span class="stat coverage-none">
         <strong>0.0%</strong> Branches (0/2)
       </span>
+      <span class="stat coverage-none">
+        <strong>0.0%</strong> Conditions (0/2)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -146,6 +149,7 @@
       </button>
     </div>
     <div class="source-column-filters">
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.css
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.css
@@ -1290,17 +1290,17 @@ body.sidebar-resizing .main-content {
 /* Adjust grid when columns are hidden */
 .no-functions.no-branches .file-list-header,
 .no-functions.no-branches .file-row {
-  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px;
+  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px 116px;
 }
 
 .no-functions:not(.no-branches) .file-list-header,
 .no-functions:not(.no-branches) .file-row {
-  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px 116px;
+  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px 116px 116px;
 }
 
 .no-branches:not(.no-functions) .file-list-header,
 .no-branches:not(.no-functions) .file-row {
-  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px 116px;
+  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px 116px 116px;
 }
 
 .file-row:nth-child(even) {
@@ -1708,6 +1708,18 @@ tr.source-line.nav-highlight > td {
   display: none;
 }
 
+.source-functions-list.hide-col-condition .col-conditions {
+  display: none;
+}
+
+.source-functions-list.hide-col-decision .col-decisions {
+  display: none;
+}
+
+.source-functions-list.hide-col-call .col-calls {
+  display: none;
+}
+
 .source-function-header {
   display: flex;
   align-items: center;
@@ -2069,6 +2081,9 @@ tr.source-line.nav-highlight > td {
 
 /* Column visibility toggle hide rules */
 .source-table.hide-col-branch .col-branch { display: none; }
+.source-table.hide-col-condition .col-condition { display: none; }
+.source-table.hide-col-decision .col-decision { display: none; }
+.source-table.hide-col-call .col-call { display: none; }
 .source-table.hide-col-tla .col-tla { display: none; }
 .source-table.hide-col-count .col-count { display: none; }
 
@@ -2298,7 +2313,7 @@ tr.source-line.nav-highlight > td {
 
 .functions-header {
   display: grid;
-  grid-template-columns: 1fr 90px 70px 90px;
+  grid-template-columns: 1fr 90px 70px 90px 90px;
   gap: 0;
   padding: 0 16px;
   background: var(--bg-tertiary);
@@ -2342,7 +2357,7 @@ tr.source-line.nav-highlight > td {
 
 .function-row {
   display: grid;
-  grid-template-columns: 1fr 90px 70px 90px;
+  grid-template-columns: 1fr 90px 70px 90px 90px;
   gap: 0;
   padding: 0 16px;
   border-bottom: 1px solid var(--border-muted);
@@ -2352,7 +2367,7 @@ tr.source-line.nav-highlight > td {
 
 .functions-container.no-branches .functions-header,
 .functions-container.no-branches .function-row {
-  grid-template-columns: 1fr 90px 70px;
+  grid-template-columns: 1fr 90px 70px 90px;
 }
 
 .function-row > div:not(:first-child) {

--- a/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -125,6 +125,9 @@
       <span class="stat coverage-low">
         <strong>50.0%</strong> Branches (1/2)
       </span>
+      <span class="stat coverage-low">
+        <strong>50.0%</strong> Conditions (1/2)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -150,6 +153,7 @@
     </div>
     <div class="source-column-filters">
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="branch" title="Toggle Branch column">Branch</button>
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -125,6 +125,9 @@
       <span class="stat coverage-none">
         <strong>0.0%</strong> Branches (0/2)
       </span>
+      <span class="stat coverage-none">
+        <strong>0.0%</strong> Conditions (0/2)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -146,6 +149,7 @@
       </button>
     </div>
     <div class="source-column-filters">
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -125,6 +125,9 @@
       <span class="stat coverage-low">
         <strong>50.0%</strong> Branches (1/2)
       </span>
+      <span class="stat coverage-low">
+        <strong>50.0%</strong> Conditions (1/2)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -150,6 +153,7 @@
     </div>
     <div class="source-column-filters">
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="branch" title="Toggle Branch column">Branch</button>
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -125,6 +125,9 @@
       <span class="stat coverage-unknown">
         <strong>-%</strong> Branches (0/0)
       </span>
+      <span class="stat coverage-unknown">
+        <strong>-%</strong> Conditions (0/0)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -146,6 +149,7 @@
       </button>
     </div>
     <div class="source-column-filters">
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.functions.html
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.functions.html
@@ -126,6 +126,10 @@
     <span class="stat-label">Branches:</span>
     <span class="stat-value coverage-low">28.6%</span>
   </div>
+  <div class="summary-stat">
+    <span class="stat-label">Conditions:</span>
+    <span class="stat-value coverage-low">28.6%</span>
+  </div>
 </div>          </section>
 
           <section class="main-section">
@@ -156,7 +160,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "bar_()",
@@ -167,7 +173,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo(int)",
@@ -178,7 +186,9 @@
     "excluded": false,
     "line_coverage": "75.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "50.0"
+    "condition_coverage": "50.0",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo5(int)",
@@ -189,7 +199,9 @@
     "excluded": false,
     "line_coverage": "75.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "50.0"
+    "condition_coverage": "50.0",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo6(int)",
@@ -200,7 +212,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "0.0"
+    "condition_coverage": "0.0",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foobar(int)",
@@ -211,7 +225,9 @@
     "excluded": false,
     "line_coverage": "75.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "50.0"
+    "condition_coverage": "50.0",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "four_bar()",
@@ -222,7 +238,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "four_bar_()",
@@ -233,7 +251,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "0.0"
+    "condition_coverage": "0.0",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "main",
@@ -244,7 +264,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "25.0",
-    "condition_coverage": "25.0"
+    "condition_coverage": "25.0",
+    "decision_coverage": "-",
+    "call_coverage": "83.3"
   }
 ,  {
     "name": "uncovered()",
@@ -255,7 +277,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ]
 </script>
@@ -264,7 +288,9 @@
     singlePage: false,
     htmlFilename: "",
     showBranches: true,
-    showConditions: true
+    showConditions: true,
+    showDecisions: false,
+    showCalls: false
   };
 </script>          </section>
         </div>

--- a/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.html
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.html
@@ -181,6 +181,31 @@
       </div>
     </div>
   </div>
+
+  <div class="summary-card">
+    <div class="summary-card-header">
+      <h3>Conditions</h3>
+    </div>
+    <div class="summary-card-body">
+      <div class="coverage-ring coverage-low">
+        <svg viewBox="0 0 36 36">
+          <path class="ring-bg" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+          <path class="ring-fill" stroke-dasharray="28.6, 100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+        </svg>
+        <span class="ring-text">28.6%</span>
+      </div>
+      <div class="summary-stats">
+        <div class="stat-row">
+          <span class="stat-label">Hit</span>
+          <span class="stat-value">4</span>
+        </div>
+        <div class="stat-row">
+          <span class="stat-label">Total</span>
+          <span class="stat-value">14</span>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 
 <div class="coverage-legend">

--- a/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.js
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -125,6 +125,9 @@
       <span class="stat coverage-low">
         <strong>25.0%</strong> Branches (1/4)
       </span>
+      <span class="stat coverage-low">
+        <strong>25.0%</strong> Conditions (1/4)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -150,6 +153,7 @@
     </div>
     <div class="source-column-filters">
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="branch" title="Toggle Branch column">Branch</button>
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.subdir_9.63bd3dc96170cd4173f6130222e788f0.html
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.subdir_9.63bd3dc96170cd4173f6130222e788f0.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html class="theme-green">
+<html class="theme-blue">
 
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
-    <title>A/file7.cpp - GCC Code Coverage Report - Diff mode</title>
+    <title>A/subdir_0/subdir_1/subdir_2/subdir_3/subdir_4/subdir_5/subdir_6/subdir_7/subdir_8/subdir_9/ - GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <script>
       // Apply theme and font size immediately to prevent flash
@@ -22,8 +22,8 @@
         }
       })();
     </script>
-    <link rel="stylesheet" href="coverage.boost.css"/>
-    <script src="coverage.boost.js" charset="UTF-8"></script>
+    <link rel="stylesheet" href="coverage_nested.css"/>
+    <script src="coverage_nested.js" charset="UTF-8"></script>
   </head>
 
   <body>
@@ -32,7 +32,7 @@
       <aside class="sidebar" id="sidebar"><script>if(localStorage.getItem('sidebar-collapsed')==='true'){document.currentScript.parentElement.classList.add('collapsed');}else{var sw=localStorage.getItem('gcovr-sidebar-width');if(sw)document.documentElement.style.setProperty('--sidebar-width',sw+'px');}</script>
         <div class="sidebar-header">
           <div class="sidebar-header-row">
-            <a href="coverage.boost.html" class="sidebar-logo" title="Back to index">
+            <a href="coverage_nested.html" class="sidebar-logo" title="Back to index">
               <svg viewBox="150 150 700 160" class="boost-wordmark"><path fill="#ffa000" d="M292.45,152.89h-93.18l-46.59,80,12.63,21.69,46.57-79.99h47.07c20.07,0,36.38,16.18,36.38,36.07,0,8.46-3.54,18.29-10.84,22.4,7.11,5.3,10.54,13.73,10.54,22.01,0,19.88-16.32,36.06-36.38,36.06h-61.71l16.12-27.7h45.59c4.66,0,8.45-3.75,8.45-8.36s-3.57-8.16-8.05-8.35c-.13-.02-36.25,0-36.25,0l16.14-27.71s20.22.02,20.31,0c1.9-.06,3.63-.74,5-1.85,1.93-1.53,3.15-3.87,3.15-6.5,0-4.62-3.79-8.37-8.45-8.37h-30.03l-47.04,80.75,17.39,29.85h93.18l46.59-80-46.59-80h0Z"/><path fill="currentColor" d="M550.81,291.93c-9.23,0-17.31-2.01-24.23-6.04s-12.29-9.63-16.1-16.83c-3.81-7.19-5.72-15.4-5.72-24.63s1.9-17.6,5.72-24.79c3.81-7.19,9.18-12.82,16.1-16.91,6.92-4.08,15-6.12,24.23-6.12s17.44,2.04,24.31,6.12,12.21,9.72,16.02,16.91,5.72,15.46,5.72,24.79-1.91,17.44-5.72,24.63-9.15,12.8-16.02,16.83c-6.87,4.02-14.97,6.04-24.31,6.04ZM550.81,272.45c5.37,0,9.79-1.23,13.28-3.7,3.49-2.47,6.12-5.82,7.89-10.06s2.66-8.99,2.66-14.25-.89-10.2-2.66-14.49c-1.77-4.29-4.4-7.7-7.89-10.22-3.49-2.52-7.92-3.78-13.28-3.78s-9.82,1.26-13.36,3.78c-3.54,2.52-6.2,5.93-7.97,10.22-1.77,4.29-2.66,9.12-2.66,14.49s.89,10.01,2.66,14.25c1.77,4.24,4.43,7.59,7.97,10.06s7.99,3.7,13.36,3.7Z"/><path fill="currentColor" d="M648.53,291.93c-9.23,0-17.31-2.01-24.23-6.04s-12.29-9.63-16.1-16.83c-3.81-7.19-5.72-15.4-5.72-24.63s1.9-17.6,5.72-24.79c3.81-7.19,9.18-12.82,16.1-16.91,6.92-4.08,15-6.12,24.23-6.12s17.44,2.04,24.31,6.12,12.21,9.72,16.02,16.91,5.72,15.46,5.72,24.79-1.91,17.44-5.72,24.63-9.15,12.8-16.02,16.83c-6.87,4.02-14.97,6.04-24.31,6.04ZM648.53,272.45c5.37,0,9.79-1.23,13.28-3.7,3.49-2.47,6.12-5.82,7.89-10.06s2.66-8.99,2.66-14.25-.89-10.2-2.66-14.49c-1.77-4.29-4.4-7.7-7.89-10.22-3.49-2.52-7.92-3.78-13.28-3.78s-9.82,1.26-13.36,3.78c-3.54,2.52-6.2,5.93-7.97,10.22-1.77,4.29-2.66,9.12-2.66,14.49s.89,10.01,2.66,14.25c1.77,4.24,4.43,7.59,7.97,10.06s7.99,3.7,13.36,3.7Z"/><path fill="currentColor" d="M722.75,260.85c.54,4.62,2.55,7.86,6.04,9.74s7.49,2.82,11.99,2.82,8.21-.8,11.11-2.41c2.9-1.61,4.35-4.24,4.35-7.89,0-2.25-.99-4-2.98-5.23s-4.56-2.2-7.73-2.9c-3.17-.7-6.66-1.37-10.46-2.01-3.81-.64-7.65-1.5-11.51-2.58-3.86-1.07-7.41-2.58-10.63-4.51-3.22-1.93-5.8-4.53-7.73-7.81-1.93-3.27-2.9-7.49-2.9-12.64,0-4.83,1.55-9.47,4.67-13.93,3.11-4.45,7.49-8.05,13.12-10.79,5.63-2.74,12.1-4.11,19.4-4.11,6.55,0,12.61,1.32,18.19,3.95,5.58,2.63,10.06,6.25,13.44,10.87s5.07,9.98,5.07,16.1h-21.41c-.43-4.61-2.15-7.86-5.15-9.74-3.01-1.88-6.6-2.82-10.79-2.82-4.94,0-8.69.99-11.27,2.98s-3.86,4.48-3.86,7.49c0,2.47.99,4.4,2.98,5.8,1.98,1.4,4.56,2.47,7.73,3.22,3.16.75,6.68,1.42,10.55,2.01,3.86.59,7.7,1.4,11.51,2.42,3.81,1.02,7.33,2.47,10.55,4.35s5.8,4.4,7.73,7.57,2.9,7.27,2.9,12.32c0,5.69-1.56,10.71-4.67,15.05-3.11,4.35-7.49,7.73-13.12,10.14-5.64,2.42-12.26,3.62-19.88,3.62-7.08,0-13.52-1.37-19.32-4.11s-10.44-6.44-13.93-11.11c-3.49-4.67-5.34-9.95-5.55-15.86h21.57,0Z"/><path fill="currentColor" d="M815.48,264.84v-47.29h17.55v-18.35h-17.55v-21.78l-34.42,40.14h12.84v51.81c0,11.05,8.95,20,20,20h21.7v-18.52h-14.12c-3.31,0-6-2.69-6-6h0Z"/><path fill="currentColor" d="M494.62,242.26c-2.36-3.92-5.58-7.03-9.66-9.34-1.08-.61-2.19-1.14-3.33-1.61.7-.44,1.36-.91,1.96-1.45,2.95-2.63,5.1-5.82,6.44-9.58,1.34-3.76,2.01-7.35,2.01-10.79,0-8.69-1.99-15.4-5.96-20.12s-9.31-8.02-16.02-9.9c-6.71-1.88-14.14-2.82-22.3-2.82h-34.29v112.7h40.41c8.16,0,15.59-.99,22.3-2.98,6.71-1.98,12.05-5.45,16.02-10.38,3.97-4.94,5.96-11.7,5.96-20.29,0-5.04-1.18-9.53-3.54-13.44ZM472.48,264.8c-1.88,2.09-4.46,3.52-7.73,4.27-3.28.75-6.9,1.13-10.87,1.13h-18.51v-74.54h12.4c4.08,0,7.73.32,10.95.97,3.22.64,5.77,1.96,7.65,3.95,1.88,1.99,2.82,4.91,2.82,8.77s-.94,6.79-2.82,8.78c-1.88,1.99-4.46,3.3-7.73,3.94-1.87.37-3.86.62-5.96.78l-11.25,19.19h12.46c4.08,0,7.73.35,10.95,1.05,3.22.7,5.77,2.01,7.65,3.94s2.82,4.83,2.82,8.69-.94,7-2.82,9.1v-.02Z"/></svg>
             </a>
             <button class="sidebar-toggle" id="sidebar-toggle" title="Toggle sidebar">
@@ -59,24 +59,11 @@
           </button>
         </div>
         <nav class="sidebar-nav" id="file-tree">
-<div class="tree-item">
+<div class="tree-item ">
   <div class="tree-item-header">
-    <a href="coverage.boost.html" class="tree-toggle" title="Back to directory">
-      <span class="toggle-icon">&larr;</span>
-    </a>
-    <span class="tree-icon folder">
-      <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M1.75 1A1.75 1.75 0 000 2.75v10.5C0 14.216.784 15 1.75 15h12.5A1.75 1.75 0 0016 13.25v-8.5A1.75 1.75 0 0014.25 3H7.5a.25.25 0 01-.2-.1l-.9-1.2C6.07 1.26 5.55 1 5 1H1.75z"></path></svg>
-    </span>
-    <a class="tree-label" href="coverage.boost.html">Back to Index</a>
-  </div>
-</div>
-<div class="tree-item active">
-  <div class="tree-item-header">
-    <span class="tree-toggle-spacer"></span>
-    <span class="tree-icon file">
-      <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M3.75 1.5a.25.25 0 00-.25.25v12.5c0 .138.112.25.25.25h9.5a.25.25 0 00.25-.25V6h-2.75A1.75 1.75 0 019 4.25V1.5H3.75zm6.75.062V4.25c0 .138.112.25.25.25h2.688l-2.938-2.938zM2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0113.25 16h-9.5A1.75 1.75 0 012 14.25V1.75z"></path></svg>
-    </span>
-    <span class="tree-label">A/file7.cpp</span>
+    <span class="tree-spacer"></span>
+    <svg class="tree-icon tree-icon-file" viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M3.75 1.5a.25.25 0 00-.25.25v12.5c0 .138.112.25.25.25h9.5a.25.25 0 00.25-.25V6h-2.75A1.75 1.75 0 019 4.25V1.5H3.75zm6.75.062V4.25c0 .138.112.25.25.25h2.688l-2.938-2.938zM2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0113.25 16h-9.5A1.75 1.75 0 012 14.25V1.75z"></path></svg>
+    <a class="tree-label" href="coverage_nested.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html" title="File2.cpp">File2.cpp</a>
   </div>
 </div>
         </nav>
@@ -93,7 +80,7 @@
             <svg viewBox="0 0 16 16" fill="currentColor"><path d="M2.5 12a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5z"/></svg>
           </button>
           <div class="breadcrumb">
-<a href="coverage.boost.html" class="breadcrumb-home">Index</a><span class="separator">/</span><span class="current" title="A/file7.cpp">A / file7.cpp</span>          </div>
+<a href="coverage_nested.html" class="breadcrumb-home">GCC Code Coverage Report</a><span class="separator">/</span><span class="current" title="A/subdir_0/subdir_1/subdir_2/subdir_3/subdir_4/subdir_5/subdir_6/subdir_7/subdir_8/subdir_9/">A / subdir_0 / subdir_1 / subdir_2 / subdir_3 / subdir_4 / subdir_5 / subdir_6 / subdir_7 / subdir_8 / subdir_9 / </span>          </div>
           <div class="header-actions">
           </div>
           <div class="view-toggle" id="view-toggle" style="display:none">
@@ -112,161 +99,189 @@
 
         <div class="content-wrapper">
           <section class="summary-section">
-<div class="source-summary">
-  <div class="source-info">
-    <h2 class="source-filename">A/file7.cpp</h2>
-    <div class="source-stats">
-      <span class="stat coverage-none">
-        <strong>0.0%</strong> Lines (0/2)
-      </span>
-      <span class="stat coverage-none">
-        <strong>0.0%</strong> List of functions (0/1)
-      </span>
-      <span class="stat coverage-unknown">
-        <strong>-%</strong> Branches (0/0)
-      </span>
-      <span class="stat coverage-unknown">
-        <strong>-%</strong> Conditions (0/0)
-      </span>
+<div class="summary-cards">
+  <div class="summary-card">
+    <div class="summary-card-header">
+      <h3>Lines</h3>
+    </div>
+    <div class="summary-card-body">
+      <div class="coverage-ring coverage-low">
+        <svg viewBox="0 0 36 36">
+          <path class="ring-bg" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+          <path class="ring-fill" stroke-dasharray="59.5, 100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+        </svg>
+        <span class="ring-text">59.5%</span>
+      </div>
+      <div class="summary-stats">
+        <div class="stat-row">
+          <span class="stat-label">Hit</span>
+          <span class="stat-value">25</span>
+        </div>
+        <div class="stat-row">
+          <span class="stat-label">Total</span>
+          <span class="stat-value">42</span>
+        </div>
+      </div>
     </div>
   </div>
-  <div class="nav-hint">
-    <span><kbd>[</kbd> <kbd>]</kbd> prev/next file</span>
-    <span><kbd>n</kbd> <kbd>p</kbd> prev/next uncovered line</span>
+
+  <div class="summary-card">
+    <div class="summary-card-header">
+      <h3>Functions</h3>
+    </div>
+    <div class="summary-card-body">
+      <div class="coverage-ring coverage-low">
+        <svg viewBox="0 0 36 36">
+          <path class="ring-bg" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+          <path class="ring-fill" stroke-dasharray="60.0, 100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+        </svg>
+        <span class="ring-text">60.0%</span>
+      </div>
+      <div class="summary-stats">
+        <div class="stat-row">
+          <span class="stat-label">Hit</span>
+          <span class="stat-value">6</span>
+        </div>
+        <div class="stat-row">
+          <span class="stat-label">Total</span>
+          <span class="stat-value">10</span>
+        </div>
+      </div>
+    </div>
   </div>
+
+  <div class="summary-card">
+    <div class="summary-card-header">
+      <h3>Branches</h3>
+    </div>
+    <div class="summary-card-body">
+      <div class="coverage-ring coverage-low">
+        <svg viewBox="0 0 36 36">
+          <path class="ring-bg" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+          <path class="ring-fill" stroke-dasharray="28.6, 100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+        </svg>
+        <span class="ring-text">28.6%</span>
+      </div>
+      <div class="summary-stats">
+        <div class="stat-row">
+          <span class="stat-label">Hit</span>
+          <span class="stat-value">4</span>
+        </div>
+        <div class="stat-row">
+          <span class="stat-label">Total</span>
+          <span class="stat-value">14</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="summary-card">
+    <div class="summary-card-header">
+      <h3>Conditions</h3>
+    </div>
+    <div class="summary-card-body">
+      <div class="coverage-ring coverage-low">
+        <svg viewBox="0 0 36 36">
+          <path class="ring-bg" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+          <path class="ring-fill" stroke-dasharray="28.6, 100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+        </svg>
+        <span class="ring-text">28.6%</span>
+      </div>
+      <div class="summary-stats">
+        <div class="stat-row">
+          <span class="stat-label">Hit</span>
+          <span class="stat-value">4</span>
+        </div>
+        <div class="stat-row">
+          <span class="stat-label">Total</span>
+          <span class="stat-value">14</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="coverage-legend">
+  <span class="legend-item coverage-high">High: &ge; 90.0%</span>
+  <span class="legend-item coverage-medium">Medium: &ge; 75.0%</span>
+  <span class="legend-item coverage-low">Low: &lt; 75.0%</span>
+  <span class="legend-separator"></span>
+  <a href="coverage_nested.functions.html" class="legend-item legend-functions-link" title="List of all functions">
+    <span class="fx-icon" aria-hidden="true"><i>f</i>(x)</span>
+    List of functions
+  </a>
 </div>          </section>
 
           <section class="main-section">
-<div class="source-container no-branches">
-  <div class="source-header">
-    <span class="source-header-filename">file7.cpp</span>
-    <div class="source-line-filters">
-      <button type="button" class="btn btn-sm button_toggle_coveredLine show_coveredLine" value="coveredLine" title="Toggle covered lines">
-        covered
-      </button>
-      <button type="button" class="btn btn-sm button_toggle_uncoveredLine show_uncoveredLine" value="uncoveredLine" title="Toggle uncovered lines">
-        uncovered
-      </button>
+<div class="file-list-container no-branches no-decisions no-calls">
+  <div class="file-list-header">
+    <div class="col-name sortable sorted-ascending" data-sort="filename">
+      Name
     </div>
-    <div class="source-column-filters">
-      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
-      <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
-      <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
+    <div class="col-coverage sortable" data-sort="coverage">
+      Coverage
     </div>
-    <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html" title="Previous file">
-        <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
-      </a>
-      <a class="nav-link nav-next" href="coverage.boost.B.cec86a34c08f941fc92924df967d4300.html" title="Next file">
-        <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
-      </a>
+    <div class="col-lines sortable" data-sort="lines">
+      Lines
     </div>
-<span class="source-header-sep"></span>    <div id="coverage-nav">
-      <button type="button" id="nav-prev" class="nav-link" title="Previous uncovered line (p)">
-        <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(90 8 8)"/></svg>
-      </button>
-      <span id="nav-counter" class="nav-counter"></span>
-      <button type="button" id="nav-next" class="nav-link" title="Next uncovered line (n)">
-        <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(-90 8 8)"/></svg>
-      </button>
+    <div class="col-functions sortable" data-sort="functions">
+      Functions
+    </div>
+    <div class="col-conditions sortable" data-sort="conditions">
+      Conditions
     </div>
   </div>
 
-
-  <details class="source-functions">
-    <summary class="source-functions-toggle">
-      <span class="fx-icon"><i>f</i>(x)</span>
-      Functions (1)
-    </summary>
-    <div class="source-functions-list">
-      <div class="source-function-header">
-        <span class="source-function-col-name" data-sort="name">Function</span>
-        <span class="source-function-col-stat" data-sort="calls">Calls</span>
-        <span class="source-function-col-stat" data-sort="lines">Lines</span>
-        <span class="source-function-col-stat" data-sort="blocks">Blocks</span>
-      </div>
-      <a href="#l1" class="source-function-item fn-uncovered"
-         data-name="uncovered()" data-calls="0" data-lines="0.0" data-branches="-1" data-blocks="0.0">
-        <span class="source-function-col-name">
-          <span class="source-function-name">uncovered()</span>
-          <span class="source-function-line">:1</span>
+  <div class="file-list-body" id="file-list">
+    <div class="file-row file"
+         data-filename="File2.cpp"
+         data-coverage="57.1"
+         data-lines="7"
+         data-lines-exec="4"
+         data-lines-coverage="57.1"
+         data-lines-class="coverage-low"
+         data-functions="50.0"
+         data-functions-coverage="50.0"
+         data-functions-class="coverage-low"
+         data-branches="-"
+         data-branches-coverage="-"
+         data-branches-class="coverage-unknown"
+         data-conditions="-"
+         data-conditions-coverage="-"
+         data-conditions-class="coverage-unknown"
+         data-decisions="-"
+         data-decisions-coverage="-"
+         data-decisions-class="coverage-unknown"
+         data-calls="-"
+         data-calls-coverage="-"
+         data-calls-class="coverage-unknown"
+         data-diff="None">
+      <div class="col-name">
+        <span class="file-icon">
+          <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M3.75 1.5a.25.25 0 00-.25.25v12.5c0 .138.112.25.25.25h9.5a.25.25 0 00.25-.25V6h-2.75A1.75 1.75 0 019 4.25V1.5H3.75zm6.75.062V4.25c0 .138.112.25.25.25h2.688a.252.252 0 00-.011-.013l-2.914-2.914a.272.272 0 00-.013-.011zM2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0113.25 16h-9.5A1.75 1.75 0 012 14.25V1.75z"></path></svg>
         </span>
-        <span class="source-function-col-stat not-called">0</span>
-        <span class="source-function-col-stat cov-low">0.0%</span>
-        <span class="source-function-col-stat cov-low">0.0%</span>
-      </a>
-    </div>
-  </details>
+        <a href="coverage_nested.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html" title="File2.cpp">File2.cpp</a>
+      </div>
 
-  <div class="source-table-container">
-    <table class="source-table">
-      <thead>
-        <tr>
-          <th class="col-lineno">Line</th>
-          <th class="col-condition">Condition</th>
-          <th class="col-tla">TLA</th>
-          <th class="col-count">Hits</th>
-          <th class="col-source">Source Code</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr class="source-line uncoveredLine show_uncoveredLine">
-          <td class="col-lineno">
-            <a id="l1">1</a>
-          </td>
-          <td class="col-condition">
-          </td>
-          <td class="col-tla"></td>
-          <td class="col-count uncoveredLine">
-<span class="hit-miss">&cross;</span>          </td>
-          <td class="col-source"><span class="kt">int</span><span class="w"> </span><span class="nf">uncovered</span><span class="p">()</span></td>
-        </tr>
-        <tr class="source-line">
-          <td class="col-lineno">
-            <a id="l2">2</a>
-          </td>
-          <td class="col-condition">
-          </td>
-          <td class="col-tla"></td>
-          <td class="col-count">
-          </td>
-          <td class="col-source"><span class="p">{</span></td>
-        </tr>
-        <tr class="source-line uncoveredLine show_uncoveredLine">
-          <td class="col-lineno">
-            <a id="l3">3</a>
-          </td>
-          <td class="col-condition">
-          </td>
-          <td class="col-tla"></td>
-          <td class="col-count uncoveredLine">
-<span class="hit-miss">&cross;</span>          </td>
-          <td class="col-source"><span class="k">return</span><span class="w"> </span><span class="mi">0</span><span class="p">;</span></td>
-        </tr>
-        <tr class="source-line">
-          <td class="col-lineno">
-            <a id="l4">4</a>
-          </td>
-          <td class="col-condition">
-          </td>
-          <td class="col-tla"></td>
-          <td class="col-count">
-          </td>
-          <td class="col-source"><span class="p">}</span></td>
-        </tr>
-        <tr class="source-line">
-          <td class="col-lineno">
-            <a id="l5">5</a>
-          </td>
-          <td class="col-condition">
-          </td>
-          <td class="col-tla"></td>
-          <td class="col-count">
-          </td>
-          <td class="col-source"></td>
-        </tr>
-      </tbody>
-    </table>
+      <div class="col-coverage">
+        <div class="coverage-bar-container">
+          <div class="coverage-bar coverage-low" style="width: 57.1%"></div>
+        </div>
+        <span class="coverage-percent coverage-low">57.1%</span>
+      </div>
+
+      <div class="col-lines">
+        <span class="stat-value">4</span>
+        <span class="stat-separator">/</span>
+        <span class="stat-total">7</span>
+      </div>
+      <div class="col-functions">
+        <span class="stat-value coverage-low">50.0%</span>
+      </div>
+      <div class="col-conditions">
+        <span class="stat-value coverage-unknown">-</span>
+      </div>
+    </div>
   </div>
 </div>          </section>
         </div>

--- a/tests/html/reference/nested-theme-boost-blue/gcc-5/coverage_nested.css
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-5/coverage_nested.css
@@ -1708,6 +1708,18 @@ tr.source-line.nav-highlight > td {
   display: none;
 }
 
+.source-functions-list.hide-col-condition .col-conditions {
+  display: none;
+}
+
+.source-functions-list.hide-col-decision .col-decisions {
+  display: none;
+}
+
+.source-functions-list.hide-col-call .col-calls {
+  display: none;
+}
+
 .source-function-header {
   display: flex;
   align-items: center;
@@ -2069,6 +2081,9 @@ tr.source-line.nav-highlight > td {
 
 /* Column visibility toggle hide rules */
 .source-table.hide-col-branch .col-branch { display: none; }
+.source-table.hide-col-condition .col-condition { display: none; }
+.source-table.hide-col-decision .col-decision { display: none; }
+.source-table.hide-col-call .col-call { display: none; }
 .source-table.hide-col-tla .col-tla { display: none; }
 .source-table.hide-col-count .col-count { display: none; }
 

--- a/tests/html/reference/nested-theme-boost-blue/gcc-5/coverage_nested.functions.html
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-5/coverage_nested.functions.html
@@ -155,7 +155,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "bar_()",
@@ -166,7 +168,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo(int)",
@@ -177,7 +181,9 @@
     "excluded": false,
     "line_coverage": "75.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo5(int)",
@@ -188,7 +194,9 @@
     "excluded": false,
     "line_coverage": "75.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo6(int)",
@@ -199,7 +207,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foobar(int)",
@@ -210,7 +220,9 @@
     "excluded": false,
     "line_coverage": "75.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "four_bar()",
@@ -221,7 +233,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "four_bar_()",
@@ -232,7 +246,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "main",
@@ -243,7 +259,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "25.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "83.3"
   }
 ,  {
     "name": "uncovered()",
@@ -254,7 +272,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ]
 </script>
@@ -263,7 +283,9 @@
     singlePage: false,
     htmlFilename: "",
     showBranches: true,
-    showConditions: false
+    showConditions: false,
+    showDecisions: false,
+    showCalls: false
   };
 </script>          </section>
         </div>

--- a/tests/html/reference/nested-theme-boost-blue/gcc-5/coverage_nested.js
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-5/coverage_nested.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/html/reference/nested-theme-boost-blue/gcc-9/coverage_nested.css
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-9/coverage_nested.css
@@ -1708,6 +1708,18 @@ tr.source-line.nav-highlight > td {
   display: none;
 }
 
+.source-functions-list.hide-col-condition .col-conditions {
+  display: none;
+}
+
+.source-functions-list.hide-col-decision .col-decisions {
+  display: none;
+}
+
+.source-functions-list.hide-col-call .col-calls {
+  display: none;
+}
+
 .source-function-header {
   display: flex;
   align-items: center;
@@ -2069,6 +2081,9 @@ tr.source-line.nav-highlight > td {
 
 /* Column visibility toggle hide rules */
 .source-table.hide-col-branch .col-branch { display: none; }
+.source-table.hide-col-condition .col-condition { display: none; }
+.source-table.hide-col-decision .col-decision { display: none; }
+.source-table.hide-col-call .col-call { display: none; }
 .source-table.hide-col-tla .col-tla { display: none; }
 .source-table.hide-col-count .col-count { display: none; }
 

--- a/tests/html/reference/nested-theme-boost-blue/gcc-9/coverage_nested.js
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-9/coverage_nested.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/html/reference/nested-theme-boost-green/clang-10/coverage_nested.css
+++ b/tests/html/reference/nested-theme-boost-green/clang-10/coverage_nested.css
@@ -1708,6 +1708,18 @@ tr.source-line.nav-highlight > td {
   display: none;
 }
 
+.source-functions-list.hide-col-condition .col-conditions {
+  display: none;
+}
+
+.source-functions-list.hide-col-decision .col-decisions {
+  display: none;
+}
+
+.source-functions-list.hide-col-call .col-calls {
+  display: none;
+}
+
 .source-function-header {
   display: flex;
   align-items: center;
@@ -2069,6 +2081,9 @@ tr.source-line.nav-highlight > td {
 
 /* Column visibility toggle hide rules */
 .source-table.hide-col-branch .col-branch { display: none; }
+.source-table.hide-col-condition .col-condition { display: none; }
+.source-table.hide-col-decision .col-decision { display: none; }
+.source-table.hide-col-call .col-call { display: none; }
 .source-table.hide-col-tla .col-tla { display: none; }
 .source-table.hide-col-count .col-count { display: none; }
 

--- a/tests/html/reference/nested-theme-boost-green/clang-10/coverage_nested.functions.html
+++ b/tests/html/reference/nested-theme-boost-green/clang-10/coverage_nested.functions.html
@@ -155,7 +155,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z3fooi",
@@ -166,7 +168,9 @@
     "excluded": false,
     "line_coverage": "80.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z4bar_v",
@@ -177,7 +181,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z4foo5i",
@@ -188,7 +194,9 @@
     "excluded": false,
     "line_coverage": "80.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z4foo6i",
@@ -199,7 +207,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z6foobari",
@@ -210,7 +220,9 @@
     "excluded": false,
     "line_coverage": "80.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z8four_barv",
@@ -221,7 +233,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z9four_bar_v",
@@ -232,7 +246,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "_Z9uncoveredv",
@@ -243,7 +259,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ]
 </script>
@@ -252,7 +270,9 @@
     singlePage: false,
     htmlFilename: "",
     showBranches: true,
-    showConditions: false
+    showConditions: false,
+    showDecisions: false,
+    showCalls: false
   };
 </script>          </section>
         </div>

--- a/tests/html/reference/nested-theme-boost-green/clang-10/coverage_nested.js
+++ b/tests/html/reference/nested-theme-boost-green/clang-10/coverage_nested.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/html/reference/nested-theme-boost-green/clang-12/coverage_nested.css
+++ b/tests/html/reference/nested-theme-boost-green/clang-12/coverage_nested.css
@@ -1708,6 +1708,18 @@ tr.source-line.nav-highlight > td {
   display: none;
 }
 
+.source-functions-list.hide-col-condition .col-conditions {
+  display: none;
+}
+
+.source-functions-list.hide-col-decision .col-decisions {
+  display: none;
+}
+
+.source-functions-list.hide-col-call .col-calls {
+  display: none;
+}
+
 .source-function-header {
   display: flex;
   align-items: center;
@@ -2069,6 +2081,9 @@ tr.source-line.nav-highlight > td {
 
 /* Column visibility toggle hide rules */
 .source-table.hide-col-branch .col-branch { display: none; }
+.source-table.hide-col-condition .col-condition { display: none; }
+.source-table.hide-col-decision .col-decision { display: none; }
+.source-table.hide-col-call .col-call { display: none; }
 .source-table.hide-col-tla .col-tla { display: none; }
 .source-table.hide-col-count .col-count { display: none; }
 

--- a/tests/html/reference/nested-theme-boost-green/clang-12/coverage_nested.functions.html
+++ b/tests/html/reference/nested-theme-boost-green/clang-12/coverage_nested.functions.html
@@ -155,7 +155,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "bar_()",
@@ -166,7 +168,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo(int)",
@@ -177,7 +181,9 @@
     "excluded": false,
     "line_coverage": "80.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo5(int)",
@@ -188,7 +194,9 @@
     "excluded": false,
     "line_coverage": "80.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo6(int)",
@@ -199,7 +207,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foobar(int)",
@@ -210,7 +220,9 @@
     "excluded": false,
     "line_coverage": "80.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "four_bar()",
@@ -221,7 +233,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "four_bar_()",
@@ -232,7 +246,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "uncovered()",
@@ -243,7 +259,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ]
 </script>
@@ -252,7 +270,9 @@
     singlePage: false,
     htmlFilename: "",
     showBranches: true,
-    showConditions: false
+    showConditions: false,
+    showDecisions: false,
+    showCalls: false
   };
 </script>          </section>
         </div>

--- a/tests/html/reference/nested-theme-boost-green/clang-12/coverage_nested.js
+++ b/tests/html/reference/nested-theme-boost-green/clang-12/coverage_nested.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.C.65c6818f1beed0acac61ab4a271ddda2.html
+++ b/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.C.65c6818f1beed0acac61ab4a271ddda2.html
@@ -181,6 +181,31 @@
       </div>
     </div>
   </div>
+
+  <div class="summary-card">
+    <div class="summary-card-header">
+      <h3>Conditions</h3>
+    </div>
+    <div class="summary-card-body">
+      <div class="coverage-ring coverage-low">
+        <svg viewBox="0 0 36 36">
+          <path class="ring-bg" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+          <path class="ring-fill" stroke-dasharray="30.0, 100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+        </svg>
+        <span class="ring-text">30.0%</span>
+      </div>
+      <div class="summary-stats">
+        <div class="stat-row">
+          <span class="stat-label">Hit</span>
+          <span class="stat-value">3</span>
+        </div>
+        <div class="stat-row">
+          <span class="stat-label">Total</span>
+          <span class="stat-value">10</span>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 
 <div class="coverage-legend">

--- a/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.D.de4bee21461092ca61985814ef11fc54.html
+++ b/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.D.de4bee21461092ca61985814ef11fc54.html
@@ -174,6 +174,31 @@
       </div>
     </div>
   </div>
+
+  <div class="summary-card">
+    <div class="summary-card-header">
+      <h3>Conditions</h3>
+    </div>
+    <div class="summary-card-body">
+      <div class="coverage-ring coverage-low">
+        <svg viewBox="0 0 36 36">
+          <path class="ring-bg" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+          <path class="ring-fill" stroke-dasharray="30.0, 100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+        </svg>
+        <span class="ring-text">30.0%</span>
+      </div>
+      <div class="summary-stats">
+        <div class="stat-row">
+          <span class="stat-label">Hit</span>
+          <span class="stat-value">3</span>
+        </div>
+        <div class="stat-row">
+          <span class="stat-label">Total</span>
+          <span class="stat-value">10</span>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 
 <div class="coverage-legend">

--- a/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html
+++ b/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html
@@ -125,6 +125,9 @@
       <span class="stat coverage-unknown">
         <strong>-%</strong> Branches (0/0)
       </span>
+      <span class="stat coverage-unknown">
+        <strong>-%</strong> Conditions (0/0)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -146,6 +149,7 @@
       </button>
     </div>
     <div class="source-column-filters">
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -125,6 +125,9 @@
       <span class="stat coverage-low">
         <strong>50.0%</strong> Branches (1/2)
       </span>
+      <span class="stat coverage-low">
+        <strong>50.0%</strong> Conditions (1/2)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -150,6 +153,7 @@
     </div>
     <div class="source-column-filters">
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="branch" title="Toggle Branch column">Branch</button>
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
+++ b/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
@@ -125,6 +125,9 @@
       <span class="stat coverage-none">
         <strong>0.0%</strong> Branches (0/2)
       </span>
+      <span class="stat coverage-none">
+        <strong>0.0%</strong> Conditions (0/2)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -146,6 +149,7 @@
       </button>
     </div>
     <div class="source-column-filters">
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.css
+++ b/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.css
@@ -1290,17 +1290,17 @@ body.sidebar-resizing .main-content {
 /* Adjust grid when columns are hidden */
 .no-functions.no-branches .file-list-header,
 .no-functions.no-branches .file-row {
-  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px;
+  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px 116px;
 }
 
 .no-functions:not(.no-branches) .file-list-header,
 .no-functions:not(.no-branches) .file-row {
-  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px 116px;
+  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px 116px 116px;
 }
 
 .no-branches:not(.no-functions) .file-list-header,
 .no-branches:not(.no-functions) .file-row {
-  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px 116px;
+  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) 116px 116px 116px;
 }
 
 .file-row:nth-child(even) {
@@ -1708,6 +1708,18 @@ tr.source-line.nav-highlight > td {
   display: none;
 }
 
+.source-functions-list.hide-col-condition .col-conditions {
+  display: none;
+}
+
+.source-functions-list.hide-col-decision .col-decisions {
+  display: none;
+}
+
+.source-functions-list.hide-col-call .col-calls {
+  display: none;
+}
+
 .source-function-header {
   display: flex;
   align-items: center;
@@ -2069,6 +2081,9 @@ tr.source-line.nav-highlight > td {
 
 /* Column visibility toggle hide rules */
 .source-table.hide-col-branch .col-branch { display: none; }
+.source-table.hide-col-condition .col-condition { display: none; }
+.source-table.hide-col-decision .col-decision { display: none; }
+.source-table.hide-col-call .col-call { display: none; }
 .source-table.hide-col-tla .col-tla { display: none; }
 .source-table.hide-col-count .col-count { display: none; }
 
@@ -2298,7 +2313,7 @@ tr.source-line.nav-highlight > td {
 
 .functions-header {
   display: grid;
-  grid-template-columns: 1fr 90px 70px 90px;
+  grid-template-columns: 1fr 90px 70px 90px 90px;
   gap: 0;
   padding: 0 16px;
   background: var(--bg-tertiary);
@@ -2342,7 +2357,7 @@ tr.source-line.nav-highlight > td {
 
 .function-row {
   display: grid;
-  grid-template-columns: 1fr 90px 70px 90px;
+  grid-template-columns: 1fr 90px 70px 90px 90px;
   gap: 0;
   padding: 0 16px;
   border-bottom: 1px solid var(--border-muted);
@@ -2352,7 +2367,7 @@ tr.source-line.nav-highlight > td {
 
 .functions-container.no-branches .functions-header,
 .functions-container.no-branches .function-row {
-  grid-template-columns: 1fr 90px 70px;
+  grid-template-columns: 1fr 90px 70px 90px;
 }
 
 .function-row > div:not(:first-child) {

--- a/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -125,6 +125,9 @@
       <span class="stat coverage-low">
         <strong>50.0%</strong> Branches (1/2)
       </span>
+      <span class="stat coverage-low">
+        <strong>50.0%</strong> Conditions (1/2)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -150,6 +153,7 @@
     </div>
     <div class="source-column-filters">
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="branch" title="Toggle Branch column">Branch</button>
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -125,6 +125,9 @@
       <span class="stat coverage-none">
         <strong>0.0%</strong> Branches (0/2)
       </span>
+      <span class="stat coverage-none">
+        <strong>0.0%</strong> Conditions (0/2)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -146,6 +149,7 @@
       </button>
     </div>
     <div class="source-column-filters">
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -125,6 +125,9 @@
       <span class="stat coverage-low">
         <strong>50.0%</strong> Branches (1/2)
       </span>
+      <span class="stat coverage-low">
+        <strong>50.0%</strong> Conditions (1/2)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -150,6 +153,7 @@
     </div>
     <div class="source-column-filters">
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="branch" title="Toggle Branch column">Branch</button>
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -125,6 +125,9 @@
       <span class="stat coverage-unknown">
         <strong>-%</strong> Branches (0/0)
       </span>
+      <span class="stat coverage-unknown">
+        <strong>-%</strong> Conditions (0/0)
+      </span>
     </div>
   </div>
   <div class="nav-hint">
@@ -146,6 +149,7 @@
       </button>
     </div>
     <div class="source-column-filters">
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>

--- a/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.functions.html
+++ b/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.functions.html
@@ -126,6 +126,10 @@
     <span class="stat-label">Branches:</span>
     <span class="stat-value coverage-low">30.0%</span>
   </div>
+  <div class="summary-stat">
+    <span class="stat-label">Conditions:</span>
+    <span class="stat-value coverage-low">30.0%</span>
+  </div>
 </div>          </section>
 
           <section class="main-section">
@@ -156,7 +160,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "bar_()",
@@ -167,7 +173,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo(int)",
@@ -178,7 +186,9 @@
     "excluded": false,
     "line_coverage": "75.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "50.0"
+    "condition_coverage": "50.0",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo5(int)",
@@ -189,7 +199,9 @@
     "excluded": false,
     "line_coverage": "75.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "50.0"
+    "condition_coverage": "50.0",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo6(int)",
@@ -200,7 +212,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "0.0"
+    "condition_coverage": "0.0",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foobar(int)",
@@ -211,7 +225,9 @@
     "excluded": false,
     "line_coverage": "75.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "50.0"
+    "condition_coverage": "50.0",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "four_bar()",
@@ -222,7 +238,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "four_bar_()",
@@ -233,7 +251,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "0.0"
+    "condition_coverage": "0.0",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "uncovered()",
@@ -244,7 +264,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ]
 </script>
@@ -253,7 +275,9 @@
     singlePage: false,
     htmlFilename: "",
     showBranches: true,
-    showConditions: true
+    showConditions: true,
+    showDecisions: false,
+    showCalls: false
   };
 </script>          </section>
         </div>

--- a/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.html
+++ b/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.html
@@ -209,6 +209,31 @@
       </div>
     </div>
   </div>
+
+  <div class="summary-card">
+    <div class="summary-card-header">
+      <h3>Conditions</h3>
+    </div>
+    <div class="summary-card-body">
+      <div class="coverage-ring coverage-low">
+        <svg viewBox="0 0 36 36">
+          <path class="ring-bg" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+          <path class="ring-fill" stroke-dasharray="30.0, 100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+        </svg>
+        <span class="ring-text">30.0%</span>
+      </div>
+      <div class="summary-stats">
+        <div class="stat-row">
+          <span class="stat-label">Hit</span>
+          <span class="stat-value">3</span>
+        </div>
+        <div class="stat-row">
+          <span class="stat-label">Total</span>
+          <span class="stat-value">10</span>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 
 <div class="coverage-legend">

--- a/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.js
+++ b/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.subdir_9.63bd3dc96170cd4173f6130222e788f0.html
+++ b/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.subdir_9.63bd3dc96170cd4173f6130222e788f0.html
@@ -3,7 +3,7 @@
 
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
-    <title>A/file7.cpp - GCC Code Coverage Report - Diff mode</title>
+    <title>subdir_0/subdir_1/subdir_2/subdir_3/subdir_4/subdir_5/subdir_6/subdir_7/subdir_8/subdir_9/ - GCC Code Coverage Report</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <script>
       // Apply theme and font size immediately to prevent flash
@@ -22,8 +22,8 @@
         }
       })();
     </script>
-    <link rel="stylesheet" href="coverage.boost.css"/>
-    <script src="coverage.boost.js" charset="UTF-8"></script>
+    <link rel="stylesheet" href="coverage_nested.css"/>
+    <script src="coverage_nested.js" charset="UTF-8"></script>
   </head>
 
   <body>
@@ -32,7 +32,7 @@
       <aside class="sidebar" id="sidebar"><script>if(localStorage.getItem('sidebar-collapsed')==='true'){document.currentScript.parentElement.classList.add('collapsed');}else{var sw=localStorage.getItem('gcovr-sidebar-width');if(sw)document.documentElement.style.setProperty('--sidebar-width',sw+'px');}</script>
         <div class="sidebar-header">
           <div class="sidebar-header-row">
-            <a href="coverage.boost.html" class="sidebar-logo" title="Back to index">
+            <a href="coverage_nested.html" class="sidebar-logo" title="Back to index">
               <svg viewBox="150 150 700 160" class="boost-wordmark"><path fill="#ffa000" d="M292.45,152.89h-93.18l-46.59,80,12.63,21.69,46.57-79.99h47.07c20.07,0,36.38,16.18,36.38,36.07,0,8.46-3.54,18.29-10.84,22.4,7.11,5.3,10.54,13.73,10.54,22.01,0,19.88-16.32,36.06-36.38,36.06h-61.71l16.12-27.7h45.59c4.66,0,8.45-3.75,8.45-8.36s-3.57-8.16-8.05-8.35c-.13-.02-36.25,0-36.25,0l16.14-27.71s20.22.02,20.31,0c1.9-.06,3.63-.74,5-1.85,1.93-1.53,3.15-3.87,3.15-6.5,0-4.62-3.79-8.37-8.45-8.37h-30.03l-47.04,80.75,17.39,29.85h93.18l46.59-80-46.59-80h0Z"/><path fill="currentColor" d="M550.81,291.93c-9.23,0-17.31-2.01-24.23-6.04s-12.29-9.63-16.1-16.83c-3.81-7.19-5.72-15.4-5.72-24.63s1.9-17.6,5.72-24.79c3.81-7.19,9.18-12.82,16.1-16.91,6.92-4.08,15-6.12,24.23-6.12s17.44,2.04,24.31,6.12,12.21,9.72,16.02,16.91,5.72,15.46,5.72,24.79-1.91,17.44-5.72,24.63-9.15,12.8-16.02,16.83c-6.87,4.02-14.97,6.04-24.31,6.04ZM550.81,272.45c5.37,0,9.79-1.23,13.28-3.7,3.49-2.47,6.12-5.82,7.89-10.06s2.66-8.99,2.66-14.25-.89-10.2-2.66-14.49c-1.77-4.29-4.4-7.7-7.89-10.22-3.49-2.52-7.92-3.78-13.28-3.78s-9.82,1.26-13.36,3.78c-3.54,2.52-6.2,5.93-7.97,10.22-1.77,4.29-2.66,9.12-2.66,14.49s.89,10.01,2.66,14.25c1.77,4.24,4.43,7.59,7.97,10.06s7.99,3.7,13.36,3.7Z"/><path fill="currentColor" d="M648.53,291.93c-9.23,0-17.31-2.01-24.23-6.04s-12.29-9.63-16.1-16.83c-3.81-7.19-5.72-15.4-5.72-24.63s1.9-17.6,5.72-24.79c3.81-7.19,9.18-12.82,16.1-16.91,6.92-4.08,15-6.12,24.23-6.12s17.44,2.04,24.31,6.12,12.21,9.72,16.02,16.91,5.72,15.46,5.72,24.79-1.91,17.44-5.72,24.63-9.15,12.8-16.02,16.83c-6.87,4.02-14.97,6.04-24.31,6.04ZM648.53,272.45c5.37,0,9.79-1.23,13.28-3.7,3.49-2.47,6.12-5.82,7.89-10.06s2.66-8.99,2.66-14.25-.89-10.2-2.66-14.49c-1.77-4.29-4.4-7.7-7.89-10.22-3.49-2.52-7.92-3.78-13.28-3.78s-9.82,1.26-13.36,3.78c-3.54,2.52-6.2,5.93-7.97,10.22-1.77,4.29-2.66,9.12-2.66,14.49s.89,10.01,2.66,14.25c1.77,4.24,4.43,7.59,7.97,10.06s7.99,3.7,13.36,3.7Z"/><path fill="currentColor" d="M722.75,260.85c.54,4.62,2.55,7.86,6.04,9.74s7.49,2.82,11.99,2.82,8.21-.8,11.11-2.41c2.9-1.61,4.35-4.24,4.35-7.89,0-2.25-.99-4-2.98-5.23s-4.56-2.2-7.73-2.9c-3.17-.7-6.66-1.37-10.46-2.01-3.81-.64-7.65-1.5-11.51-2.58-3.86-1.07-7.41-2.58-10.63-4.51-3.22-1.93-5.8-4.53-7.73-7.81-1.93-3.27-2.9-7.49-2.9-12.64,0-4.83,1.55-9.47,4.67-13.93,3.11-4.45,7.49-8.05,13.12-10.79,5.63-2.74,12.1-4.11,19.4-4.11,6.55,0,12.61,1.32,18.19,3.95,5.58,2.63,10.06,6.25,13.44,10.87s5.07,9.98,5.07,16.1h-21.41c-.43-4.61-2.15-7.86-5.15-9.74-3.01-1.88-6.6-2.82-10.79-2.82-4.94,0-8.69.99-11.27,2.98s-3.86,4.48-3.86,7.49c0,2.47.99,4.4,2.98,5.8,1.98,1.4,4.56,2.47,7.73,3.22,3.16.75,6.68,1.42,10.55,2.01,3.86.59,7.7,1.4,11.51,2.42,3.81,1.02,7.33,2.47,10.55,4.35s5.8,4.4,7.73,7.57,2.9,7.27,2.9,12.32c0,5.69-1.56,10.71-4.67,15.05-3.11,4.35-7.49,7.73-13.12,10.14-5.64,2.42-12.26,3.62-19.88,3.62-7.08,0-13.52-1.37-19.32-4.11s-10.44-6.44-13.93-11.11c-3.49-4.67-5.34-9.95-5.55-15.86h21.57,0Z"/><path fill="currentColor" d="M815.48,264.84v-47.29h17.55v-18.35h-17.55v-21.78l-34.42,40.14h12.84v51.81c0,11.05,8.95,20,20,20h21.7v-18.52h-14.12c-3.31,0-6-2.69-6-6h0Z"/><path fill="currentColor" d="M494.62,242.26c-2.36-3.92-5.58-7.03-9.66-9.34-1.08-.61-2.19-1.14-3.33-1.61.7-.44,1.36-.91,1.96-1.45,2.95-2.63,5.1-5.82,6.44-9.58,1.34-3.76,2.01-7.35,2.01-10.79,0-8.69-1.99-15.4-5.96-20.12s-9.31-8.02-16.02-9.9c-6.71-1.88-14.14-2.82-22.3-2.82h-34.29v112.7h40.41c8.16,0,15.59-.99,22.3-2.98,6.71-1.98,12.05-5.45,16.02-10.38,3.97-4.94,5.96-11.7,5.96-20.29,0-5.04-1.18-9.53-3.54-13.44ZM472.48,264.8c-1.88,2.09-4.46,3.52-7.73,4.27-3.28.75-6.9,1.13-10.87,1.13h-18.51v-74.54h12.4c4.08,0,7.73.32,10.95.97,3.22.64,5.77,1.96,7.65,3.95,1.88,1.99,2.82,4.91,2.82,8.77s-.94,6.79-2.82,8.78c-1.88,1.99-4.46,3.3-7.73,3.94-1.87.37-3.86.62-5.96.78l-11.25,19.19h12.46c4.08,0,7.73.35,10.95,1.05,3.22.7,5.77,2.01,7.65,3.94s2.82,4.83,2.82,8.69-.94,7-2.82,9.1v-.02Z"/></svg>
             </a>
             <button class="sidebar-toggle" id="sidebar-toggle" title="Toggle sidebar">
@@ -59,24 +59,11 @@
           </button>
         </div>
         <nav class="sidebar-nav" id="file-tree">
-<div class="tree-item">
+<div class="tree-item ">
   <div class="tree-item-header">
-    <a href="coverage.boost.html" class="tree-toggle" title="Back to directory">
-      <span class="toggle-icon">&larr;</span>
-    </a>
-    <span class="tree-icon folder">
-      <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M1.75 1A1.75 1.75 0 000 2.75v10.5C0 14.216.784 15 1.75 15h12.5A1.75 1.75 0 0016 13.25v-8.5A1.75 1.75 0 0014.25 3H7.5a.25.25 0 01-.2-.1l-.9-1.2C6.07 1.26 5.55 1 5 1H1.75z"></path></svg>
-    </span>
-    <a class="tree-label" href="coverage.boost.html">Back to Index</a>
-  </div>
-</div>
-<div class="tree-item active">
-  <div class="tree-item-header">
-    <span class="tree-toggle-spacer"></span>
-    <span class="tree-icon file">
-      <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M3.75 1.5a.25.25 0 00-.25.25v12.5c0 .138.112.25.25.25h9.5a.25.25 0 00.25-.25V6h-2.75A1.75 1.75 0 019 4.25V1.5H3.75zm6.75.062V4.25c0 .138.112.25.25.25h2.688l-2.938-2.938zM2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0113.25 16h-9.5A1.75 1.75 0 012 14.25V1.75z"></path></svg>
-    </span>
-    <span class="tree-label">A/file7.cpp</span>
+    <span class="tree-spacer"></span>
+    <svg class="tree-icon tree-icon-file" viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M3.75 1.5a.25.25 0 00-.25.25v12.5c0 .138.112.25.25.25h9.5a.25.25 0 00.25-.25V6h-2.75A1.75 1.75 0 019 4.25V1.5H3.75zm6.75.062V4.25c0 .138.112.25.25.25h2.688l-2.938-2.938zM2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0113.25 16h-9.5A1.75 1.75 0 012 14.25V1.75z"></path></svg>
+    <a class="tree-label" href="coverage_nested.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html" title="File2.cpp">File2.cpp</a>
   </div>
 </div>
         </nav>
@@ -93,7 +80,7 @@
             <svg viewBox="0 0 16 16" fill="currentColor"><path d="M2.5 12a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5z"/></svg>
           </button>
           <div class="breadcrumb">
-<a href="coverage.boost.html" class="breadcrumb-home">Index</a><span class="separator">/</span><span class="current" title="A/file7.cpp">A / file7.cpp</span>          </div>
+<a href="coverage_nested.html" class="breadcrumb-home">GCC Code Coverage Report</a><span class="separator">/</span><span class="current" title="subdir_0/subdir_1/subdir_2/subdir_3/subdir_4/subdir_5/subdir_6/subdir_7/subdir_8/subdir_9/">subdir_0 / subdir_1 / subdir_2 / subdir_3 / subdir_4 / subdir_5 / subdir_6 / subdir_7 / subdir_8 / subdir_9 / </span>          </div>
           <div class="header-actions">
           </div>
           <div class="view-toggle" id="view-toggle" style="display:none">
@@ -112,161 +99,189 @@
 
         <div class="content-wrapper">
           <section class="summary-section">
-<div class="source-summary">
-  <div class="source-info">
-    <h2 class="source-filename">A/file7.cpp</h2>
-    <div class="source-stats">
-      <span class="stat coverage-none">
-        <strong>0.0%</strong> Lines (0/2)
-      </span>
-      <span class="stat coverage-none">
-        <strong>0.0%</strong> List of functions (0/1)
-      </span>
-      <span class="stat coverage-unknown">
-        <strong>-%</strong> Branches (0/0)
-      </span>
-      <span class="stat coverage-unknown">
-        <strong>-%</strong> Conditions (0/0)
-      </span>
+<div class="summary-cards">
+  <div class="summary-card">
+    <div class="summary-card-header">
+      <h3>Lines</h3>
+    </div>
+    <div class="summary-card-body">
+      <div class="coverage-ring coverage-low">
+        <svg viewBox="0 0 36 36">
+          <path class="ring-bg" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+          <path class="ring-fill" stroke-dasharray="50.0, 100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+        </svg>
+        <span class="ring-text">50.0%</span>
+      </div>
+      <div class="summary-stats">
+        <div class="stat-row">
+          <span class="stat-label">Hit</span>
+          <span class="stat-value">17</span>
+        </div>
+        <div class="stat-row">
+          <span class="stat-label">Total</span>
+          <span class="stat-value">34</span>
+        </div>
+      </div>
     </div>
   </div>
-  <div class="nav-hint">
-    <span><kbd>[</kbd> <kbd>]</kbd> prev/next file</span>
-    <span><kbd>n</kbd> <kbd>p</kbd> prev/next uncovered line</span>
+
+  <div class="summary-card">
+    <div class="summary-card-header">
+      <h3>Functions</h3>
+    </div>
+    <div class="summary-card-body">
+      <div class="coverage-ring coverage-low">
+        <svg viewBox="0 0 36 36">
+          <path class="ring-bg" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+          <path class="ring-fill" stroke-dasharray="55.6, 100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+        </svg>
+        <span class="ring-text">55.6%</span>
+      </div>
+      <div class="summary-stats">
+        <div class="stat-row">
+          <span class="stat-label">Hit</span>
+          <span class="stat-value">5</span>
+        </div>
+        <div class="stat-row">
+          <span class="stat-label">Total</span>
+          <span class="stat-value">9</span>
+        </div>
+      </div>
+    </div>
   </div>
+
+  <div class="summary-card">
+    <div class="summary-card-header">
+      <h3>Branches</h3>
+    </div>
+    <div class="summary-card-body">
+      <div class="coverage-ring coverage-low">
+        <svg viewBox="0 0 36 36">
+          <path class="ring-bg" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+          <path class="ring-fill" stroke-dasharray="30.0, 100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+        </svg>
+        <span class="ring-text">30.0%</span>
+      </div>
+      <div class="summary-stats">
+        <div class="stat-row">
+          <span class="stat-label">Hit</span>
+          <span class="stat-value">3</span>
+        </div>
+        <div class="stat-row">
+          <span class="stat-label">Total</span>
+          <span class="stat-value">10</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="summary-card">
+    <div class="summary-card-header">
+      <h3>Conditions</h3>
+    </div>
+    <div class="summary-card-body">
+      <div class="coverage-ring coverage-low">
+        <svg viewBox="0 0 36 36">
+          <path class="ring-bg" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+          <path class="ring-fill" stroke-dasharray="30.0, 100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>
+        </svg>
+        <span class="ring-text">30.0%</span>
+      </div>
+      <div class="summary-stats">
+        <div class="stat-row">
+          <span class="stat-label">Hit</span>
+          <span class="stat-value">3</span>
+        </div>
+        <div class="stat-row">
+          <span class="stat-label">Total</span>
+          <span class="stat-value">10</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="coverage-legend">
+  <span class="legend-item coverage-high">High: &ge; 90.0%</span>
+  <span class="legend-item coverage-medium">Medium: &ge; 75.0%</span>
+  <span class="legend-item coverage-low">Low: &lt; 75.0%</span>
+  <span class="legend-separator"></span>
+  <a href="coverage_nested.functions.html" class="legend-item legend-functions-link" title="List of all functions">
+    <span class="fx-icon" aria-hidden="true"><i>f</i>(x)</span>
+    List of functions
+  </a>
 </div>          </section>
 
           <section class="main-section">
-<div class="source-container no-branches">
-  <div class="source-header">
-    <span class="source-header-filename">file7.cpp</span>
-    <div class="source-line-filters">
-      <button type="button" class="btn btn-sm button_toggle_coveredLine show_coveredLine" value="coveredLine" title="Toggle covered lines">
-        covered
-      </button>
-      <button type="button" class="btn btn-sm button_toggle_uncoveredLine show_uncoveredLine" value="uncoveredLine" title="Toggle uncovered lines">
-        uncovered
-      </button>
+<div class="file-list-container no-branches no-decisions no-calls">
+  <div class="file-list-header">
+    <div class="col-name sortable sorted-ascending" data-sort="filename">
+      Name
     </div>
-    <div class="source-column-filters">
-      <button type="button" class="btn btn-sm col-toggle show-col" data-col="condition" title="Toggle Condition column">Condition</button>
-      <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
-      <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
+    <div class="col-coverage sortable" data-sort="coverage">
+      Coverage
     </div>
-    <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html" title="Previous file">
-        <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
-      </a>
-      <a class="nav-link nav-next" href="coverage.boost.B.cec86a34c08f941fc92924df967d4300.html" title="Next file">
-        <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
-      </a>
+    <div class="col-lines sortable" data-sort="lines">
+      Lines
     </div>
-<span class="source-header-sep"></span>    <div id="coverage-nav">
-      <button type="button" id="nav-prev" class="nav-link" title="Previous uncovered line (p)">
-        <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(90 8 8)"/></svg>
-      </button>
-      <span id="nav-counter" class="nav-counter"></span>
-      <button type="button" id="nav-next" class="nav-link" title="Next uncovered line (n)">
-        <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(-90 8 8)"/></svg>
-      </button>
+    <div class="col-functions sortable" data-sort="functions">
+      Functions
+    </div>
+    <div class="col-conditions sortable" data-sort="conditions">
+      Conditions
     </div>
   </div>
 
-
-  <details class="source-functions">
-    <summary class="source-functions-toggle">
-      <span class="fx-icon"><i>f</i>(x)</span>
-      Functions (1)
-    </summary>
-    <div class="source-functions-list">
-      <div class="source-function-header">
-        <span class="source-function-col-name" data-sort="name">Function</span>
-        <span class="source-function-col-stat" data-sort="calls">Calls</span>
-        <span class="source-function-col-stat" data-sort="lines">Lines</span>
-        <span class="source-function-col-stat" data-sort="blocks">Blocks</span>
-      </div>
-      <a href="#l1" class="source-function-item fn-uncovered"
-         data-name="uncovered()" data-calls="0" data-lines="0.0" data-branches="-1" data-blocks="0.0">
-        <span class="source-function-col-name">
-          <span class="source-function-name">uncovered()</span>
-          <span class="source-function-line">:1</span>
+  <div class="file-list-body" id="file-list">
+    <div class="file-row file"
+         data-filename="File2.cpp"
+         data-coverage="57.1"
+         data-lines="7"
+         data-lines-exec="4"
+         data-lines-coverage="57.1"
+         data-lines-class="coverage-low"
+         data-functions="50.0"
+         data-functions-coverage="50.0"
+         data-functions-class="coverage-low"
+         data-branches="-"
+         data-branches-coverage="-"
+         data-branches-class="coverage-unknown"
+         data-conditions="-"
+         data-conditions-coverage="-"
+         data-conditions-class="coverage-unknown"
+         data-decisions="-"
+         data-decisions-coverage="-"
+         data-decisions-class="coverage-unknown"
+         data-calls="-"
+         data-calls-coverage="-"
+         data-calls-class="coverage-unknown"
+         data-diff="None">
+      <div class="col-name">
+        <span class="file-icon">
+          <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M3.75 1.5a.25.25 0 00-.25.25v12.5c0 .138.112.25.25.25h9.5a.25.25 0 00.25-.25V6h-2.75A1.75 1.75 0 019 4.25V1.5H3.75zm6.75.062V4.25c0 .138.112.25.25.25h2.688a.252.252 0 00-.011-.013l-2.914-2.914a.272.272 0 00-.013-.011zM2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0113.25 16h-9.5A1.75 1.75 0 012 14.25V1.75z"></path></svg>
         </span>
-        <span class="source-function-col-stat not-called">0</span>
-        <span class="source-function-col-stat cov-low">0.0%</span>
-        <span class="source-function-col-stat cov-low">0.0%</span>
-      </a>
-    </div>
-  </details>
+        <a href="coverage_nested.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html" title="File2.cpp">File2.cpp</a>
+      </div>
 
-  <div class="source-table-container">
-    <table class="source-table">
-      <thead>
-        <tr>
-          <th class="col-lineno">Line</th>
-          <th class="col-condition">Condition</th>
-          <th class="col-tla">TLA</th>
-          <th class="col-count">Hits</th>
-          <th class="col-source">Source Code</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr class="source-line uncoveredLine show_uncoveredLine">
-          <td class="col-lineno">
-            <a id="l1">1</a>
-          </td>
-          <td class="col-condition">
-          </td>
-          <td class="col-tla"></td>
-          <td class="col-count uncoveredLine">
-<span class="hit-miss">&cross;</span>          </td>
-          <td class="col-source"><span class="kt">int</span><span class="w"> </span><span class="nf">uncovered</span><span class="p">()</span></td>
-        </tr>
-        <tr class="source-line">
-          <td class="col-lineno">
-            <a id="l2">2</a>
-          </td>
-          <td class="col-condition">
-          </td>
-          <td class="col-tla"></td>
-          <td class="col-count">
-          </td>
-          <td class="col-source"><span class="p">{</span></td>
-        </tr>
-        <tr class="source-line uncoveredLine show_uncoveredLine">
-          <td class="col-lineno">
-            <a id="l3">3</a>
-          </td>
-          <td class="col-condition">
-          </td>
-          <td class="col-tla"></td>
-          <td class="col-count uncoveredLine">
-<span class="hit-miss">&cross;</span>          </td>
-          <td class="col-source"><span class="k">return</span><span class="w"> </span><span class="mi">0</span><span class="p">;</span></td>
-        </tr>
-        <tr class="source-line">
-          <td class="col-lineno">
-            <a id="l4">4</a>
-          </td>
-          <td class="col-condition">
-          </td>
-          <td class="col-tla"></td>
-          <td class="col-count">
-          </td>
-          <td class="col-source"><span class="p">}</span></td>
-        </tr>
-        <tr class="source-line">
-          <td class="col-lineno">
-            <a id="l5">5</a>
-          </td>
-          <td class="col-condition">
-          </td>
-          <td class="col-tla"></td>
-          <td class="col-count">
-          </td>
-          <td class="col-source"></td>
-        </tr>
-      </tbody>
-    </table>
+      <div class="col-coverage">
+        <div class="coverage-bar-container">
+          <div class="coverage-bar coverage-low" style="width: 57.1%"></div>
+        </div>
+        <span class="coverage-percent coverage-low">57.1%</span>
+      </div>
+
+      <div class="col-lines">
+        <span class="stat-value">4</span>
+        <span class="stat-separator">/</span>
+        <span class="stat-total">7</span>
+      </div>
+      <div class="col-functions">
+        <span class="stat-value coverage-low">50.0%</span>
+      </div>
+      <div class="col-conditions">
+        <span class="stat-value coverage-unknown">-</span>
+      </div>
+    </div>
   </div>
 </div>          </section>
         </div>

--- a/tests/html/reference/nested-theme-boost-green/gcc-5/coverage_nested.css
+++ b/tests/html/reference/nested-theme-boost-green/gcc-5/coverage_nested.css
@@ -1708,6 +1708,18 @@ tr.source-line.nav-highlight > td {
   display: none;
 }
 
+.source-functions-list.hide-col-condition .col-conditions {
+  display: none;
+}
+
+.source-functions-list.hide-col-decision .col-decisions {
+  display: none;
+}
+
+.source-functions-list.hide-col-call .col-calls {
+  display: none;
+}
+
 .source-function-header {
   display: flex;
   align-items: center;
@@ -2069,6 +2081,9 @@ tr.source-line.nav-highlight > td {
 
 /* Column visibility toggle hide rules */
 .source-table.hide-col-branch .col-branch { display: none; }
+.source-table.hide-col-condition .col-condition { display: none; }
+.source-table.hide-col-decision .col-decision { display: none; }
+.source-table.hide-col-call .col-call { display: none; }
 .source-table.hide-col-tla .col-tla { display: none; }
 .source-table.hide-col-count .col-count { display: none; }
 

--- a/tests/html/reference/nested-theme-boost-green/gcc-5/coverage_nested.functions.html
+++ b/tests/html/reference/nested-theme-boost-green/gcc-5/coverage_nested.functions.html
@@ -155,7 +155,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "bar_()",
@@ -166,7 +168,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo(int)",
@@ -177,7 +181,9 @@
     "excluded": false,
     "line_coverage": "75.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo5(int)",
@@ -188,7 +194,9 @@
     "excluded": false,
     "line_coverage": "75.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foo6(int)",
@@ -199,7 +207,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "foobar(int)",
@@ -210,7 +220,9 @@
     "excluded": false,
     "line_coverage": "75.0",
     "branch_coverage": "50.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "four_bar()",
@@ -221,7 +233,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "four_bar_()",
@@ -232,7 +246,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "0.0",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ,  {
     "name": "uncovered()",
@@ -243,7 +259,9 @@
     "excluded": false,
     "line_coverage": "0.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ]
 </script>
@@ -252,7 +270,9 @@
     singlePage: false,
     htmlFilename: "",
     showBranches: true,
-    showConditions: false
+    showConditions: false,
+    showDecisions: false,
+    showCalls: false
   };
 </script>          </section>
         </div>

--- a/tests/html/reference/nested-theme-boost-green/gcc-5/coverage_nested.js
+++ b/tests/html/reference/nested-theme-boost-green/gcc-5/coverage_nested.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/html/reference/theme-boost-blue/clang-10/coverage.css
+++ b/tests/html/reference/theme-boost-blue/clang-10/coverage.css
@@ -1708,6 +1708,18 @@ tr.source-line.nav-highlight > td {
   display: none;
 }
 
+.source-functions-list.hide-col-condition .col-conditions {
+  display: none;
+}
+
+.source-functions-list.hide-col-decision .col-decisions {
+  display: none;
+}
+
+.source-functions-list.hide-col-call .col-calls {
+  display: none;
+}
+
 .source-function-header {
   display: flex;
   align-items: center;
@@ -2069,6 +2081,9 @@ tr.source-line.nav-highlight > td {
 
 /* Column visibility toggle hide rules */
 .source-table.hide-col-branch .col-branch { display: none; }
+.source-table.hide-col-condition .col-condition { display: none; }
+.source-table.hide-col-decision .col-decision { display: none; }
+.source-table.hide-col-call .col-call { display: none; }
 .source-table.hide-col-tla .col-tla { display: none; }
 .source-table.hide-col-count .col-count { display: none; }
 

--- a/tests/html/reference/theme-boost-blue/clang-10/coverage.functions.html
+++ b/tests/html/reference/theme-boost-blue/clang-10/coverage.functions.html
@@ -89,7 +89,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ]
 </script>
@@ -98,7 +100,9 @@
     singlePage: false,
     htmlFilename: "",
     showBranches: false,
-    showConditions: false
+    showConditions: false,
+    showDecisions: false,
+    showCalls: false
   };
 </script>          </section>
         </div>

--- a/tests/html/reference/theme-boost-blue/clang-10/coverage.js
+++ b/tests/html/reference/theme-boost-blue/clang-10/coverage.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/html/reference/theme-boost-blue/gcc-14/coverage.css
+++ b/tests/html/reference/theme-boost-blue/gcc-14/coverage.css
@@ -1708,6 +1708,18 @@ tr.source-line.nav-highlight > td {
   display: none;
 }
 
+.source-functions-list.hide-col-condition .col-conditions {
+  display: none;
+}
+
+.source-functions-list.hide-col-decision .col-decisions {
+  display: none;
+}
+
+.source-functions-list.hide-col-call .col-calls {
+  display: none;
+}
+
 .source-function-header {
   display: flex;
   align-items: center;
@@ -2069,6 +2081,9 @@ tr.source-line.nav-highlight > td {
 
 /* Column visibility toggle hide rules */
 .source-table.hide-col-branch .col-branch { display: none; }
+.source-table.hide-col-condition .col-condition { display: none; }
+.source-table.hide-col-decision .col-decision { display: none; }
+.source-table.hide-col-call .col-call { display: none; }
 .source-table.hide-col-tla .col-tla { display: none; }
 .source-table.hide-col-count .col-count { display: none; }
 

--- a/tests/html/reference/theme-boost-blue/gcc-14/coverage.js
+++ b/tests/html/reference/theme-boost-blue/gcc-14/coverage.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/html/reference/theme-boost-blue/gcc-5/coverage.css
+++ b/tests/html/reference/theme-boost-blue/gcc-5/coverage.css
@@ -1708,6 +1708,18 @@ tr.source-line.nav-highlight > td {
   display: none;
 }
 
+.source-functions-list.hide-col-condition .col-conditions {
+  display: none;
+}
+
+.source-functions-list.hide-col-decision .col-decisions {
+  display: none;
+}
+
+.source-functions-list.hide-col-call .col-calls {
+  display: none;
+}
+
 .source-function-header {
   display: flex;
   align-items: center;
@@ -2069,6 +2081,9 @@ tr.source-line.nav-highlight > td {
 
 /* Column visibility toggle hide rules */
 .source-table.hide-col-branch .col-branch { display: none; }
+.source-table.hide-col-condition .col-condition { display: none; }
+.source-table.hide-col-decision .col-decision { display: none; }
+.source-table.hide-col-call .col-call { display: none; }
 .source-table.hide-col-tla .col-tla { display: none; }
 .source-table.hide-col-count .col-count { display: none; }
 

--- a/tests/html/reference/theme-boost-blue/gcc-5/coverage.functions.html
+++ b/tests/html/reference/theme-boost-blue/gcc-5/coverage.functions.html
@@ -89,7 +89,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ]
 </script>
@@ -98,7 +100,9 @@
     singlePage: false,
     htmlFilename: "",
     showBranches: false,
-    showConditions: false
+    showConditions: false,
+    showDecisions: false,
+    showCalls: false
   };
 </script>          </section>
         </div>

--- a/tests/html/reference/theme-boost-blue/gcc-5/coverage.js
+++ b/tests/html/reference/theme-boost-blue/gcc-5/coverage.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/html/reference/theme-boost-green/clang-10/coverage.css
+++ b/tests/html/reference/theme-boost-green/clang-10/coverage.css
@@ -1708,6 +1708,18 @@ tr.source-line.nav-highlight > td {
   display: none;
 }
 
+.source-functions-list.hide-col-condition .col-conditions {
+  display: none;
+}
+
+.source-functions-list.hide-col-decision .col-decisions {
+  display: none;
+}
+
+.source-functions-list.hide-col-call .col-calls {
+  display: none;
+}
+
 .source-function-header {
   display: flex;
   align-items: center;
@@ -2069,6 +2081,9 @@ tr.source-line.nav-highlight > td {
 
 /* Column visibility toggle hide rules */
 .source-table.hide-col-branch .col-branch { display: none; }
+.source-table.hide-col-condition .col-condition { display: none; }
+.source-table.hide-col-decision .col-decision { display: none; }
+.source-table.hide-col-call .col-call { display: none; }
 .source-table.hide-col-tla .col-tla { display: none; }
 .source-table.hide-col-count .col-count { display: none; }
 

--- a/tests/html/reference/theme-boost-green/clang-10/coverage.functions.html
+++ b/tests/html/reference/theme-boost-green/clang-10/coverage.functions.html
@@ -89,7 +89,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ]
 </script>
@@ -98,7 +100,9 @@
     singlePage: false,
     htmlFilename: "",
     showBranches: false,
-    showConditions: false
+    showConditions: false,
+    showDecisions: false,
+    showCalls: false
   };
 </script>          </section>
         </div>

--- a/tests/html/reference/theme-boost-green/clang-10/coverage.js
+++ b/tests/html/reference/theme-boost-green/clang-10/coverage.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/html/reference/theme-boost-green/gcc-14/coverage.css
+++ b/tests/html/reference/theme-boost-green/gcc-14/coverage.css
@@ -1708,6 +1708,18 @@ tr.source-line.nav-highlight > td {
   display: none;
 }
 
+.source-functions-list.hide-col-condition .col-conditions {
+  display: none;
+}
+
+.source-functions-list.hide-col-decision .col-decisions {
+  display: none;
+}
+
+.source-functions-list.hide-col-call .col-calls {
+  display: none;
+}
+
 .source-function-header {
   display: flex;
   align-items: center;
@@ -2069,6 +2081,9 @@ tr.source-line.nav-highlight > td {
 
 /* Column visibility toggle hide rules */
 .source-table.hide-col-branch .col-branch { display: none; }
+.source-table.hide-col-condition .col-condition { display: none; }
+.source-table.hide-col-decision .col-decision { display: none; }
+.source-table.hide-col-call .col-call { display: none; }
 .source-table.hide-col-tla .col-tla { display: none; }
 .source-table.hide-col-count .col-count { display: none; }
 

--- a/tests/html/reference/theme-boost-green/gcc-14/coverage.js
+++ b/tests/html/reference/theme-boost-green/gcc-14/coverage.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/html/reference/theme-boost-green/gcc-5/coverage.css
+++ b/tests/html/reference/theme-boost-green/gcc-5/coverage.css
@@ -1708,6 +1708,18 @@ tr.source-line.nav-highlight > td {
   display: none;
 }
 
+.source-functions-list.hide-col-condition .col-conditions {
+  display: none;
+}
+
+.source-functions-list.hide-col-decision .col-decisions {
+  display: none;
+}
+
+.source-functions-list.hide-col-call .col-calls {
+  display: none;
+}
+
 .source-function-header {
   display: flex;
   align-items: center;
@@ -2069,6 +2081,9 @@ tr.source-line.nav-highlight > td {
 
 /* Column visibility toggle hide rules */
 .source-table.hide-col-branch .col-branch { display: none; }
+.source-table.hide-col-condition .col-condition { display: none; }
+.source-table.hide-col-decision .col-decision { display: none; }
+.source-table.hide-col-call .col-call { display: none; }
 .source-table.hide-col-tla .col-tla { display: none; }
 .source-table.hide-col-count .col-count { display: none; }
 

--- a/tests/html/reference/theme-boost-green/gcc-5/coverage.functions.html
+++ b/tests/html/reference/theme-boost-green/gcc-5/coverage.functions.html
@@ -89,7 +89,9 @@
     "excluded": false,
     "line_coverage": "100.0",
     "branch_coverage": "-",
-    "condition_coverage": "-"
+    "condition_coverage": "-",
+    "decision_coverage": "-",
+    "call_coverage": "-"
   }
 ]
 </script>
@@ -98,7 +100,9 @@
     singlePage: false,
     htmlFilename: "",
     showBranches: false,
-    showConditions: false
+    showConditions: false,
+    showDecisions: false,
+    showCalls: false
   };
 </script>          </section>
         </div>

--- a/tests/html/reference/theme-boost-green/gcc-5/coverage.js
+++ b/tests/html/reference/theme-boost-green/gcc-5/coverage.js
@@ -820,6 +820,8 @@
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
+    var showDecisions = config.showDecisions;
+    var showCalls = config.showCalls;
     var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
@@ -897,6 +899,16 @@
       // col-conditions (optional)
       if (showConditions) {
         row.appendChild(el('div', 'col-conditions', entry.condition_coverage + '%'));
+      }
+
+      // col-decisions (optional)
+      if (showDecisions) {
+        row.appendChild(el('div', 'col-decisions', entry.decision_coverage + '%'));
+      }
+
+      // col-calls (optional)
+      if (showCalls) {
+        row.appendChild(el('div', 'col-calls', entry.call_coverage + '%'));
       }
 
       return row;

--- a/tests/template-function/reference/template-function/clang-10/coverage.html
+++ b/tests/template-function/reference/template-function/clang-10/coverage.html
@@ -1392,7 +1392,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="58.3">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-low" style="width: 100%;">
         <div class="percent">58.3%</div>
-        <div class="counter" title="Exec / Excl / Total">7 /  / 12</div>
+        <div class="counter" title="Exec / Excl / Total">7 / - / 12</div>
       </div>
     </div>
   </div>

--- a/tests/template-function/reference/template-function/clang-10/coverage.merged.html
+++ b/tests/template-function/reference/template-function/clang-10/coverage.merged.html
@@ -1392,7 +1392,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="58.3">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-low" style="width: 100%;">
         <div class="percent">58.3%</div>
-        <div class="counter" title="Exec / Excl / Total">7 /  / 12</div>
+        <div class="counter" title="Exec / Excl / Total">7 / - / 12</div>
       </div>
     </div>
   </div>

--- a/tests/template-function/reference/template-function/clang-11/coverage.html
+++ b/tests/template-function/reference/template-function/clang-11/coverage.html
@@ -1392,7 +1392,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="58.3">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-low" style="width: 100%;">
         <div class="percent">58.3%</div>
-        <div class="counter" title="Exec / Excl / Total">7 /  / 12</div>
+        <div class="counter" title="Exec / Excl / Total">7 / - / 12</div>
       </div>
     </div>
   </div>

--- a/tests/template-function/reference/template-function/clang-11/coverage.merged.html
+++ b/tests/template-function/reference/template-function/clang-11/coverage.merged.html
@@ -1392,7 +1392,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="58.3">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-low" style="width: 100%;">
         <div class="percent">58.3%</div>
-        <div class="counter" title="Exec / Excl / Total">7 /  / 12</div>
+        <div class="counter" title="Exec / Excl / Total">7 / - / 12</div>
       </div>
     </div>
   </div>

--- a/tests/template-function/reference/template-function/clang-12/coverage.html
+++ b/tests/template-function/reference/template-function/clang-12/coverage.html
@@ -1392,7 +1392,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="58.3">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-low" style="width: 100%;">
         <div class="percent">58.3%</div>
-        <div class="counter" title="Exec / Excl / Total">7 /  / 12</div>
+        <div class="counter" title="Exec / Excl / Total">7 / - / 12</div>
       </div>
     </div>
   </div>

--- a/tests/template-function/reference/template-function/clang-12/coverage.merged.html
+++ b/tests/template-function/reference/template-function/clang-12/coverage.merged.html
@@ -1392,7 +1392,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="58.3">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-low" style="width: 100%;">
         <div class="percent">58.3%</div>
-        <div class="counter" title="Exec / Excl / Total">7 /  / 12</div>
+        <div class="counter" title="Exec / Excl / Total">7 / - / 12</div>
       </div>
     </div>
   </div>

--- a/tests/template-function/reference/template-function/clang-17-Darwin/coverage.html
+++ b/tests/template-function/reference/template-function/clang-17-Darwin/coverage.html
@@ -1392,7 +1392,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="58.3">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-low" style="width: 100%;">
         <div class="percent">58.3%</div>
-        <div class="counter" title="Exec / Excl / Total">7 /  / 12</div>
+        <div class="counter" title="Exec / Excl / Total">7 / - / 12</div>
       </div>
     </div>
   </div>

--- a/tests/template-function/reference/template-function/clang-17-Darwin/coverage.merged.html
+++ b/tests/template-function/reference/template-function/clang-17-Darwin/coverage.merged.html
@@ -1392,7 +1392,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="58.3">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-low" style="width: 100%;">
         <div class="percent">58.3%</div>
-        <div class="counter" title="Exec / Excl / Total">7 /  / 12</div>
+        <div class="counter" title="Exec / Excl / Total">7 / - / 12</div>
       </div>
     </div>
   </div>

--- a/tests/template-function/reference/template-function/clang-18/coverage.html
+++ b/tests/template-function/reference/template-function/clang-18/coverage.html
@@ -1392,7 +1392,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="58.3">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-low" style="width: 100%;">
         <div class="percent">58.3%</div>
-        <div class="counter" title="Exec / Excl / Total">7 /  / 12</div>
+        <div class="counter" title="Exec / Excl / Total">7 / - / 12</div>
       </div>
     </div>
   </div>

--- a/tests/template-function/reference/template-function/clang-18/coverage.merged.html
+++ b/tests/template-function/reference/template-function/clang-18/coverage.merged.html
@@ -1392,7 +1392,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="58.3">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-low" style="width: 100%;">
         <div class="percent">58.3%</div>
-        <div class="counter" title="Exec / Excl / Total">7 /  / 12</div>
+        <div class="counter" title="Exec / Excl / Total">7 / - / 12</div>
       </div>
     </div>
   </div>

--- a/tests/template-function/reference/template-function/gcc-14/coverage.html
+++ b/tests/template-function/reference/template-function/gcc-14/coverage.html
@@ -1409,7 +1409,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="50.0">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-low" style="width: 100%;">
         <div class="percent">50.0%</div>
-        <div class="counter" title="Exec / Excl / Total">3 /  / 6</div>
+        <div class="counter" title="Exec / Excl / Total">3 / - / 6</div>
       </div>
     </div>
   </div>

--- a/tests/template-function/reference/template-function/gcc-14/coverage.merged.html
+++ b/tests/template-function/reference/template-function/gcc-14/coverage.merged.html
@@ -1409,7 +1409,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="50.0">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-low" style="width: 100%;">
         <div class="percent">50.0%</div>
-        <div class="counter" title="Exec / Excl / Total">3 /  / 6</div>
+        <div class="counter" title="Exec / Excl / Total">3 / - / 6</div>
       </div>
     </div>
   </div>

--- a/tests/template-function/reference/template-function/gcc-5/coverage.html
+++ b/tests/template-function/reference/template-function/gcc-5/coverage.html
@@ -1392,7 +1392,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="58.3">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-low" style="width: 100%;">
         <div class="percent">58.3%</div>
-        <div class="counter" title="Exec / Excl / Total">7 /  / 12</div>
+        <div class="counter" title="Exec / Excl / Total">7 / - / 12</div>
       </div>
     </div>
   </div>

--- a/tests/template-function/reference/template-function/gcc-5/coverage.merged.html
+++ b/tests/template-function/reference/template-function/gcc-5/coverage.merged.html
@@ -1392,7 +1392,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="58.3">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-low" style="width: 100%;">
         <div class="percent">58.3%</div>
-        <div class="counter" title="Exec / Excl / Total">7 /  / 12</div>
+        <div class="counter" title="Exec / Excl / Total">7 / - / 12</div>
       </div>
     </div>
   </div>

--- a/tests/template-function/reference/template-function/gcc-8/coverage.html
+++ b/tests/template-function/reference/template-function/gcc-8/coverage.html
@@ -1392,7 +1392,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="50.0">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-low" style="width: 100%;">
         <div class="percent">50.0%</div>
-        <div class="counter" title="Exec / Excl / Total">3 /  / 6</div>
+        <div class="counter" title="Exec / Excl / Total">3 / - / 6</div>
       </div>
     </div>
   </div>

--- a/tests/template-function/reference/template-function/gcc-8/coverage.merged.html
+++ b/tests/template-function/reference/template-function/gcc-8/coverage.merged.html
@@ -1392,7 +1392,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="50.0">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-low" style="width: 100%;">
         <div class="percent">50.0%</div>
-        <div class="counter" title="Exec / Excl / Total">3 /  / 6</div>
+        <div class="counter" title="Exec / Excl / Total">3 / - / 6</div>
       </div>
     </div>
   </div>

--- a/tests/template-function/reference/template-function/gcc-9/coverage.html
+++ b/tests/template-function/reference/template-function/gcc-9/coverage.html
@@ -1392,7 +1392,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="50.0">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-low" style="width: 100%;">
         <div class="percent">50.0%</div>
-        <div class="counter" title="Exec / Excl / Total">3 /  / 6</div>
+        <div class="counter" title="Exec / Excl / Total">3 / - / 6</div>
       </div>
     </div>
   </div>

--- a/tests/template-function/reference/template-function/gcc-9/coverage.merged.html
+++ b/tests/template-function/reference/template-function/gcc-9/coverage.merged.html
@@ -1392,7 +1392,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div role="gridcell" class="color-fg-muted d-flex col-2" data-sort="50.0">
       <div class="d-flex flex-justify-between flex-wrap gcovr-m-l-5 coverage-low" style="width: 100%;">
         <div class="percent">50.0%</div>
-        <div class="counter" title="Exec / Excl / Total">3 /  / 6</div>
+        <div class="counter" title="Exec / Excl / Total">3 / - / 6</div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
- Change the HTML boost theme to add the following:
  - Conditions Summary Card
  - Decisions Summary Card
  - Calls Summary Card
  - Change the source page to add the same missing summaries
as the top level cards
  - Change the source page to add the toggle buttons with the
matching columns
  - Change the functions page to add the same missing summaries
as the top level cards
  - Adjust the CSS and other templates for the missing columns
in the various pages
- There's no decision 'excluded' field; fix template which
  wanted to access this field
- Use the SHOW_X checks everywhere to be consistent. If there's
  no data for that type of optional item, it will show no
  coverage but at least all summaries/columns will align
  as a set

Fixes #1276