### PR TITLE
Use StrictUndefined in Jinja2 environment for HTML reports

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,9 @@ Next Release
 
 Breaking changes:
 
+- Jinja2 environment for HTML reports is now created with ``undefined=StrictUndefined`` to raise an
+  error if a variable is not defined in the template. (:issue:`1282`)
+
 New features and notable changes:
 
 - Improve HTML report:

--- a/src/gcovr/formats/html/write.py
+++ b/src/gcovr/formats/html/write.py
@@ -31,6 +31,7 @@ from jinja2 import (
     FileSystemLoader,
     FunctionLoader,
     PackageLoader,
+    StrictUndefined,
     Template,
 )
 from markupsafe import Markup
@@ -132,6 +133,7 @@ def user_templates() -> Environment:
         autoescape=True,
         trim_blocks=True,
         lstrip_blocks=True,
+        undefined=StrictUndefined,
     )
 
 


### PR DESCRIPTION
To abort on undefined template variables activate the strict handling of undefined values in Jinja2 environment.