### PR TITLE
Add missing changes for #1282

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ Next Release
 Breaking changes:
 
 - Jinja2 environment for HTML reports is now created with ``undefined=StrictUndefined`` to raise an
-  error if a variable is not defined in the template. (:issue:`1282`)
+  error if a variable is not defined in the template. (:issue:`1282`, :issue:`1283`)
 - Links to lines in HTML reports now use ``L<line>`` instead of a ``l<line>``. (:issue:`1285`)
 
 New features and notable changes:

--- a/src/gcovr/formats/html/boost/directory_page.navigation.html
+++ b/src/gcovr/formats/html/boost/directory_page.navigation.html
@@ -1,5 +1,5 @@
 {# -*- engine: jinja -*- #}
-{% if parent_link %}
+{% if parent_link is defined %}
 <div class="nav-links">
   <a href="{{parent_link}}" class="nav-link nav-up" title="Go to parent directory">
     <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M3.22 9.78a.75.75 0 010-1.06l4.25-4.25a.75.75 0 011.06 0l4.25 4.25a.75.75 0 01-1.06 1.06L8 6.06 4.28 9.78a.75.75 0 01-1.06 0z"></path></svg>

--- a/src/gcovr/formats/html/boost/functions_page.content.html
+++ b/src/gcovr/formats/html/boost/functions_page.content.html
@@ -49,7 +49,7 @@
 <script>
   window.__functionsPageConfig = {
     singlePage: {{ "true" if info.single_page else "false" }},
-    htmlFilename: "{{ html_filename }}",
+    htmlFilename: "{{ html_filename | default("") }}",
     showBranches: {{ "true" if info.branches.total > info.branches.excluded else "false" }},
     showConditions: {{ "true" if SHOW_CONDITION_COVERAGE else "false" }},
     showDecisions: {{ "true" if SHOW_DECISION else "false" }},

--- a/src/gcovr/formats/html/boost/source_page.content.html
+++ b/src/gcovr/formats/html/boost/source_page.content.html
@@ -82,12 +82,6 @@
     {% endif %}
   </div>
 
-  {% if info.single_page %}
-  {%  set anchor_prefix = html_filename + "|" %}
-  {% else %}
-  {%  set anchor_prefix = '' %}
-  {% endif %}
-
   {% if function_list is defined and function_list | length > 0 %}
   <details class="source-functions">
     <summary class="source-functions-toggle">
@@ -108,7 +102,7 @@
       {% for entry in function_list | sort(attribute='line') %}
       {% set calls = entry.count if entry.count is defined else entry.execution_count if entry.execution_count is defined else none %}
       {% set blks = entry.blocks if entry.blocks is defined else entry.blocks_percent if entry.blocks_percent is defined else none %}
-      <a href="#{{ anchor_prefix }}L{{ entry.line }}" class="source-function-item{% if entry.excluded %} fn-excluded{% elif calls is not none and calls > 0 %}{% else %} fn-uncovered{% endif %}"
+      <a href="#L{{ entry.line }}" class="source-function-item{% if entry.excluded %} fn-excluded{% elif calls is not none and calls > 0 %}{% else %} fn-uncovered{% endif %}"
          data-name="{{ entry.name }}" data-calls="{{ calls if calls is not none else -1 }}" data-lines="{{ entry.line_coverage if entry.line_coverage is defined else -1 }}" data-branches="{{ entry.branch_coverage if entry.branch_coverage is defined and entry.branch_coverage != '-' else -1 }}" data-blocks="{{ blks if blks is not none else -1 }}">
         <span class="source-function-col-name">
           <span class="source-function-name">{{ entry.name }}</span>
@@ -161,7 +155,7 @@
       </thead>
       <tbody>
         {% for row in source_lines %}
-        {%  set line_anchor = "{}L{}".format(line_anchor_prefix, row.lineno) %}
+        {%  set line_anchor = "L{}".format(row.lineno) %}
         <tr class="source-line{% if row.covclass %} {{row.covclass}} show_{{row.covclass}}{% endif %}">
           <td class="col-lineno">
             <a id="{{ line_anchor }}" href="#{{ line_anchor }}">{{row.lineno}}</a>

--- a/src/gcovr/formats/html/common/functions_page.content.html
+++ b/src/gcovr/formats/html/common/functions_page.content.html
@@ -15,7 +15,7 @@
   <div class="Box-row Box-row--focus-gray py-2 d-flex">
     <div role="gridcell" class="color-fg-muted flex-auto min-width-0 col-md-2">
       {#- #}<a href="{%- if info.single_page %}#{{ entry['html_filename'] }}|
-                     {%- elif (html_filename != entry['html_filename']) %}{{ entry['html_filename'] }}#
+                     {%- elif (html_filename | default('') != entry['html_filename']) %}{{ entry['html_filename'] }}#
                      {%- else %}#
                      {%- endif %}L{{ entry['line'] }}">{{ entry["name"] }} ({{ entry["filename"] }}:{{ entry["line"] }})</a>
       {#- #}

--- a/src/gcovr/formats/html/common/single_page.html
+++ b/src/gcovr/formats/html/common/single_page.html
@@ -9,7 +9,7 @@
 {% block content %}
 {% if not info.static_report %}
 <script>
-  gcovr.default_content_id = "{{ directories[-1].dirname }}";
+  gcovr.default_content_id = "{{ directories[-1].id }}";
 </script>
 {% endif %}
 <hr class="js-disabled-hidden"/>
@@ -25,7 +25,7 @@
 </div>
 
 {%  for directory in directories %}
-<div id="{{ directory.dirname }}" class="js-enabled-hidden{% if not loop.first %} js-disabled-hidden{% endif %}" data-title="{{ directory.relative_path }}">
+<div id="{{ directory.id }}" class="js-enabled-hidden{% if not loop.first %} js-disabled-hidden{% endif %}" data-title="{{ directory.relative_path }}">
   <nav>
     {% include "directory_page.navigation.html" | indent(2) %}
   </nav>

--- a/src/gcovr/formats/html/default/directory_page.summary.html
+++ b/src/gcovr/formats/html/default/directory_page.summary.html
@@ -4,7 +4,7 @@
     <table class="legend">
       <tr>
         <th scope="row">Directory:</th>
-        <td>{{info.get_directory()}}{{relative_path}}</td>
+        <td>{{ info.get_directory() }}{{ relative_path | default("") }}</td>
       </tr>
       <tr>
         <th scope="row">Coverage:</th>

--- a/src/gcovr/formats/html/github/directory_page.summary.html
+++ b/src/gcovr/formats/html/github/directory_page.summary.html
@@ -8,7 +8,7 @@
             <path d="M1.75 1A1.75 1.75 0 0 0 0 2.75v10.5C0 14.216.784 15 1.75 15h12.5A1.75 1.75 0 0 0 16 13.25v-8.5A1.75 1.75 0 0 0 14.25 3H7.5a.25.25 0 0 1-.2-.1l-.9-1.2C6.07 1.26 5.55 1 5 1H1.75Z"></path>
           </svg>
         </div>
-        <span>{{info.get_directory()}}{{relative_path}}</span>
+        <span>{{ info.get_directory() }}{{ relative_path | default("") }}</span>
       </div>
       <div class="d-flex flex-wrap" style="margin-bottom: 2px;">
         <div class="mr-2" style="min-width: 70px;">Coverage:</div>

--- a/src/gcovr/formats/html/write.py
+++ b/src/gcovr/formats/html/write.py
@@ -110,6 +110,7 @@ def templates(options: Options) -> Environment:
         autoescape=True,
         trim_blocks=True,
         lstrip_blocks=True,
+        undefined=StrictUndefined,
     )
 
 
@@ -421,29 +422,15 @@ def write_report(
     if root_info.link_function_list and root_info.functions["total"] == 0:
         root_info.link_function_list = False
 
-    # Generate the coverage output (on a per-package basis)
-    # source_dirs = set()
-    filecov_list = covdata.sorted_filecov(
-        sort_key=options.sort_key,
-        sort_reverse=options.sort_reverse,
-        by_metric="branch" if options.sort_branches else "line",
-        filename_uses_relative_pathname=True,
-        recurse=True,
-    )
-
     LOGGER.debug("Store additional properties...")
-    files = []
-    sourcefiles = dict[str, str | None]()
 
-    def _store_filenames(cdata: CoverageContainer | FileCoverage) -> None:
+    def _update_properties(cdata: CoverageContainer | FileCoverage) -> None:
         """Store the filenames and the source file links for the report."""
         filtered_name = options.root_filter.sub("", cdata.filename)
-        if filtered_name != "":
-            files.append(filtered_name)
         cdata.properties["filtered_name"] = force_unix_separator(filtered_name)
         if options.html_details or options.html_nested or options.html_single_page:
             if cdata == covdata:
-                cdata.properties["sourcefile"] = (
+                _, cdata.properties["sourcefile"] = os.path.split(
                     output_file[: -len(GZIP_SUFFIX)]
                     if output_file.endswith(GZIP_SUFFIX)
                     else output_file
@@ -462,24 +449,30 @@ def write_report(
                     ).split(".", maxsplit=1)[1]
         else:
             cdata.properties["sourcefile"] = None
-        sourcefiles[cdata.properties["filtered_name"]] = cdata.properties["sourcefile"]
 
+    # Generate the coverage output (on a per-package basis)
+    # source_dirs = set()
+    filecov_list = sorted(
+        covdata.filecov(recurse=True), key=lambda x: x.filename.lower()
+    )
     for filecov in filecov_list:
-        _store_filenames(filecov)
-    if options.html_nested:
-        for dircov in covdata.dircov(recurse=True):
-            _store_filenames(dircov)
+        _update_properties(filecov)
+    for dircov in covdata.dircov(recurse=True):
+        _update_properties(dircov)
 
     # Define the common root directory, which may differ from options.root_dir
     # when source files share a common prefix.
+    filtered_name = [cdata.properties["filtered_name"] for cdata in filecov_list]
     root_directory = ""
-    if len(files) > 1:
-        common_dir = commonpath(files)
+    if len(filtered_name) > 1:
+        common_dir = commonpath(filtered_name)
         if common_dir != "":
             root_directory = common_dir
     else:
         directory, _ = os.path.split(
-            files[0] if files else options.root_filter.sub("", covdata.dirname)
+            filtered_name[0]
+            if filtered_name
+            else options.root_filter.sub("", covdata.dirname)
         )
         if directory != "":
             root_directory = str(directory) + os.sep
@@ -488,9 +481,10 @@ def write_report(
 
     previous_fname: str | None = None
     previous_link_report: str | None = None
-    for fname in sorted(sourcefiles):
+    for filecov in filecov_list:
+        fname = filecov.properties["filtered_name"]
         root_info.navigation[fname] = (previous_link_report, None)
-        link_report = sourcefiles[fname]
+        link_report = filecov.properties["sourcefile"]
         if link_report is not None:
             if root_info.relative_anchors or root_info.single_page:
                 link_report = os.path.basename(link_report)
@@ -596,26 +590,16 @@ def write_report(
             root_info,
             output_file,
             covdata,
-            filecov_list,
             data,
         )
     else:
-        if options.html_nested:
-            write_directory_pages(
-                options,
-                root_info,
-                output_file,
-                covdata,
-                data,
-            )
-        else:
-            write_root_page(
-                options,
-                root_info,
-                output_file,
-                data,
-                filecov_list,
-            )
+        write_directory_pages(
+            options,
+            root_info,
+            output_file,
+            covdata,
+            data,
+        )
 
         if options.html_details or options.html_nested:
             write_source_pages(
@@ -631,23 +615,56 @@ def write_root_page(
     options: Options,
     root_info: RootInfo,
     output_file: str,
+    covdata: CoverageContainer,
     data: dict[str, Any],
-    filecov_list: list[FileCoverage],
 ) -> None:
     """Generate the root HTML file that contains the high level report."""
-    files = []
-    for filecov in filecov_list:
-        files.append(get_coverage_data(root_info, filecov))
-
     html_string = (
         templates(options)
         .get_template("directory_page.html")
-        .render(**data, entries=files)
+        .render(
+            **data,
+            **get_directory_data(options, root_info, covdata, recurse_files=True),
+        )
     )
     with open_text_for_writing(
         output_file, encoding=options.html_encoding, errors="xmlcharrefreplace"
     ) as fh:
         fh.write(html_string + "\n")
+
+
+def write_directory_pages(
+    options: Options,
+    root_info: RootInfo,
+    output_file: str,
+    covdata: CoverageContainer,
+    data: dict[str, Any],
+) -> None:
+    """Write a page for each directory."""
+    root_key = covdata.dirname
+
+    for dircov in covdata.dircov(recurse=True) if options.html_nested else [covdata]:
+        html_string = (
+            templates(options)
+            .get_template("directory_page.html")
+            .render(
+                **data,
+                **get_directory_data(
+                    options, root_info, dircov, recurse_files=not options.html_nested
+                ),
+            )
+        )
+        filename = None
+        if dircov.dirname in [root_key, ""]:
+            filename = output_file
+        else:
+            filename = dircov.properties["sourcefile"]
+
+        if filename:
+            with open_text_for_writing(
+                filename, encoding=options.html_encoding, errors="xmlcharrefreplace"
+            ) as fh:
+                fh.write(html_string + "\n")
 
 
 def write_source_pages(
@@ -701,43 +718,11 @@ def write_source_pages(
         raise RuntimeError(f"{error_no_files_not_found} source file(s) not found.")
 
 
-def write_directory_pages(
-    options: Options,
-    root_info: RootInfo,
-    output_file: str,
-    covdata: CoverageContainer,
-    data: dict[str, Any],
-) -> None:
-    """Write a page for each directory."""
-    root_key = covdata.dirname
-
-    for dircov in covdata.dircov(recurse=True):
-        directory_data = get_directory_data(options, root_info, dircov)
-
-        html_string = (
-            templates(options)
-            .get_template("directory_page.html")
-            .render(**data, **directory_data)
-        )
-        filename = None
-        if dircov.dirname in [root_key, ""]:
-            filename = output_file
-        else:
-            filename = dircov.properties["sourcefile"]
-
-        if filename:
-            with open_text_for_writing(
-                filename, encoding=options.html_encoding, errors="xmlcharrefreplace"
-            ) as fh:
-                fh.write(html_string + "\n")
-
-
 def write_single_page(
     options: Options,
     root_info: RootInfo,
     output_file: str,
     covdata: CoverageContainer,
-    filecov_list: list[FileCoverage],
     data: dict[str, Any],
 ) -> None:
     """Write a single page HTML report."""
@@ -756,15 +741,16 @@ def write_single_page(
 
         files.append(file_data)
 
-    all_files = []
-    for filecov in filecov_list:
-        all_files.append(get_coverage_data(root_info, filecov))
-    directories = list[dict[str, Any]]([{"entries": all_files}])
-    if not root_info.static_report and options.html_nested:
+    directories = list[dict[str, Any]]()
+    # This is used if javascript is deactivated in browser.
+    directories.append(
+        get_directory_data(options, root_info, covdata, recurse_files=True)
+    )
+    directories[0].update({"id": "gcovr-directory-root"})
+    # For a static report we do not need to generate the directory tree data for each directory.
+    if options.html_nested and not root_info.static_report:
         for dircov in covdata.dircov(recurse=True):
             directories.append(get_directory_data(options, root_info, dircov))
-    if len(directories) == 1:
-        directories[0]["dirname"] = "/"  # We need this to have a correct id in HTML.
 
     html_string = (
         templates(options)
@@ -910,20 +896,20 @@ def get_directory_data(
     options: Options,
     root_info: RootInfo,
     covdata: CoverageContainer,
+    recurse_files: bool = False,
 ) -> dict[str, Any]:
     """Get the data for a directory to generate the HTML"""
-    relative_path = covdata.properties["filtered_name"]
-    if relative_path == ".":
+    if covdata.parent is None:
         relative_path = ""
-    elif relative_path.startswith(root_info.directory):
-        relative_path = relative_path[len(root_info.directory) :]
+    else:
+        relative_path = covdata.properties["filtered_name"]
+        if relative_path == ".":
+            relative_path = ""
+        elif relative_path.startswith(root_info.directory):
+            relative_path = relative_path[len(root_info.directory) :]
     directory_data = dict[str, Any](
         {
-            "dirname": (
-                covdata.properties["sourcefile"]
-                if covdata.properties["filtered_name"]
-                else "/"
-            ),
+            "id": covdata.properties["sourcefile"],
             "relative_path": relative_path,
         }
     )
@@ -931,18 +917,29 @@ def get_directory_data(
     if covdata.is_compare_info_available():
         directory_data["diff"] = covdata.diff.name
 
-    covdata_list = covdata.sorted_coverage(
-        sort_key=options.sort_key,
-        sort_reverse=options.sort_reverse,
-        by_metric="branch" if options.sort_branches else "line",
-        filename_uses_relative_pathname=True,
-    )
+    if options.html_nested or covdata.parent is None:
+        covdata_list = (
+            covdata.sorted_filecov(
+                sort_key=options.sort_key,
+                sort_reverse=options.sort_reverse,
+                by_metric="branch" if options.sort_branches else "line",
+                filename_uses_relative_pathname=True,
+                recurse=True,
+            )
+            if recurse_files
+            else covdata.sorted_coverage(
+                sort_key=options.sort_key,
+                sort_reverse=options.sort_reverse,
+                by_metric="branch" if options.sort_branches else "line",
+                filename_uses_relative_pathname=True,
+            )
+        )
 
-    files = []
-    for cdata in covdata_list:
-        files.append(get_coverage_data(root_info, cdata, relative_path))
+        files = []
+        for cdata in covdata_list:
+            files.append(get_coverage_data(root_info, cdata, relative_path))
 
-    directory_data["entries"] = files
+        directory_data["entries"] = files
 
     return directory_data
 

--- a/src/gcovr/formats/markdown/default/report_template.md.j2
+++ b/src/gcovr/formats/markdown/default/report_template.md.j2
@@ -7,7 +7,7 @@
 | **Lines**     | {{summary.line_badge}} {{summary.line_covered}}/{{summary.line_total}} ({{summary.line_percent}}%) |
 | **Functions** | {{summary.function_badge}} {{summary.function_covered}}/{{summary.function_total}} ({{summary.function_percent}}%) |
 | **Branches**  | {{summary.branch_badge}} {{summary.branch_covered}}/{{summary.branch_total}} ({{summary.branch_percent}}%) |
-{% if entries %}
+{% if entries is defined %}
 
 ## {{- '#' * (heading_level - 1) }} 📄 File coverage
 

--- a/src/gcovr/formats/markdown/write.py
+++ b/src/gcovr/formats/markdown/write.py
@@ -22,6 +22,7 @@ from typing import Any
 from jinja2 import (
     Environment,
     PackageLoader,
+    StrictUndefined,
 )
 
 from ...data_model.container import CoverageContainer
@@ -42,6 +43,7 @@ def templates() -> Environment:
         autoescape=True,
         trim_blocks=True,
         lstrip_blocks=True,
+        undefined=StrictUndefined,
     )
 
 

--- a/tests/compare/reference/changed/clang-10/coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
+++ b/tests/compare/reference/changed/clang-10/coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
@@ -150,10 +150,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/changed/clang-10/coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
+++ b/tests/compare/reference/changed/clang-10/coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
@@ -154,10 +154,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/changed/clang-10/coverage.boost.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
+++ b/tests/compare/reference/changed/clang-10/coverage.boost.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
@@ -150,9 +150,9 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.D.f26830d87b54e9f418a67752d418ba31.html" title="Previous file">
+      <span class="nav-link nav-prev disabled" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
-      </a>
+      </span>
       <a class="nav-link nav-next" href="coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>

--- a/tests/compare/reference/changed/clang-10/coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
+++ b/tests/compare/reference/changed/clang-10/coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
@@ -154,10 +154,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/changed/clang-10/coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
+++ b/tests/compare/reference/changed/clang-10/coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
@@ -150,10 +150,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/changed/clang-10/coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
+++ b/tests/compare/reference/changed/clang-10/coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
@@ -157,7 +157,7 @@
       <a class="nav-link nav-prev" href="coverage.boost.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/changed/clang-10/coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
+++ b/tests/compare/reference/changed/clang-10/coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
@@ -150,10 +150,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.B.cec86a34c08f941fc92924df967d4300.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.main.cpp.13fb8fc771195717481a98e084ed0848.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/changed/clang-10/coverage.boost.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/tests/compare/reference/changed/clang-10/coverage.boost.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -154,7 +154,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.B.cec86a34c08f941fc92924df967d4300.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <span class="nav-link nav-next disabled" title="Next file">

--- a/tests/compare/reference/changed/clang-10/coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
+++ b/tests/compare/reference/changed/clang-10/coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
@@ -107,9 +107,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">3 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
+      <a class="nav prev" href="coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav next" href="coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/clang-10/coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
+++ b/tests/compare/reference/changed/clang-10/coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
@@ -100,9 +100,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">1 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav prev" href="coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav next" href="coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/clang-10/coverage.default.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
+++ b/tests/compare/reference/changed/clang-10/coverage.default.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
@@ -100,7 +100,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">1 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.D.f26830d87b54e9f418a67752d418ba31.html"></a>
+      <a class="nav prev" href="coverage.default.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
       <a class="nav next" href="coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
     </div>

--- a/tests/compare/reference/changed/clang-10/coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
+++ b/tests/compare/reference/changed/clang-10/coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
@@ -96,9 +96,9 @@
       <button type="button" class="button_toggle_ADDED show_ADDED"value="ADDED" title="Toggle added lines">All added</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav prev" href="coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav next" href="coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/clang-10/coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
+++ b/tests/compare/reference/changed/clang-10/coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
@@ -103,9 +103,9 @@
       <button type="button" class="button_toggle_REMOVED show_REMOVED"value="REMOVED" title="Toggle removed lines">All removed</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav prev" href="coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
+      <a class="nav next" href="coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/clang-10/coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
+++ b/tests/compare/reference/changed/clang-10/coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
@@ -102,7 +102,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.default.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav next" href="coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/clang-10/coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
+++ b/tests/compare/reference/changed/clang-10/coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
@@ -100,9 +100,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">2 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav prev" href="coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav next" href="coverage.default.main.cpp.13fb8fc771195717481a98e084ed0848.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/clang-10/coverage.default.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/tests/compare/reference/changed/clang-10/coverage.default.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -100,7 +100,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">0 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav prev" href="coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
       <a class="nav next" href="coverage.default.html"></a>
     </div>

--- a/tests/compare/reference/changed/clang-10/coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
+++ b/tests/compare/reference/changed/clang-10/coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">3 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
+      <a class="nav prev" href="coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav next" href="coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/clang-10/coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
+++ b/tests/compare/reference/changed/clang-10/coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">1 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav prev" href="coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav next" href="coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/clang-10/coverage.github.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
+++ b/tests/compare/reference/changed/clang-10/coverage.github.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">1 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.D.f26830d87b54e9f418a67752d418ba31.html"></a>
+      <a class="nav prev" href="coverage.github.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
       <a class="nav next" href="coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
     </div>

--- a/tests/compare/reference/changed/clang-10/coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
+++ b/tests/compare/reference/changed/clang-10/coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
@@ -91,9 +91,9 @@
       <button type="button" class="button_toggle_ADDED show_ADDED" value="ADDED" title="Toggle added lines">All added</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav prev" href="coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav next" href="coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/clang-10/coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
+++ b/tests/compare/reference/changed/clang-10/coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
@@ -98,9 +98,9 @@
       <button type="button" class="button_toggle_REMOVED show_REMOVED" value="REMOVED" title="Toggle removed lines">All removed</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav prev" href="coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
+      <a class="nav next" href="coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/clang-10/coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
+++ b/tests/compare/reference/changed/clang-10/coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
@@ -97,7 +97,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.github.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav next" href="coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/clang-10/coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
+++ b/tests/compare/reference/changed/clang-10/coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">2 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav prev" href="coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav next" href="coverage.github.main.cpp.13fb8fc771195717481a98e084ed0848.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/clang-10/coverage.github.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/tests/compare/reference/changed/clang-10/coverage.github.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">0 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav prev" href="coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
       <a class="nav next" href="coverage.github.html"></a>
     </div>

--- a/tests/compare/reference/changed/clang-12/coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
+++ b/tests/compare/reference/changed/clang-12/coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
@@ -150,10 +150,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/changed/clang-12/coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
+++ b/tests/compare/reference/changed/clang-12/coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
@@ -154,10 +154,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/changed/clang-12/coverage.boost.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
+++ b/tests/compare/reference/changed/clang-12/coverage.boost.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
@@ -150,9 +150,9 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.D.f26830d87b54e9f418a67752d418ba31.html" title="Previous file">
+      <span class="nav-link nav-prev disabled" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
-      </a>
+      </span>
       <a class="nav-link nav-next" href="coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>

--- a/tests/compare/reference/changed/clang-12/coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
+++ b/tests/compare/reference/changed/clang-12/coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
@@ -154,10 +154,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/changed/clang-12/coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
+++ b/tests/compare/reference/changed/clang-12/coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
@@ -150,10 +150,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/changed/clang-12/coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
+++ b/tests/compare/reference/changed/clang-12/coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
@@ -157,7 +157,7 @@
       <a class="nav-link nav-prev" href="coverage.boost.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/changed/clang-12/coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
+++ b/tests/compare/reference/changed/clang-12/coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
@@ -150,10 +150,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.B.cec86a34c08f941fc92924df967d4300.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.main.cpp.13fb8fc771195717481a98e084ed0848.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/changed/clang-12/coverage.boost.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/tests/compare/reference/changed/clang-12/coverage.boost.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -154,7 +154,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.B.cec86a34c08f941fc92924df967d4300.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <span class="nav-link nav-next disabled" title="Next file">

--- a/tests/compare/reference/changed/clang-12/coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
+++ b/tests/compare/reference/changed/clang-12/coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
@@ -107,9 +107,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">3 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
+      <a class="nav prev" href="coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav next" href="coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/clang-12/coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
+++ b/tests/compare/reference/changed/clang-12/coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
@@ -100,9 +100,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">1 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav prev" href="coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav next" href="coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/clang-12/coverage.default.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
+++ b/tests/compare/reference/changed/clang-12/coverage.default.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
@@ -100,7 +100,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">1 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.D.f26830d87b54e9f418a67752d418ba31.html"></a>
+      <a class="nav prev" href="coverage.default.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
       <a class="nav next" href="coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
     </div>

--- a/tests/compare/reference/changed/clang-12/coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
+++ b/tests/compare/reference/changed/clang-12/coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
@@ -96,9 +96,9 @@
       <button type="button" class="button_toggle_ADDED show_ADDED"value="ADDED" title="Toggle added lines">All added</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav prev" href="coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav next" href="coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/clang-12/coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
+++ b/tests/compare/reference/changed/clang-12/coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
@@ -103,9 +103,9 @@
       <button type="button" class="button_toggle_REMOVED show_REMOVED"value="REMOVED" title="Toggle removed lines">All removed</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav prev" href="coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
+      <a class="nav next" href="coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/clang-12/coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
+++ b/tests/compare/reference/changed/clang-12/coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
@@ -102,7 +102,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.default.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav next" href="coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/clang-12/coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
+++ b/tests/compare/reference/changed/clang-12/coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
@@ -100,9 +100,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">2 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav prev" href="coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav next" href="coverage.default.main.cpp.13fb8fc771195717481a98e084ed0848.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/clang-12/coverage.default.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/tests/compare/reference/changed/clang-12/coverage.default.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -100,7 +100,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">0 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav prev" href="coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
       <a class="nav next" href="coverage.default.html"></a>
     </div>

--- a/tests/compare/reference/changed/clang-12/coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
+++ b/tests/compare/reference/changed/clang-12/coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">3 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
+      <a class="nav prev" href="coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav next" href="coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/clang-12/coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
+++ b/tests/compare/reference/changed/clang-12/coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">1 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav prev" href="coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav next" href="coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/clang-12/coverage.github.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
+++ b/tests/compare/reference/changed/clang-12/coverage.github.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">1 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.D.f26830d87b54e9f418a67752d418ba31.html"></a>
+      <a class="nav prev" href="coverage.github.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
       <a class="nav next" href="coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
     </div>

--- a/tests/compare/reference/changed/clang-12/coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
+++ b/tests/compare/reference/changed/clang-12/coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
@@ -91,9 +91,9 @@
       <button type="button" class="button_toggle_ADDED show_ADDED" value="ADDED" title="Toggle added lines">All added</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav prev" href="coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav next" href="coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/clang-12/coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
+++ b/tests/compare/reference/changed/clang-12/coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
@@ -98,9 +98,9 @@
       <button type="button" class="button_toggle_REMOVED show_REMOVED" value="REMOVED" title="Toggle removed lines">All removed</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav prev" href="coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
+      <a class="nav next" href="coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/clang-12/coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
+++ b/tests/compare/reference/changed/clang-12/coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
@@ -97,7 +97,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.github.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav next" href="coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/clang-12/coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
+++ b/tests/compare/reference/changed/clang-12/coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">2 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav prev" href="coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav next" href="coverage.github.main.cpp.13fb8fc771195717481a98e084ed0848.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/clang-12/coverage.github.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/tests/compare/reference/changed/clang-12/coverage.github.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">0 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav prev" href="coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
       <a class="nav next" href="coverage.github.html"></a>
     </div>

--- a/tests/compare/reference/changed/gcc-11/coverage.boost.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/tests/compare/reference/changed/gcc-11/coverage.boost.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -154,7 +154,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.B.cec86a34c08f941fc92924df967d4300.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <span class="nav-link nav-next disabled" title="Next file">

--- a/tests/compare/reference/changed/gcc-11/coverage.default.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/tests/compare/reference/changed/gcc-11/coverage.default.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -100,7 +100,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">0 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav prev" href="coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
       <a class="nav next" href="coverage.default.html"></a>
     </div>

--- a/tests/compare/reference/changed/gcc-11/coverage.github.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/tests/compare/reference/changed/gcc-11/coverage.github.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">0 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav prev" href="coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
       <a class="nav next" href="coverage.github.html"></a>
     </div>

--- a/tests/compare/reference/changed/gcc-14/coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
+++ b/tests/compare/reference/changed/gcc-14/coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
@@ -154,10 +154,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/changed/gcc-14/coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
+++ b/tests/compare/reference/changed/gcc-14/coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
@@ -158,10 +158,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/changed/gcc-14/coverage.boost.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
+++ b/tests/compare/reference/changed/gcc-14/coverage.boost.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
@@ -154,9 +154,9 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.D.f26830d87b54e9f418a67752d418ba31.html" title="Previous file">
+      <span class="nav-link nav-prev disabled" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
-      </a>
+      </span>
       <a class="nav-link nav-next" href="coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>

--- a/tests/compare/reference/changed/gcc-14/coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
+++ b/tests/compare/reference/changed/gcc-14/coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
@@ -158,10 +158,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/changed/gcc-14/coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
+++ b/tests/compare/reference/changed/gcc-14/coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
@@ -154,10 +154,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/changed/gcc-14/coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
+++ b/tests/compare/reference/changed/gcc-14/coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
@@ -161,7 +161,7 @@
       <a class="nav-link nav-prev" href="coverage.boost.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/changed/gcc-14/coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
+++ b/tests/compare/reference/changed/gcc-14/coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
@@ -154,10 +154,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.B.cec86a34c08f941fc92924df967d4300.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.main.cpp.13fb8fc771195717481a98e084ed0848.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/changed/gcc-14/coverage.boost.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/tests/compare/reference/changed/gcc-14/coverage.boost.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -158,7 +158,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.B.cec86a34c08f941fc92924df967d4300.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <span class="nav-link nav-next disabled" title="Next file">

--- a/tests/compare/reference/changed/gcc-14/coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
+++ b/tests/compare/reference/changed/gcc-14/coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
@@ -115,9 +115,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">3 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
+      <a class="nav prev" href="coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav next" href="coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/gcc-14/coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
+++ b/tests/compare/reference/changed/gcc-14/coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
@@ -107,9 +107,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">1 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav prev" href="coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav next" href="coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/gcc-14/coverage.default.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
+++ b/tests/compare/reference/changed/gcc-14/coverage.default.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
@@ -107,7 +107,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">1 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.D.f26830d87b54e9f418a67752d418ba31.html"></a>
+      <a class="nav prev" href="coverage.default.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
       <a class="nav next" href="coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
     </div>

--- a/tests/compare/reference/changed/gcc-14/coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
+++ b/tests/compare/reference/changed/gcc-14/coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
@@ -103,9 +103,9 @@
       <button type="button" class="button_toggle_ADDED show_ADDED"value="ADDED" title="Toggle added lines">All added</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav prev" href="coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav next" href="coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/gcc-14/coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
+++ b/tests/compare/reference/changed/gcc-14/coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
@@ -111,9 +111,9 @@
       <button type="button" class="button_toggle_REMOVED show_REMOVED"value="REMOVED" title="Toggle removed lines">All removed</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav prev" href="coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
+      <a class="nav next" href="coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/gcc-14/coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
+++ b/tests/compare/reference/changed/gcc-14/coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
@@ -109,7 +109,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.default.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav next" href="coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/gcc-14/coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
+++ b/tests/compare/reference/changed/gcc-14/coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
@@ -107,9 +107,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">2 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav prev" href="coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav next" href="coverage.default.main.cpp.13fb8fc771195717481a98e084ed0848.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/gcc-14/coverage.default.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/tests/compare/reference/changed/gcc-14/coverage.default.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -107,7 +107,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">0 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav prev" href="coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
       <a class="nav next" href="coverage.default.html"></a>
     </div>

--- a/tests/compare/reference/changed/gcc-14/coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
+++ b/tests/compare/reference/changed/gcc-14/coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
@@ -110,9 +110,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">3 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
+      <a class="nav prev" href="coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav next" href="coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/gcc-14/coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
+++ b/tests/compare/reference/changed/gcc-14/coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">1 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav prev" href="coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav next" href="coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/gcc-14/coverage.github.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
+++ b/tests/compare/reference/changed/gcc-14/coverage.github.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
@@ -102,7 +102,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">1 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.D.f26830d87b54e9f418a67752d418ba31.html"></a>
+      <a class="nav prev" href="coverage.github.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
       <a class="nav next" href="coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
     </div>

--- a/tests/compare/reference/changed/gcc-14/coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
+++ b/tests/compare/reference/changed/gcc-14/coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
@@ -98,9 +98,9 @@
       <button type="button" class="button_toggle_ADDED show_ADDED" value="ADDED" title="Toggle added lines">All added</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav prev" href="coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav next" href="coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/gcc-14/coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
+++ b/tests/compare/reference/changed/gcc-14/coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
@@ -106,9 +106,9 @@
       <button type="button" class="button_toggle_REMOVED show_REMOVED" value="REMOVED" title="Toggle removed lines">All removed</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav prev" href="coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
+      <a class="nav next" href="coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/gcc-14/coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
+++ b/tests/compare/reference/changed/gcc-14/coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
@@ -104,7 +104,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.github.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav next" href="coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/gcc-14/coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
+++ b/tests/compare/reference/changed/gcc-14/coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">2 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav prev" href="coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav next" href="coverage.github.main.cpp.13fb8fc771195717481a98e084ed0848.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/gcc-14/coverage.github.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/tests/compare/reference/changed/gcc-14/coverage.github.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -102,7 +102,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">0 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav prev" href="coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
       <a class="nav next" href="coverage.github.html"></a>
     </div>

--- a/tests/compare/reference/changed/gcc-5/coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
+++ b/tests/compare/reference/changed/gcc-5/coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
@@ -150,10 +150,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/changed/gcc-5/coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
+++ b/tests/compare/reference/changed/gcc-5/coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
@@ -154,10 +154,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/changed/gcc-5/coverage.boost.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
+++ b/tests/compare/reference/changed/gcc-5/coverage.boost.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
@@ -150,9 +150,9 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.D.f26830d87b54e9f418a67752d418ba31.html" title="Previous file">
+      <span class="nav-link nav-prev disabled" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
-      </a>
+      </span>
       <a class="nav-link nav-next" href="coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>

--- a/tests/compare/reference/changed/gcc-5/coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
+++ b/tests/compare/reference/changed/gcc-5/coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
@@ -154,10 +154,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/changed/gcc-5/coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
+++ b/tests/compare/reference/changed/gcc-5/coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
@@ -150,10 +150,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/changed/gcc-5/coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
+++ b/tests/compare/reference/changed/gcc-5/coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
@@ -157,7 +157,7 @@
       <a class="nav-link nav-prev" href="coverage.boost.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/changed/gcc-5/coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
+++ b/tests/compare/reference/changed/gcc-5/coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
@@ -150,10 +150,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.B.cec86a34c08f941fc92924df967d4300.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.main.cpp.13fb8fc771195717481a98e084ed0848.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/changed/gcc-5/coverage.boost.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/tests/compare/reference/changed/gcc-5/coverage.boost.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -154,7 +154,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.B.cec86a34c08f941fc92924df967d4300.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <span class="nav-link nav-next disabled" title="Next file">

--- a/tests/compare/reference/changed/gcc-5/coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
+++ b/tests/compare/reference/changed/gcc-5/coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
@@ -107,9 +107,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">3 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
+      <a class="nav prev" href="coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav next" href="coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/gcc-5/coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
+++ b/tests/compare/reference/changed/gcc-5/coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
@@ -100,9 +100,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">1 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav prev" href="coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav next" href="coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/gcc-5/coverage.default.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
+++ b/tests/compare/reference/changed/gcc-5/coverage.default.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
@@ -100,7 +100,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">1 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.D.f26830d87b54e9f418a67752d418ba31.html"></a>
+      <a class="nav prev" href="coverage.default.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
       <a class="nav next" href="coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
     </div>

--- a/tests/compare/reference/changed/gcc-5/coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
+++ b/tests/compare/reference/changed/gcc-5/coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
@@ -96,9 +96,9 @@
       <button type="button" class="button_toggle_ADDED show_ADDED"value="ADDED" title="Toggle added lines">All added</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav prev" href="coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav next" href="coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/gcc-5/coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
+++ b/tests/compare/reference/changed/gcc-5/coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
@@ -103,9 +103,9 @@
       <button type="button" class="button_toggle_REMOVED show_REMOVED"value="REMOVED" title="Toggle removed lines">All removed</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav prev" href="coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
+      <a class="nav next" href="coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/gcc-5/coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
+++ b/tests/compare/reference/changed/gcc-5/coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
@@ -102,7 +102,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.default.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav next" href="coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/gcc-5/coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
+++ b/tests/compare/reference/changed/gcc-5/coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
@@ -100,9 +100,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">2 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav prev" href="coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav next" href="coverage.default.main.cpp.13fb8fc771195717481a98e084ed0848.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/gcc-5/coverage.default.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/tests/compare/reference/changed/gcc-5/coverage.default.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -100,7 +100,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">0 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav prev" href="coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
       <a class="nav next" href="coverage.default.html"></a>
     </div>

--- a/tests/compare/reference/changed/gcc-5/coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
+++ b/tests/compare/reference/changed/gcc-5/coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">3 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
+      <a class="nav prev" href="coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav next" href="coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/gcc-5/coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
+++ b/tests/compare/reference/changed/gcc-5/coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">1 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav prev" href="coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav next" href="coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/gcc-5/coverage.github.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
+++ b/tests/compare/reference/changed/gcc-5/coverage.github.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">1 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.D.f26830d87b54e9f418a67752d418ba31.html"></a>
+      <a class="nav prev" href="coverage.github.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
       <a class="nav next" href="coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
     </div>

--- a/tests/compare/reference/changed/gcc-5/coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
+++ b/tests/compare/reference/changed/gcc-5/coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
@@ -91,9 +91,9 @@
       <button type="button" class="button_toggle_ADDED show_ADDED" value="ADDED" title="Toggle added lines">All added</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav prev" href="coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav next" href="coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/gcc-5/coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
+++ b/tests/compare/reference/changed/gcc-5/coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
@@ -98,9 +98,9 @@
       <button type="button" class="button_toggle_REMOVED show_REMOVED" value="REMOVED" title="Toggle removed lines">All removed</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav prev" href="coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
+      <a class="nav next" href="coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/gcc-5/coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
+++ b/tests/compare/reference/changed/gcc-5/coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
@@ -97,7 +97,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.github.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav next" href="coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/gcc-5/coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
+++ b/tests/compare/reference/changed/gcc-5/coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">2 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav prev" href="coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav next" href="coverage.github.main.cpp.13fb8fc771195717481a98e084ed0848.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/changed/gcc-5/coverage.github.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/tests/compare/reference/changed/gcc-5/coverage.github.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">0 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav prev" href="coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
       <a class="nav next" href="coverage.github.html"></a>
     </div>

--- a/tests/compare/reference/changed/gcc-9/coverage.boost.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/tests/compare/reference/changed/gcc-9/coverage.boost.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -154,7 +154,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.B.cec86a34c08f941fc92924df967d4300.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <span class="nav-link nav-next disabled" title="Next file">

--- a/tests/compare/reference/changed/gcc-9/coverage.default.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/tests/compare/reference/changed/gcc-9/coverage.default.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -100,7 +100,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">0 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav prev" href="coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
       <a class="nav next" href="coverage.default.html"></a>
     </div>

--- a/tests/compare/reference/changed/gcc-9/coverage.github.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/tests/compare/reference/changed/gcc-9/coverage.github.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">0 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav prev" href="coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
       <a class="nav next" href="coverage.github.html"></a>
     </div>

--- a/tests/compare/reference/equal/clang-10/coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
+++ b/tests/compare/reference/equal/clang-10/coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
@@ -150,10 +150,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/equal/clang-10/coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
+++ b/tests/compare/reference/equal/clang-10/coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
@@ -154,10 +154,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/equal/clang-10/coverage.boost.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
+++ b/tests/compare/reference/equal/clang-10/coverage.boost.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
@@ -150,9 +150,9 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.D.f26830d87b54e9f418a67752d418ba31.html" title="Previous file">
+      <span class="nav-link nav-prev disabled" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
-      </a>
+      </span>
       <a class="nav-link nav-next" href="coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>

--- a/tests/compare/reference/equal/clang-10/coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
+++ b/tests/compare/reference/equal/clang-10/coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
@@ -154,10 +154,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/equal/clang-10/coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
+++ b/tests/compare/reference/equal/clang-10/coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
@@ -150,10 +150,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/equal/clang-10/coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
+++ b/tests/compare/reference/equal/clang-10/coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
@@ -157,7 +157,7 @@
       <a class="nav-link nav-prev" href="coverage.boost.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/equal/clang-10/coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
+++ b/tests/compare/reference/equal/clang-10/coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
@@ -150,10 +150,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.B.cec86a34c08f941fc92924df967d4300.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.main.cpp.13fb8fc771195717481a98e084ed0848.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/equal/clang-10/coverage.boost.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/tests/compare/reference/equal/clang-10/coverage.boost.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -154,7 +154,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.B.cec86a34c08f941fc92924df967d4300.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <span class="nav-link nav-next disabled" title="Next file">

--- a/tests/compare/reference/equal/clang-10/coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
+++ b/tests/compare/reference/equal/clang-10/coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
@@ -107,9 +107,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">7 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
+      <a class="nav prev" href="coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav next" href="coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/clang-10/coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
+++ b/tests/compare/reference/equal/clang-10/coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
@@ -100,9 +100,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">5 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav prev" href="coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav next" href="coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/clang-10/coverage.default.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
+++ b/tests/compare/reference/equal/clang-10/coverage.default.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
@@ -100,7 +100,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">5 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.D.f26830d87b54e9f418a67752d418ba31.html"></a>
+      <a class="nav prev" href="coverage.default.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
       <a class="nav next" href="coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
     </div>

--- a/tests/compare/reference/equal/clang-10/coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
+++ b/tests/compare/reference/equal/clang-10/coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
@@ -100,9 +100,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">5 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav prev" href="coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav next" href="coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/clang-10/coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
+++ b/tests/compare/reference/equal/clang-10/coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
@@ -107,9 +107,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">10 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav prev" href="coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
+      <a class="nav next" href="coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/clang-10/coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
+++ b/tests/compare/reference/equal/clang-10/coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
@@ -102,7 +102,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.default.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav next" href="coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/clang-10/coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
+++ b/tests/compare/reference/equal/clang-10/coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
@@ -100,9 +100,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">2 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav prev" href="coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav next" href="coverage.default.main.cpp.13fb8fc771195717481a98e084ed0848.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/clang-10/coverage.default.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/tests/compare/reference/equal/clang-10/coverage.default.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -100,7 +100,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">8 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav prev" href="coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
       <a class="nav next" href="coverage.default.html"></a>
     </div>

--- a/tests/compare/reference/equal/clang-10/coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
+++ b/tests/compare/reference/equal/clang-10/coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">7 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
+      <a class="nav prev" href="coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav next" href="coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/clang-10/coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
+++ b/tests/compare/reference/equal/clang-10/coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">5 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav prev" href="coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav next" href="coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/clang-10/coverage.github.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
+++ b/tests/compare/reference/equal/clang-10/coverage.github.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">5 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.D.f26830d87b54e9f418a67752d418ba31.html"></a>
+      <a class="nav prev" href="coverage.github.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
       <a class="nav next" href="coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
     </div>

--- a/tests/compare/reference/equal/clang-10/coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
+++ b/tests/compare/reference/equal/clang-10/coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">5 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav prev" href="coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav next" href="coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/clang-10/coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
+++ b/tests/compare/reference/equal/clang-10/coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">10 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav prev" href="coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
+      <a class="nav next" href="coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/clang-10/coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
+++ b/tests/compare/reference/equal/clang-10/coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
@@ -97,7 +97,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.github.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav next" href="coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/clang-10/coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
+++ b/tests/compare/reference/equal/clang-10/coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">2 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav prev" href="coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav next" href="coverage.github.main.cpp.13fb8fc771195717481a98e084ed0848.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/clang-10/coverage.github.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/tests/compare/reference/equal/clang-10/coverage.github.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">8 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav prev" href="coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
       <a class="nav next" href="coverage.github.html"></a>
     </div>

--- a/tests/compare/reference/equal/clang-12/coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
+++ b/tests/compare/reference/equal/clang-12/coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
@@ -150,10 +150,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/equal/clang-12/coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
+++ b/tests/compare/reference/equal/clang-12/coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
@@ -154,10 +154,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/equal/clang-12/coverage.boost.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
+++ b/tests/compare/reference/equal/clang-12/coverage.boost.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
@@ -150,9 +150,9 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.D.f26830d87b54e9f418a67752d418ba31.html" title="Previous file">
+      <span class="nav-link nav-prev disabled" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
-      </a>
+      </span>
       <a class="nav-link nav-next" href="coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>

--- a/tests/compare/reference/equal/clang-12/coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
+++ b/tests/compare/reference/equal/clang-12/coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
@@ -154,10 +154,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/equal/clang-12/coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
+++ b/tests/compare/reference/equal/clang-12/coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
@@ -150,10 +150,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/equal/clang-12/coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
+++ b/tests/compare/reference/equal/clang-12/coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
@@ -157,7 +157,7 @@
       <a class="nav-link nav-prev" href="coverage.boost.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/equal/clang-12/coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
+++ b/tests/compare/reference/equal/clang-12/coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
@@ -150,10 +150,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.B.cec86a34c08f941fc92924df967d4300.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.main.cpp.13fb8fc771195717481a98e084ed0848.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/equal/clang-12/coverage.boost.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/tests/compare/reference/equal/clang-12/coverage.boost.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -154,7 +154,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.B.cec86a34c08f941fc92924df967d4300.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <span class="nav-link nav-next disabled" title="Next file">

--- a/tests/compare/reference/equal/clang-12/coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
+++ b/tests/compare/reference/equal/clang-12/coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
@@ -107,9 +107,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">7 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
+      <a class="nav prev" href="coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav next" href="coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/clang-12/coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
+++ b/tests/compare/reference/equal/clang-12/coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
@@ -100,9 +100,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">5 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav prev" href="coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav next" href="coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/clang-12/coverage.default.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
+++ b/tests/compare/reference/equal/clang-12/coverage.default.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
@@ -100,7 +100,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">5 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.D.f26830d87b54e9f418a67752d418ba31.html"></a>
+      <a class="nav prev" href="coverage.default.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
       <a class="nav next" href="coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
     </div>

--- a/tests/compare/reference/equal/clang-12/coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
+++ b/tests/compare/reference/equal/clang-12/coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
@@ -100,9 +100,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">5 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav prev" href="coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav next" href="coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/clang-12/coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
+++ b/tests/compare/reference/equal/clang-12/coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
@@ -107,9 +107,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">10 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav prev" href="coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
+      <a class="nav next" href="coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/clang-12/coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
+++ b/tests/compare/reference/equal/clang-12/coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
@@ -102,7 +102,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.default.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav next" href="coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/clang-12/coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
+++ b/tests/compare/reference/equal/clang-12/coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
@@ -100,9 +100,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">2 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav prev" href="coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav next" href="coverage.default.main.cpp.13fb8fc771195717481a98e084ed0848.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/clang-12/coverage.default.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/tests/compare/reference/equal/clang-12/coverage.default.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -100,7 +100,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">8 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav prev" href="coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
       <a class="nav next" href="coverage.default.html"></a>
     </div>

--- a/tests/compare/reference/equal/clang-12/coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
+++ b/tests/compare/reference/equal/clang-12/coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">7 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
+      <a class="nav prev" href="coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav next" href="coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/clang-12/coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
+++ b/tests/compare/reference/equal/clang-12/coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">5 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav prev" href="coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav next" href="coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/clang-12/coverage.github.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
+++ b/tests/compare/reference/equal/clang-12/coverage.github.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">5 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.D.f26830d87b54e9f418a67752d418ba31.html"></a>
+      <a class="nav prev" href="coverage.github.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
       <a class="nav next" href="coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
     </div>

--- a/tests/compare/reference/equal/clang-12/coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
+++ b/tests/compare/reference/equal/clang-12/coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">5 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav prev" href="coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav next" href="coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/clang-12/coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
+++ b/tests/compare/reference/equal/clang-12/coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">10 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav prev" href="coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
+      <a class="nav next" href="coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/clang-12/coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
+++ b/tests/compare/reference/equal/clang-12/coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
@@ -97,7 +97,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.github.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav next" href="coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/clang-12/coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
+++ b/tests/compare/reference/equal/clang-12/coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">2 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav prev" href="coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav next" href="coverage.github.main.cpp.13fb8fc771195717481a98e084ed0848.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/clang-12/coverage.github.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/tests/compare/reference/equal/clang-12/coverage.github.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">8 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav prev" href="coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
       <a class="nav next" href="coverage.github.html"></a>
     </div>

--- a/tests/compare/reference/equal/gcc-11/coverage.boost.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/tests/compare/reference/equal/gcc-11/coverage.boost.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -154,7 +154,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.B.cec86a34c08f941fc92924df967d4300.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <span class="nav-link nav-next disabled" title="Next file">

--- a/tests/compare/reference/equal/gcc-11/coverage.default.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/tests/compare/reference/equal/gcc-11/coverage.default.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -100,7 +100,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">8 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav prev" href="coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
       <a class="nav next" href="coverage.default.html"></a>
     </div>

--- a/tests/compare/reference/equal/gcc-11/coverage.github.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/tests/compare/reference/equal/gcc-11/coverage.github.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">8 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav prev" href="coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
       <a class="nav next" href="coverage.github.html"></a>
     </div>

--- a/tests/compare/reference/equal/gcc-14/coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
+++ b/tests/compare/reference/equal/gcc-14/coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
@@ -154,10 +154,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/equal/gcc-14/coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
+++ b/tests/compare/reference/equal/gcc-14/coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
@@ -158,10 +158,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/equal/gcc-14/coverage.boost.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
+++ b/tests/compare/reference/equal/gcc-14/coverage.boost.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
@@ -154,9 +154,9 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.D.f26830d87b54e9f418a67752d418ba31.html" title="Previous file">
+      <span class="nav-link nav-prev disabled" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
-      </a>
+      </span>
       <a class="nav-link nav-next" href="coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>

--- a/tests/compare/reference/equal/gcc-14/coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
+++ b/tests/compare/reference/equal/gcc-14/coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
@@ -158,10 +158,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/equal/gcc-14/coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
+++ b/tests/compare/reference/equal/gcc-14/coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
@@ -154,10 +154,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/equal/gcc-14/coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
+++ b/tests/compare/reference/equal/gcc-14/coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
@@ -161,7 +161,7 @@
       <a class="nav-link nav-prev" href="coverage.boost.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/equal/gcc-14/coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
+++ b/tests/compare/reference/equal/gcc-14/coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
@@ -154,10 +154,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.B.cec86a34c08f941fc92924df967d4300.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.main.cpp.13fb8fc771195717481a98e084ed0848.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/equal/gcc-14/coverage.boost.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/tests/compare/reference/equal/gcc-14/coverage.boost.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -158,7 +158,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.B.cec86a34c08f941fc92924df967d4300.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <span class="nav-link nav-next disabled" title="Next file">

--- a/tests/compare/reference/equal/gcc-14/coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
+++ b/tests/compare/reference/equal/gcc-14/coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
@@ -115,9 +115,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">7 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
+      <a class="nav prev" href="coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav next" href="coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/gcc-14/coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
+++ b/tests/compare/reference/equal/gcc-14/coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
@@ -107,9 +107,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">4 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav prev" href="coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav next" href="coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/gcc-14/coverage.default.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
+++ b/tests/compare/reference/equal/gcc-14/coverage.default.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
@@ -107,7 +107,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">4 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.D.f26830d87b54e9f418a67752d418ba31.html"></a>
+      <a class="nav prev" href="coverage.default.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
       <a class="nav next" href="coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
     </div>

--- a/tests/compare/reference/equal/gcc-14/coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
+++ b/tests/compare/reference/equal/gcc-14/coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
@@ -107,9 +107,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">4 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav prev" href="coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav next" href="coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/gcc-14/coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
+++ b/tests/compare/reference/equal/gcc-14/coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
@@ -115,9 +115,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">9 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav prev" href="coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
+      <a class="nav next" href="coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/gcc-14/coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
+++ b/tests/compare/reference/equal/gcc-14/coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
@@ -109,7 +109,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.default.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav next" href="coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/gcc-14/coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
+++ b/tests/compare/reference/equal/gcc-14/coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
@@ -107,9 +107,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">2 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav prev" href="coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav next" href="coverage.default.main.cpp.13fb8fc771195717481a98e084ed0848.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/gcc-14/coverage.default.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/tests/compare/reference/equal/gcc-14/coverage.default.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -107,7 +107,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">8 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav prev" href="coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
       <a class="nav next" href="coverage.default.html"></a>
     </div>

--- a/tests/compare/reference/equal/gcc-14/coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
+++ b/tests/compare/reference/equal/gcc-14/coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
@@ -110,9 +110,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">7 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
+      <a class="nav prev" href="coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav next" href="coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/gcc-14/coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
+++ b/tests/compare/reference/equal/gcc-14/coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">4 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav prev" href="coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav next" href="coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/gcc-14/coverage.github.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
+++ b/tests/compare/reference/equal/gcc-14/coverage.github.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
@@ -102,7 +102,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">4 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.D.f26830d87b54e9f418a67752d418ba31.html"></a>
+      <a class="nav prev" href="coverage.github.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
       <a class="nav next" href="coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
     </div>

--- a/tests/compare/reference/equal/gcc-14/coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
+++ b/tests/compare/reference/equal/gcc-14/coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">4 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav prev" href="coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav next" href="coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/gcc-14/coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
+++ b/tests/compare/reference/equal/gcc-14/coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
@@ -110,9 +110,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">9 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav prev" href="coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
+      <a class="nav next" href="coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/gcc-14/coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
+++ b/tests/compare/reference/equal/gcc-14/coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
@@ -104,7 +104,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.github.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav next" href="coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/gcc-14/coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
+++ b/tests/compare/reference/equal/gcc-14/coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">2 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav prev" href="coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav next" href="coverage.github.main.cpp.13fb8fc771195717481a98e084ed0848.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/gcc-14/coverage.github.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/tests/compare/reference/equal/gcc-14/coverage.github.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -102,7 +102,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">8 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav prev" href="coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
       <a class="nav next" href="coverage.github.html"></a>
     </div>

--- a/tests/compare/reference/equal/gcc-5/coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
+++ b/tests/compare/reference/equal/gcc-5/coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
@@ -150,10 +150,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/equal/gcc-5/coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
+++ b/tests/compare/reference/equal/gcc-5/coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
@@ -154,10 +154,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/equal/gcc-5/coverage.boost.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
+++ b/tests/compare/reference/equal/gcc-5/coverage.boost.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
@@ -150,9 +150,9 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.D.f26830d87b54e9f418a67752d418ba31.html" title="Previous file">
+      <span class="nav-link nav-prev disabled" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
-      </a>
+      </span>
       <a class="nav-link nav-next" href="coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>

--- a/tests/compare/reference/equal/gcc-5/coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
+++ b/tests/compare/reference/equal/gcc-5/coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
@@ -154,10 +154,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/equal/gcc-5/coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
+++ b/tests/compare/reference/equal/gcc-5/coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
@@ -150,10 +150,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/equal/gcc-5/coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
+++ b/tests/compare/reference/equal/gcc-5/coverage.boost.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
@@ -157,7 +157,7 @@
       <a class="nav-link nav-prev" href="coverage.boost.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/equal/gcc-5/coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
+++ b/tests/compare/reference/equal/gcc-5/coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
@@ -150,10 +150,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage.boost.B.cec86a34c08f941fc92924df967d4300.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage.boost.main.cpp.13fb8fc771195717481a98e084ed0848.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/compare/reference/equal/gcc-5/coverage.boost.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/tests/compare/reference/equal/gcc-5/coverage.boost.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -154,7 +154,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.B.cec86a34c08f941fc92924df967d4300.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <span class="nav-link nav-next disabled" title="Next file">

--- a/tests/compare/reference/equal/gcc-5/coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
+++ b/tests/compare/reference/equal/gcc-5/coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
@@ -107,9 +107,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">7 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
+      <a class="nav prev" href="coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav next" href="coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/gcc-5/coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
+++ b/tests/compare/reference/equal/gcc-5/coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
@@ -100,9 +100,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">4 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav prev" href="coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav next" href="coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/gcc-5/coverage.default.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
+++ b/tests/compare/reference/equal/gcc-5/coverage.default.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
@@ -100,7 +100,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">4 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.D.f26830d87b54e9f418a67752d418ba31.html"></a>
+      <a class="nav prev" href="coverage.default.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
       <a class="nav next" href="coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
     </div>

--- a/tests/compare/reference/equal/gcc-5/coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
+++ b/tests/compare/reference/equal/gcc-5/coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
@@ -100,9 +100,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">4 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav prev" href="coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav next" href="coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/gcc-5/coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
+++ b/tests/compare/reference/equal/gcc-5/coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
@@ -107,9 +107,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">9 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav prev" href="coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
+      <a class="nav next" href="coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/gcc-5/coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
+++ b/tests/compare/reference/equal/gcc-5/coverage.default.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
@@ -102,7 +102,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.default.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav next" href="coverage.default.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/gcc-5/coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
+++ b/tests/compare/reference/equal/gcc-5/coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
@@ -100,9 +100,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">2 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav prev" href="coverage.default.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
-      <a class="nav next" href="coverage.default.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav next" href="coverage.default.main.cpp.13fb8fc771195717481a98e084ed0848.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/gcc-5/coverage.default.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/tests/compare/reference/equal/gcc-5/coverage.default.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -100,7 +100,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">8 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav prev" href="coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
       <a class="nav next" href="coverage.default.html"></a>
     </div>

--- a/tests/compare/reference/equal/gcc-5/coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
+++ b/tests/compare/reference/equal/gcc-5/coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">7 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
+      <a class="nav prev" href="coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav next" href="coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/gcc-5/coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
+++ b/tests/compare/reference/equal/gcc-5/coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">4 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav prev" href="coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav next" href="coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/gcc-5/coverage.github.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
+++ b/tests/compare/reference/equal/gcc-5/coverage.github.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">4 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.D.f26830d87b54e9f418a67752d418ba31.html"></a>
+      <a class="nav prev" href="coverage.github.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
       <a class="nav next" href="coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
     </div>

--- a/tests/compare/reference/equal/gcc-5/coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
+++ b/tests/compare/reference/equal/gcc-5/coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">4 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav prev" href="coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav next" href="coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/gcc-5/coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
+++ b/tests/compare/reference/equal/gcc-5/coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">9 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav prev" href="coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
+      <a class="nav next" href="coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/gcc-5/coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
+++ b/tests/compare/reference/equal/gcc-5/coverage.github.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
@@ -97,7 +97,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.github.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav next" href="coverage.github.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/gcc-5/coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
+++ b/tests/compare/reference/equal/gcc-5/coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">2 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav prev" href="coverage.github.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
-      <a class="nav next" href="coverage.github.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav next" href="coverage.github.main.cpp.13fb8fc771195717481a98e084ed0848.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/compare/reference/equal/gcc-5/coverage.github.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/tests/compare/reference/equal/gcc-5/coverage.github.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">8 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav prev" href="coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
       <a class="nav next" href="coverage.github.html"></a>
     </div>

--- a/tests/compare/reference/equal/gcc-9/coverage.boost.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/tests/compare/reference/equal/gcc-9/coverage.boost.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -154,7 +154,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage.boost.B.cec86a34c08f941fc92924df967d4300.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage.boost.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <span class="nav-link nav-next disabled" title="Next file">

--- a/tests/compare/reference/equal/gcc-9/coverage.default.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/tests/compare/reference/equal/gcc-9/coverage.default.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -100,7 +100,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">8 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.default.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav prev" href="coverage.default.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
       <a class="nav index" href="coverage.default.html"></a>
       <a class="nav next" href="coverage.default.html"></a>
     </div>

--- a/tests/compare/reference/equal/gcc-9/coverage.github.main.cpp.13fb8fc771195717481a98e084ed0848.html
+++ b/tests/compare/reference/equal/gcc-9/coverage.github.main.cpp.13fb8fc771195717481a98e084ed0848.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_STRICTLY_EQUAL show_STRICTLY_EQUAL" value="STRICTLY_EQUAL" title="Toggle strictly equal lines">8 strictly equal</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.github.B.cec86a34c08f941fc92924df967d4300.html"></a>
+      <a class="nav prev" href="coverage.github.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
       <a class="nav index" href="coverage.github.html"></a>
       <a class="nav next" href="coverage.github.html"></a>
     </div>

--- a/tests/dot-folder/reference/clang-10/coverage.File2.cpp.6d8c4c3a43f26e03a73c3c52ced4b343.html
+++ b/tests/dot-folder/reference/clang-10/coverage.File2.cpp.6d8c4c3a43f26e03a73c3c52ced4b343.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file5.cpp.c953054e717675f6f8af56f7fee2fb14.html"></a>
+      <a class="nav prev" href="coverage.file1.cpp.e4b34f3a937a38f4f36ad7d4400aa49c.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File4.cpp.002784682a955d02b5c65c936343e208.html"></a>
+      <a class="nav next" href="coverage.file3.cpp.2f75129acf13033c6475b68d314e376c.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/dot-folder/reference/clang-10/coverage.File4.cpp.002784682a955d02b5c65c936343e208.html
+++ b/tests/dot-folder/reference/clang-10/coverage.File4.cpp.002784682a955d02b5c65c936343e208.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File2.cpp.6d8c4c3a43f26e03a73c3c52ced4b343.html"></a>
+      <a class="nav prev" href="coverage.file3.cpp.2f75129acf13033c6475b68d314e376c.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file1.cpp.e4b34f3a937a38f4f36ad7d4400aa49c.html"></a>
+      <a class="nav next" href="coverage.main.cpp.d0d5fc20837f40fa4765af5e07f5d1b9.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/dot-folder/reference/clang-10/coverage.file1.cpp.e4b34f3a937a38f4f36ad7d4400aa49c.html
+++ b/tests/dot-folder/reference/clang-10/coverage.file1.cpp.e4b34f3a937a38f4f36ad7d4400aa49c.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File4.cpp.002784682a955d02b5c65c936343e208.html"></a>
+      <a class="nav prev" href="coverage.file5.cpp.c953054e717675f6f8af56f7fee2fb14.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file3.cpp.2f75129acf13033c6475b68d314e376c.html"></a>
+      <a class="nav next" href="coverage.File2.cpp.6d8c4c3a43f26e03a73c3c52ced4b343.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/dot-folder/reference/clang-10/coverage.file3.cpp.2f75129acf13033c6475b68d314e376c.html
+++ b/tests/dot-folder/reference/clang-10/coverage.file3.cpp.2f75129acf13033c6475b68d314e376c.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file1.cpp.e4b34f3a937a38f4f36ad7d4400aa49c.html"></a>
+      <a class="nav prev" href="coverage.File2.cpp.6d8c4c3a43f26e03a73c3c52ced4b343.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.main.cpp.d0d5fc20837f40fa4765af5e07f5d1b9.html"></a>
+      <a class="nav next" href="coverage.File4.cpp.002784682a955d02b5c65c936343e208.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/dot-folder/reference/clang-10/coverage.file5.cpp.c953054e717675f6f8af56f7fee2fb14.html
+++ b/tests/dot-folder/reference/clang-10/coverage.file5.cpp.c953054e717675f6f8af56f7fee2fb14.html
@@ -97,7 +97,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.File6.cpp.2ec5ec77ea4333a1e7eee1bb01185c1f.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File2.cpp.6d8c4c3a43f26e03a73c3c52ced4b343.html"></a>
+      <a class="nav next" href="coverage.file1.cpp.e4b34f3a937a38f4f36ad7d4400aa49c.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/dot-folder/reference/clang-10/coverage.main.cpp.d0d5fc20837f40fa4765af5e07f5d1b9.html
+++ b/tests/dot-folder/reference/clang-10/coverage.main.cpp.d0d5fc20837f40fa4765af5e07f5d1b9.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file3.cpp.2f75129acf13033c6475b68d314e376c.html"></a>
+      <a class="nav prev" href="coverage.File4.cpp.002784682a955d02b5c65c936343e208.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.html"></a>
     </div>

--- a/tests/dot-folder/reference/clang-12/coverage.File2.cpp.6d8c4c3a43f26e03a73c3c52ced4b343.html
+++ b/tests/dot-folder/reference/clang-12/coverage.File2.cpp.6d8c4c3a43f26e03a73c3c52ced4b343.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file5.cpp.c953054e717675f6f8af56f7fee2fb14.html"></a>
+      <a class="nav prev" href="coverage.file1.cpp.e4b34f3a937a38f4f36ad7d4400aa49c.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File4.cpp.002784682a955d02b5c65c936343e208.html"></a>
+      <a class="nav next" href="coverage.file3.cpp.2f75129acf13033c6475b68d314e376c.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/dot-folder/reference/clang-12/coverage.File4.cpp.002784682a955d02b5c65c936343e208.html
+++ b/tests/dot-folder/reference/clang-12/coverage.File4.cpp.002784682a955d02b5c65c936343e208.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File2.cpp.6d8c4c3a43f26e03a73c3c52ced4b343.html"></a>
+      <a class="nav prev" href="coverage.file3.cpp.2f75129acf13033c6475b68d314e376c.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file1.cpp.e4b34f3a937a38f4f36ad7d4400aa49c.html"></a>
+      <a class="nav next" href="coverage.main.cpp.d0d5fc20837f40fa4765af5e07f5d1b9.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/dot-folder/reference/clang-12/coverage.file1.cpp.e4b34f3a937a38f4f36ad7d4400aa49c.html
+++ b/tests/dot-folder/reference/clang-12/coverage.file1.cpp.e4b34f3a937a38f4f36ad7d4400aa49c.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File4.cpp.002784682a955d02b5c65c936343e208.html"></a>
+      <a class="nav prev" href="coverage.file5.cpp.c953054e717675f6f8af56f7fee2fb14.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file3.cpp.2f75129acf13033c6475b68d314e376c.html"></a>
+      <a class="nav next" href="coverage.File2.cpp.6d8c4c3a43f26e03a73c3c52ced4b343.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/dot-folder/reference/clang-12/coverage.file3.cpp.2f75129acf13033c6475b68d314e376c.html
+++ b/tests/dot-folder/reference/clang-12/coverage.file3.cpp.2f75129acf13033c6475b68d314e376c.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file1.cpp.e4b34f3a937a38f4f36ad7d4400aa49c.html"></a>
+      <a class="nav prev" href="coverage.File2.cpp.6d8c4c3a43f26e03a73c3c52ced4b343.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.main.cpp.d0d5fc20837f40fa4765af5e07f5d1b9.html"></a>
+      <a class="nav next" href="coverage.File4.cpp.002784682a955d02b5c65c936343e208.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/dot-folder/reference/clang-12/coverage.file5.cpp.c953054e717675f6f8af56f7fee2fb14.html
+++ b/tests/dot-folder/reference/clang-12/coverage.file5.cpp.c953054e717675f6f8af56f7fee2fb14.html
@@ -97,7 +97,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.File6.cpp.2ec5ec77ea4333a1e7eee1bb01185c1f.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File2.cpp.6d8c4c3a43f26e03a73c3c52ced4b343.html"></a>
+      <a class="nav next" href="coverage.file1.cpp.e4b34f3a937a38f4f36ad7d4400aa49c.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/dot-folder/reference/clang-12/coverage.main.cpp.d0d5fc20837f40fa4765af5e07f5d1b9.html
+++ b/tests/dot-folder/reference/clang-12/coverage.main.cpp.d0d5fc20837f40fa4765af5e07f5d1b9.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file3.cpp.2f75129acf13033c6475b68d314e376c.html"></a>
+      <a class="nav prev" href="coverage.File4.cpp.002784682a955d02b5c65c936343e208.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.html"></a>
     </div>

--- a/tests/dot-folder/reference/clang-17-Darwin/coverage.main.cpp.d0d5fc20837f40fa4765af5e07f5d1b9.html
+++ b/tests/dot-folder/reference/clang-17-Darwin/coverage.main.cpp.d0d5fc20837f40fa4765af5e07f5d1b9.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file3.cpp.2f75129acf13033c6475b68d314e376c.html"></a>
+      <a class="nav prev" href="coverage.File4.cpp.002784682a955d02b5c65c936343e208.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.html"></a>
     </div>

--- a/tests/dot-folder/reference/gcc-11/coverage.main.cpp.d0d5fc20837f40fa4765af5e07f5d1b9.html
+++ b/tests/dot-folder/reference/gcc-11/coverage.main.cpp.d0d5fc20837f40fa4765af5e07f5d1b9.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file3.cpp.2f75129acf13033c6475b68d314e376c.html"></a>
+      <a class="nav prev" href="coverage.File4.cpp.002784682a955d02b5c65c936343e208.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.html"></a>
     </div>

--- a/tests/dot-folder/reference/gcc-14/coverage.File2.cpp.6d8c4c3a43f26e03a73c3c52ced4b343.html
+++ b/tests/dot-folder/reference/gcc-14/coverage.File2.cpp.6d8c4c3a43f26e03a73c3c52ced4b343.html
@@ -110,9 +110,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file5.cpp.c953054e717675f6f8af56f7fee2fb14.html"></a>
+      <a class="nav prev" href="coverage.file1.cpp.e4b34f3a937a38f4f36ad7d4400aa49c.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File4.cpp.002784682a955d02b5c65c936343e208.html"></a>
+      <a class="nav next" href="coverage.file3.cpp.2f75129acf13033c6475b68d314e376c.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/dot-folder/reference/gcc-14/coverage.File4.cpp.002784682a955d02b5c65c936343e208.html
+++ b/tests/dot-folder/reference/gcc-14/coverage.File4.cpp.002784682a955d02b5c65c936343e208.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File2.cpp.6d8c4c3a43f26e03a73c3c52ced4b343.html"></a>
+      <a class="nav prev" href="coverage.file3.cpp.2f75129acf13033c6475b68d314e376c.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file1.cpp.e4b34f3a937a38f4f36ad7d4400aa49c.html"></a>
+      <a class="nav next" href="coverage.main.cpp.d0d5fc20837f40fa4765af5e07f5d1b9.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/dot-folder/reference/gcc-14/coverage.file1.cpp.e4b34f3a937a38f4f36ad7d4400aa49c.html
+++ b/tests/dot-folder/reference/gcc-14/coverage.file1.cpp.e4b34f3a937a38f4f36ad7d4400aa49c.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File4.cpp.002784682a955d02b5c65c936343e208.html"></a>
+      <a class="nav prev" href="coverage.file5.cpp.c953054e717675f6f8af56f7fee2fb14.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file3.cpp.2f75129acf13033c6475b68d314e376c.html"></a>
+      <a class="nav next" href="coverage.File2.cpp.6d8c4c3a43f26e03a73c3c52ced4b343.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/dot-folder/reference/gcc-14/coverage.file3.cpp.2f75129acf13033c6475b68d314e376c.html
+++ b/tests/dot-folder/reference/gcc-14/coverage.file3.cpp.2f75129acf13033c6475b68d314e376c.html
@@ -110,9 +110,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file1.cpp.e4b34f3a937a38f4f36ad7d4400aa49c.html"></a>
+      <a class="nav prev" href="coverage.File2.cpp.6d8c4c3a43f26e03a73c3c52ced4b343.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.main.cpp.d0d5fc20837f40fa4765af5e07f5d1b9.html"></a>
+      <a class="nav next" href="coverage.File4.cpp.002784682a955d02b5c65c936343e208.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/dot-folder/reference/gcc-14/coverage.file5.cpp.c953054e717675f6f8af56f7fee2fb14.html
+++ b/tests/dot-folder/reference/gcc-14/coverage.file5.cpp.c953054e717675f6f8af56f7fee2fb14.html
@@ -104,7 +104,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.File6.cpp.2ec5ec77ea4333a1e7eee1bb01185c1f.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File2.cpp.6d8c4c3a43f26e03a73c3c52ced4b343.html"></a>
+      <a class="nav next" href="coverage.file1.cpp.e4b34f3a937a38f4f36ad7d4400aa49c.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/dot-folder/reference/gcc-14/coverage.main.cpp.d0d5fc20837f40fa4765af5e07f5d1b9.html
+++ b/tests/dot-folder/reference/gcc-14/coverage.main.cpp.d0d5fc20837f40fa4765af5e07f5d1b9.html
@@ -102,7 +102,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file3.cpp.2f75129acf13033c6475b68d314e376c.html"></a>
+      <a class="nav prev" href="coverage.File4.cpp.002784682a955d02b5c65c936343e208.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.html"></a>
     </div>

--- a/tests/dot-folder/reference/gcc-5/coverage.File2.cpp.6d8c4c3a43f26e03a73c3c52ced4b343.html
+++ b/tests/dot-folder/reference/gcc-5/coverage.File2.cpp.6d8c4c3a43f26e03a73c3c52ced4b343.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file5.cpp.c953054e717675f6f8af56f7fee2fb14.html"></a>
+      <a class="nav prev" href="coverage.file1.cpp.e4b34f3a937a38f4f36ad7d4400aa49c.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File4.cpp.002784682a955d02b5c65c936343e208.html"></a>
+      <a class="nav next" href="coverage.file3.cpp.2f75129acf13033c6475b68d314e376c.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/dot-folder/reference/gcc-5/coverage.File4.cpp.002784682a955d02b5c65c936343e208.html
+++ b/tests/dot-folder/reference/gcc-5/coverage.File4.cpp.002784682a955d02b5c65c936343e208.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File2.cpp.6d8c4c3a43f26e03a73c3c52ced4b343.html"></a>
+      <a class="nav prev" href="coverage.file3.cpp.2f75129acf13033c6475b68d314e376c.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file1.cpp.e4b34f3a937a38f4f36ad7d4400aa49c.html"></a>
+      <a class="nav next" href="coverage.main.cpp.d0d5fc20837f40fa4765af5e07f5d1b9.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/dot-folder/reference/gcc-5/coverage.file1.cpp.e4b34f3a937a38f4f36ad7d4400aa49c.html
+++ b/tests/dot-folder/reference/gcc-5/coverage.file1.cpp.e4b34f3a937a38f4f36ad7d4400aa49c.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File4.cpp.002784682a955d02b5c65c936343e208.html"></a>
+      <a class="nav prev" href="coverage.file5.cpp.c953054e717675f6f8af56f7fee2fb14.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file3.cpp.2f75129acf13033c6475b68d314e376c.html"></a>
+      <a class="nav next" href="coverage.File2.cpp.6d8c4c3a43f26e03a73c3c52ced4b343.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/dot-folder/reference/gcc-5/coverage.file3.cpp.2f75129acf13033c6475b68d314e376c.html
+++ b/tests/dot-folder/reference/gcc-5/coverage.file3.cpp.2f75129acf13033c6475b68d314e376c.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file1.cpp.e4b34f3a937a38f4f36ad7d4400aa49c.html"></a>
+      <a class="nav prev" href="coverage.File2.cpp.6d8c4c3a43f26e03a73c3c52ced4b343.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.main.cpp.d0d5fc20837f40fa4765af5e07f5d1b9.html"></a>
+      <a class="nav next" href="coverage.File4.cpp.002784682a955d02b5c65c936343e208.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/dot-folder/reference/gcc-5/coverage.file5.cpp.c953054e717675f6f8af56f7fee2fb14.html
+++ b/tests/dot-folder/reference/gcc-5/coverage.file5.cpp.c953054e717675f6f8af56f7fee2fb14.html
@@ -97,7 +97,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.File6.cpp.2ec5ec77ea4333a1e7eee1bb01185c1f.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File2.cpp.6d8c4c3a43f26e03a73c3c52ced4b343.html"></a>
+      <a class="nav next" href="coverage.file1.cpp.e4b34f3a937a38f4f36ad7d4400aa49c.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/dot-folder/reference/gcc-5/coverage.main.cpp.d0d5fc20837f40fa4765af5e07f5d1b9.html
+++ b/tests/dot-folder/reference/gcc-5/coverage.main.cpp.d0d5fc20837f40fa4765af5e07f5d1b9.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file3.cpp.2f75129acf13033c6475b68d314e376c.html"></a>
+      <a class="nav prev" href="coverage.File4.cpp.002784682a955d02b5c65c936343e208.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.html"></a>
     </div>

--- a/tests/dot-folder/reference/gcc-9/coverage.main.cpp.d0d5fc20837f40fa4765af5e07f5d1b9.html
+++ b/tests/dot-folder/reference/gcc-9/coverage.main.cpp.d0d5fc20837f40fa4765af5e07f5d1b9.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file3.cpp.2f75129acf13033c6475b68d314e376c.html"></a>
+      <a class="nav prev" href="coverage.File4.cpp.002784682a955d02b5c65c936343e208.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.html"></a>
     </div>

--- a/tests/html/reference/details-filter/clang-10/coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/html/reference/details-filter/clang-10/coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-filter/clang-10/coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/details-filter/clang-10/coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-filter/clang-10/coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/details-filter/clang-10/coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-filter/clang-10/coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/details-filter/clang-10/coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-filter/clang-10/coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/details-filter/clang-10/coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -97,7 +97,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage_details.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-filter/clang-10/coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/details-filter/clang-10/coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
       <a class="nav next" href="coverage_details.html"></a>
     </div>

--- a/tests/html/reference/details-filter/clang-12/coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/html/reference/details-filter/clang-12/coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-filter/clang-12/coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/details-filter/clang-12/coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-filter/clang-12/coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/details-filter/clang-12/coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-filter/clang-12/coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/details-filter/clang-12/coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-filter/clang-12/coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/details-filter/clang-12/coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -97,7 +97,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage_details.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-filter/clang-12/coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/details-filter/clang-12/coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
       <a class="nav next" href="coverage_details.html"></a>
     </div>

--- a/tests/html/reference/details-filter/gcc-14/coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/html/reference/details-filter/gcc-14/coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -110,9 +110,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-filter/gcc-14/coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/details-filter/gcc-14/coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-filter/gcc-14/coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/details-filter/gcc-14/coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-filter/gcc-14/coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/details-filter/gcc-14/coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -110,9 +110,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-filter/gcc-14/coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/details-filter/gcc-14/coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -104,7 +104,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage_details.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-filter/gcc-14/coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/details-filter/gcc-14/coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -102,7 +102,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
       <a class="nav next" href="coverage_details.html"></a>
     </div>

--- a/tests/html/reference/details-filter/gcc-5/coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/html/reference/details-filter/gcc-5/coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-filter/gcc-5/coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/details-filter/gcc-5/coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-filter/gcc-5/coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/details-filter/gcc-5/coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-filter/gcc-5/coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/details-filter/gcc-5/coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-filter/gcc-5/coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/details-filter/gcc-5/coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -97,7 +97,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage_details.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-filter/gcc-5/coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/details-filter/gcc-5/coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
       <a class="nav next" href="coverage_details.html"></a>
     </div>

--- a/tests/html/reference/details-sort-none/clang-10/coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/html/reference/details-sort-none/clang-10/coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-none/clang-10/coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/details-sort-none/clang-10/coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-none/clang-10/coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/details-sort-none/clang-10/coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-none/clang-10/coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/details-sort-none/clang-10/coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-none/clang-10/coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/details-sort-none/clang-10/coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -97,7 +97,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage_details.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-none/clang-10/coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/details-sort-none/clang-10/coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
       <a class="nav next" href="coverage_details.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>

--- a/tests/html/reference/details-sort-none/clang-12/coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/html/reference/details-sort-none/clang-12/coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-none/clang-12/coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/details-sort-none/clang-12/coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-none/clang-12/coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/details-sort-none/clang-12/coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-none/clang-12/coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/details-sort-none/clang-12/coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-none/clang-12/coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/details-sort-none/clang-12/coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -97,7 +97,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage_details.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-none/clang-12/coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/details-sort-none/clang-12/coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
       <a class="nav next" href="coverage_details.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>

--- a/tests/html/reference/details-sort-none/gcc-14/coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/html/reference/details-sort-none/gcc-14/coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -110,9 +110,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-none/gcc-14/coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/details-sort-none/gcc-14/coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-none/gcc-14/coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/details-sort-none/gcc-14/coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-none/gcc-14/coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/details-sort-none/gcc-14/coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -110,9 +110,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-none/gcc-14/coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/details-sort-none/gcc-14/coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -104,7 +104,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage_details.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-none/gcc-14/coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/details-sort-none/gcc-14/coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -102,7 +102,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
       <a class="nav next" href="coverage_details.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>

--- a/tests/html/reference/details-sort-none/gcc-5/coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/html/reference/details-sort-none/gcc-5/coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-none/gcc-5/coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/details-sort-none/gcc-5/coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-none/gcc-5/coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/details-sort-none/gcc-5/coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-none/gcc-5/coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/details-sort-none/gcc-5/coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-none/gcc-5/coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/details-sort-none/gcc-5/coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -97,7 +97,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage_details.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
-      <a class="nav next" href="coverage_details.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-none/gcc-5/coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/details-sort-none/gcc-5/coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage_details.html"></a>
       <a class="nav next" href="coverage_details.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>

--- a/tests/html/reference/details-sort-uncovered-number/clang-10/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/html/reference/details-sort-uncovered-number/clang-10/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-number/clang-10/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/details-sort-uncovered-number/clang-10/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-number/clang-10/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/details-sort-uncovered-number/clang-10/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-number/clang-10/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/details-sort-uncovered-number/clang-10/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-number/clang-10/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/details-sort-uncovered-number/clang-10/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -97,7 +97,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-number/clang-10/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/details-sort-uncovered-number/clang-10/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>

--- a/tests/html/reference/details-sort-uncovered-number/clang-12/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/html/reference/details-sort-uncovered-number/clang-12/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-number/clang-12/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/details-sort-uncovered-number/clang-12/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-number/clang-12/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/details-sort-uncovered-number/clang-12/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-number/clang-12/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/details-sort-uncovered-number/clang-12/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-number/clang-12/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/details-sort-uncovered-number/clang-12/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -97,7 +97,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-number/clang-12/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/details-sort-uncovered-number/clang-12/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>

--- a/tests/html/reference/details-sort-uncovered-number/gcc-14/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/html/reference/details-sort-uncovered-number/gcc-14/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -110,9 +110,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-number/gcc-14/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/details-sort-uncovered-number/gcc-14/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-number/gcc-14/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/details-sort-uncovered-number/gcc-14/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-number/gcc-14/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/details-sort-uncovered-number/gcc-14/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -110,9 +110,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-number/gcc-14/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/details-sort-uncovered-number/gcc-14/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -104,7 +104,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-number/gcc-14/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/details-sort-uncovered-number/gcc-14/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -102,7 +102,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>

--- a/tests/html/reference/details-sort-uncovered-number/gcc-5/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/html/reference/details-sort-uncovered-number/gcc-5/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-number/gcc-5/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/details-sort-uncovered-number/gcc-5/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-number/gcc-5/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/details-sort-uncovered-number/gcc-5/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-number/gcc-5/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/details-sort-uncovered-number/gcc-5/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-number/gcc-5/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/details-sort-uncovered-number/gcc-5/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -97,7 +97,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-number/gcc-5/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/details-sort-uncovered-number/gcc-5/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>

--- a/tests/html/reference/details-sort-uncovered-percentage/clang-10/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/html/reference/details-sort-uncovered-percentage/clang-10/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-percentage/clang-10/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/details-sort-uncovered-percentage/clang-10/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-percentage/clang-10/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/details-sort-uncovered-percentage/clang-10/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-percentage/clang-10/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/details-sort-uncovered-percentage/clang-10/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-percentage/clang-10/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/details-sort-uncovered-percentage/clang-10/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -97,7 +97,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-percentage/clang-10/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/details-sort-uncovered-percentage/clang-10/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>

--- a/tests/html/reference/details-sort-uncovered-percentage/clang-12/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/html/reference/details-sort-uncovered-percentage/clang-12/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-percentage/clang-12/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/details-sort-uncovered-percentage/clang-12/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-percentage/clang-12/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/details-sort-uncovered-percentage/clang-12/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-percentage/clang-12/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/details-sort-uncovered-percentage/clang-12/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-percentage/clang-12/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/details-sort-uncovered-percentage/clang-12/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -97,7 +97,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-percentage/clang-12/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/details-sort-uncovered-percentage/clang-12/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>

--- a/tests/html/reference/details-sort-uncovered-percentage/gcc-14/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/html/reference/details-sort-uncovered-percentage/gcc-14/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -110,9 +110,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-percentage/gcc-14/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/details-sort-uncovered-percentage/gcc-14/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-percentage/gcc-14/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/details-sort-uncovered-percentage/gcc-14/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-percentage/gcc-14/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/details-sort-uncovered-percentage/gcc-14/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -110,9 +110,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-percentage/gcc-14/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/details-sort-uncovered-percentage/gcc-14/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -104,7 +104,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-percentage/gcc-14/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/details-sort-uncovered-percentage/gcc-14/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -102,7 +102,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>

--- a/tests/html/reference/details-sort-uncovered-percentage/gcc-5/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/html/reference/details-sort-uncovered-percentage/gcc-5/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-percentage/gcc-5/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/details-sort-uncovered-percentage/gcc-5/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-percentage/gcc-5/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/details-sort-uncovered-percentage/gcc-5/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-percentage/gcc-5/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/details-sort-uncovered-percentage/gcc-5/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-percentage/gcc-5/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/details-sort-uncovered-percentage/gcc-5/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -97,7 +97,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/details-sort-uncovered-percentage/gcc-5/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/details-sort-uncovered-percentage/gcc-5/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>

--- a/tests/html/reference/details-theme-boost-blue/clang-10/coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/details-theme-boost-blue/clang-10/coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -93,10 +93,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/details-theme-boost-blue/clang-10/coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/details-theme-boost-blue/clang-10/coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -93,7 +93,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <a class="nav-link nav-next" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Next file">

--- a/tests/html/reference/details-theme-boost-blue/clang-10/coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/details-theme-boost-blue/clang-10/coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -92,7 +92,7 @@
       <a class="nav-link nav-prev" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/details-theme-boost-blue/clang-10/coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/details-theme-boost-blue/clang-10/coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -96,7 +96,7 @@
       <a class="nav-link nav-prev" href="coverage_details.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/details-theme-boost-blue/clang-10/coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/details-theme-boost-blue/clang-10/coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -89,7 +89,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <a class="nav-link nav-next" href="coverage_details.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html" title="Next file">

--- a/tests/html/reference/details-theme-boost-blue/clang-12/coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/details-theme-boost-blue/clang-12/coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -93,10 +93,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/details-theme-boost-blue/clang-12/coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/details-theme-boost-blue/clang-12/coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -93,7 +93,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <a class="nav-link nav-next" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Next file">

--- a/tests/html/reference/details-theme-boost-blue/clang-12/coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/details-theme-boost-blue/clang-12/coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -92,7 +92,7 @@
       <a class="nav-link nav-prev" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/details-theme-boost-blue/clang-12/coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/details-theme-boost-blue/clang-12/coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -96,7 +96,7 @@
       <a class="nav-link nav-prev" href="coverage_details.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/details-theme-boost-blue/clang-12/coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/details-theme-boost-blue/clang-12/coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -89,7 +89,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <a class="nav-link nav-next" href="coverage_details.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html" title="Next file">

--- a/tests/html/reference/details-theme-boost-blue/gcc-14/coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/details-theme-boost-blue/gcc-14/coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -97,10 +97,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/details-theme-boost-blue/gcc-14/coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/details-theme-boost-blue/gcc-14/coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -97,7 +97,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <a class="nav-link nav-next" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Next file">

--- a/tests/html/reference/details-theme-boost-blue/gcc-14/coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/details-theme-boost-blue/gcc-14/coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -96,7 +96,7 @@
       <a class="nav-link nav-prev" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/details-theme-boost-blue/gcc-14/coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/details-theme-boost-blue/gcc-14/coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -100,7 +100,7 @@
       <a class="nav-link nav-prev" href="coverage_details.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/details-theme-boost-blue/gcc-14/coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/details-theme-boost-blue/gcc-14/coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -93,7 +93,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <a class="nav-link nav-next" href="coverage_details.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html" title="Next file">

--- a/tests/html/reference/details-theme-boost-blue/gcc-5/coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/details-theme-boost-blue/gcc-5/coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -93,10 +93,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/details-theme-boost-blue/gcc-5/coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/details-theme-boost-blue/gcc-5/coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -93,7 +93,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <a class="nav-link nav-next" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Next file">

--- a/tests/html/reference/details-theme-boost-blue/gcc-5/coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/details-theme-boost-blue/gcc-5/coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -92,7 +92,7 @@
       <a class="nav-link nav-prev" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/details-theme-boost-blue/gcc-5/coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/details-theme-boost-blue/gcc-5/coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -96,7 +96,7 @@
       <a class="nav-link nav-prev" href="coverage_details.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/details-theme-boost-blue/gcc-5/coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/details-theme-boost-blue/gcc-5/coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -89,7 +89,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <a class="nav-link nav-next" href="coverage_details.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html" title="Next file">

--- a/tests/html/reference/details-theme-boost-green/clang-10/coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/details-theme-boost-green/clang-10/coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -93,10 +93,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/details-theme-boost-green/clang-10/coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/details-theme-boost-green/clang-10/coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -93,7 +93,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <a class="nav-link nav-next" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Next file">

--- a/tests/html/reference/details-theme-boost-green/clang-10/coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/details-theme-boost-green/clang-10/coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -92,7 +92,7 @@
       <a class="nav-link nav-prev" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/details-theme-boost-green/clang-10/coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/details-theme-boost-green/clang-10/coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -96,7 +96,7 @@
       <a class="nav-link nav-prev" href="coverage_details.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/details-theme-boost-green/clang-10/coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/details-theme-boost-green/clang-10/coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -89,7 +89,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <a class="nav-link nav-next" href="coverage_details.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html" title="Next file">

--- a/tests/html/reference/details-theme-boost-green/clang-12/coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/details-theme-boost-green/clang-12/coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -93,10 +93,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/details-theme-boost-green/clang-12/coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/details-theme-boost-green/clang-12/coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -93,7 +93,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <a class="nav-link nav-next" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Next file">

--- a/tests/html/reference/details-theme-boost-green/clang-12/coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/details-theme-boost-green/clang-12/coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -92,7 +92,7 @@
       <a class="nav-link nav-prev" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/details-theme-boost-green/clang-12/coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/details-theme-boost-green/clang-12/coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -96,7 +96,7 @@
       <a class="nav-link nav-prev" href="coverage_details.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/details-theme-boost-green/clang-12/coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/details-theme-boost-green/clang-12/coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -89,7 +89,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <a class="nav-link nav-next" href="coverage_details.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html" title="Next file">

--- a/tests/html/reference/details-theme-boost-green/gcc-14/coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/details-theme-boost-green/gcc-14/coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -97,10 +97,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/details-theme-boost-green/gcc-14/coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/details-theme-boost-green/gcc-14/coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -97,7 +97,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <a class="nav-link nav-next" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Next file">

--- a/tests/html/reference/details-theme-boost-green/gcc-14/coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/details-theme-boost-green/gcc-14/coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -96,7 +96,7 @@
       <a class="nav-link nav-prev" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/details-theme-boost-green/gcc-14/coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/details-theme-boost-green/gcc-14/coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -100,7 +100,7 @@
       <a class="nav-link nav-prev" href="coverage_details.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/details-theme-boost-green/gcc-14/coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/details-theme-boost-green/gcc-14/coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -93,7 +93,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <a class="nav-link nav-next" href="coverage_details.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html" title="Next file">

--- a/tests/html/reference/details-theme-boost-green/gcc-5/coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/details-theme-boost-green/gcc-5/coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -93,10 +93,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/details-theme-boost-green/gcc-5/coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/details-theme-boost-green/gcc-5/coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -93,7 +93,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <a class="nav-link nav-next" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Next file">

--- a/tests/html/reference/details-theme-boost-green/gcc-5/coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/details-theme-boost-green/gcc-5/coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -92,7 +92,7 @@
       <a class="nav-link nav-prev" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/details-theme-boost-green/gcc-5/coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/details-theme-boost-green/gcc-5/coverage_details.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -96,7 +96,7 @@
       <a class="nav-link nav-prev" href="coverage_details.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_details.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/details-theme-boost-green/gcc-5/coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/details-theme-boost-green/gcc-5/coverage_details.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -89,7 +89,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_details.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_details.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <a class="nav-link nav-next" href="coverage_details.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html" title="Next file">

--- a/tests/html/reference/details-theme-default-js/clang-10/coverage_single_page.html
+++ b/tests/html/reference/details-theme-default-js/clang-10/coverage_single_page.html
@@ -1296,7 +1296,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </nav>
         <main>
 <script>
-  gcovr.default_content_id = "/";
+  gcovr.default_content_id = "gcovr-directory-root";
 </script>
 <hr class="js-disabled-hidden"/>
 <div id="functions.html" class="js-enabled-hidden js-disabled-hidden" data-title="Functions">
@@ -1377,7 +1377,7 @@ document.addEventListener("DOMContentLoaded", () => {
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
 <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
   </nav>
@@ -1835,7 +1835,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1995,9 +1995,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2157,7 +2157,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
@@ -2328,7 +2328,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2530,7 +2530,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
     </div>

--- a/tests/html/reference/details-theme-default-js/clang-12/coverage_single_page.html
+++ b/tests/html/reference/details-theme-default-js/clang-12/coverage_single_page.html
@@ -1296,7 +1296,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </nav>
         <main>
 <script>
-  gcovr.default_content_id = "/";
+  gcovr.default_content_id = "gcovr-directory-root";
 </script>
 <hr class="js-disabled-hidden"/>
 <div id="functions.html" class="js-enabled-hidden js-disabled-hidden" data-title="Functions">
@@ -1377,7 +1377,7 @@ document.addEventListener("DOMContentLoaded", () => {
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
 <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
   </nav>
@@ -1835,7 +1835,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1995,9 +1995,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2157,7 +2157,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
@@ -2328,7 +2328,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2530,7 +2530,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
     </div>

--- a/tests/html/reference/details-theme-default-js/gcc-14/coverage_single_page.html
+++ b/tests/html/reference/details-theme-default-js/gcc-14/coverage_single_page.html
@@ -1301,7 +1301,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </nav>
         <main>
 <script>
-  gcovr.default_content_id = "/";
+  gcovr.default_content_id = "gcovr-directory-root";
 </script>
 <hr class="js-disabled-hidden"/>
 <div id="functions.html" class="js-enabled-hidden js-disabled-hidden" data-title="Functions">
@@ -1392,7 +1392,7 @@ document.addEventListener("DOMContentLoaded", () => {
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
 <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
   </nav>
@@ -1926,7 +1926,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2118,9 +2118,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2312,7 +2312,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
@@ -2516,7 +2516,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2758,7 +2758,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
     </div>

--- a/tests/html/reference/details-theme-default-js/gcc-5/coverage_single_page.html
+++ b/tests/html/reference/details-theme-default-js/gcc-5/coverage_single_page.html
@@ -1296,7 +1296,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </nav>
         <main>
 <script>
-  gcovr.default_content_id = "/";
+  gcovr.default_content_id = "gcovr-directory-root";
 </script>
 <hr class="js-disabled-hidden"/>
 <div id="functions.html" class="js-enabled-hidden js-disabled-hidden" data-title="Functions">
@@ -1377,7 +1377,7 @@ document.addEventListener("DOMContentLoaded", () => {
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
 <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
   </nav>
@@ -1835,7 +1835,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1995,9 +1995,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2157,7 +2157,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
@@ -2328,7 +2328,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2530,7 +2530,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
     </div>

--- a/tests/html/reference/details-theme-default-static/clang-10/coverage_single_page.html
+++ b/tests/html/reference/details-theme-default-static/clang-10/coverage_single_page.html
@@ -142,7 +142,7 @@
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
   </nav>
 <div class="Box m-3 filelist">
@@ -599,7 +599,7 @@
     <div class="nav">
       <a class="nav prev" href="#File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -759,9 +759,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -921,7 +921,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
@@ -1092,7 +1092,7 @@
     <div class="nav">
       <a class="nav prev" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1294,7 +1294,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
     </div>

--- a/tests/html/reference/details-theme-default-static/clang-12/coverage_single_page.html
+++ b/tests/html/reference/details-theme-default-static/clang-12/coverage_single_page.html
@@ -142,7 +142,7 @@
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
   </nav>
 <div class="Box m-3 filelist">
@@ -599,7 +599,7 @@
     <div class="nav">
       <a class="nav prev" href="#File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -759,9 +759,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -921,7 +921,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
@@ -1092,7 +1092,7 @@
     <div class="nav">
       <a class="nav prev" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1294,7 +1294,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
     </div>

--- a/tests/html/reference/details-theme-default-static/gcc-14/coverage_single_page.html
+++ b/tests/html/reference/details-theme-default-static/gcc-14/coverage_single_page.html
@@ -157,7 +157,7 @@
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
   </nav>
 <div class="Box m-3 filelist">
@@ -690,7 +690,7 @@
     <div class="nav">
       <a class="nav prev" href="#File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -882,9 +882,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1076,7 +1076,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
@@ -1280,7 +1280,7 @@
     <div class="nav">
       <a class="nav prev" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1522,7 +1522,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
     </div>

--- a/tests/html/reference/details-theme-default-static/gcc-5/coverage_single_page.html
+++ b/tests/html/reference/details-theme-default-static/gcc-5/coverage_single_page.html
@@ -142,7 +142,7 @@
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
   </nav>
 <div class="Box m-3 filelist">
@@ -599,7 +599,7 @@
     <div class="nav">
       <a class="nav prev" href="#File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -759,9 +759,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -921,7 +921,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
@@ -1092,7 +1092,7 @@
     <div class="nav">
       <a class="nav prev" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1294,7 +1294,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
     </div>

--- a/tests/html/reference/details-theme-github-js/clang-10/coverage_single_page.html
+++ b/tests/html/reference/details-theme-github-js/clang-10/coverage_single_page.html
@@ -760,7 +760,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </nav>
         <main>
 <script>
-  gcovr.default_content_id = "/";
+  gcovr.default_content_id = "gcovr-directory-root";
 </script>
 <hr class="js-disabled-hidden"/>
 <div id="functions.html" class="js-enabled-hidden js-disabled-hidden" data-title="Functions">
@@ -841,7 +841,7 @@ document.addEventListener("DOMContentLoaded", () => {
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
 <div class="m-3">
   <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
@@ -1311,7 +1311,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1466,9 +1466,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1623,7 +1623,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
@@ -1789,7 +1789,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1986,7 +1986,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
     </div>

--- a/tests/html/reference/details-theme-github-js/clang-12/coverage_single_page.html
+++ b/tests/html/reference/details-theme-github-js/clang-12/coverage_single_page.html
@@ -760,7 +760,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </nav>
         <main>
 <script>
-  gcovr.default_content_id = "/";
+  gcovr.default_content_id = "gcovr-directory-root";
 </script>
 <hr class="js-disabled-hidden"/>
 <div id="functions.html" class="js-enabled-hidden js-disabled-hidden" data-title="Functions">
@@ -841,7 +841,7 @@ document.addEventListener("DOMContentLoaded", () => {
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
 <div class="m-3">
   <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
@@ -1311,7 +1311,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1466,9 +1466,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1623,7 +1623,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
@@ -1789,7 +1789,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1986,7 +1986,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
     </div>

--- a/tests/html/reference/details-theme-github-js/gcc-14/coverage_single_page.html
+++ b/tests/html/reference/details-theme-github-js/gcc-14/coverage_single_page.html
@@ -765,7 +765,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </nav>
         <main>
 <script>
-  gcovr.default_content_id = "/";
+  gcovr.default_content_id = "gcovr-directory-root";
 </script>
 <hr class="js-disabled-hidden"/>
 <div id="functions.html" class="js-enabled-hidden js-disabled-hidden" data-title="Functions">
@@ -856,7 +856,7 @@ document.addEventListener("DOMContentLoaded", () => {
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
 <div class="m-3">
   <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
@@ -1402,7 +1402,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1589,9 +1589,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1778,7 +1778,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
@@ -1977,7 +1977,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2214,7 +2214,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
     </div>

--- a/tests/html/reference/details-theme-github-js/gcc-5/coverage_single_page.html
+++ b/tests/html/reference/details-theme-github-js/gcc-5/coverage_single_page.html
@@ -760,7 +760,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </nav>
         <main>
 <script>
-  gcovr.default_content_id = "/";
+  gcovr.default_content_id = "gcovr-directory-root";
 </script>
 <hr class="js-disabled-hidden"/>
 <div id="functions.html" class="js-enabled-hidden js-disabled-hidden" data-title="Functions">
@@ -841,7 +841,7 @@ document.addEventListener("DOMContentLoaded", () => {
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
 <div class="m-3">
   <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
@@ -1311,7 +1311,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1466,9 +1466,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1623,7 +1623,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
@@ -1789,7 +1789,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1986,7 +1986,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
     </div>

--- a/tests/html/reference/details-theme-github-static/clang-10/coverage_single_page.html
+++ b/tests/html/reference/details-theme-github-static/clang-10/coverage_single_page.html
@@ -136,7 +136,7 @@
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
   </nav>
 <div class="Box m-3 filelist">
@@ -603,7 +603,7 @@
     <div class="nav">
       <a class="nav prev" href="#File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -758,9 +758,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -915,7 +915,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
@@ -1081,7 +1081,7 @@
     <div class="nav">
       <a class="nav prev" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1278,7 +1278,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
     </div>

--- a/tests/html/reference/details-theme-github-static/clang-12/coverage_single_page.html
+++ b/tests/html/reference/details-theme-github-static/clang-12/coverage_single_page.html
@@ -136,7 +136,7 @@
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
   </nav>
 <div class="Box m-3 filelist">
@@ -603,7 +603,7 @@
     <div class="nav">
       <a class="nav prev" href="#File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -758,9 +758,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -915,7 +915,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
@@ -1081,7 +1081,7 @@
     <div class="nav">
       <a class="nav prev" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1278,7 +1278,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
     </div>

--- a/tests/html/reference/details-theme-github-static/gcc-14/coverage_single_page.html
+++ b/tests/html/reference/details-theme-github-static/gcc-14/coverage_single_page.html
@@ -151,7 +151,7 @@
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
   </nav>
 <div class="Box m-3 filelist">
@@ -694,7 +694,7 @@
     <div class="nav">
       <a class="nav prev" href="#File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -881,9 +881,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1070,7 +1070,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
@@ -1269,7 +1269,7 @@
     <div class="nav">
       <a class="nav prev" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1506,7 +1506,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
     </div>

--- a/tests/html/reference/details-theme-github-static/gcc-5/coverage_single_page.html
+++ b/tests/html/reference/details-theme-github-static/gcc-5/coverage_single_page.html
@@ -136,7 +136,7 @@
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
   </nav>
 <div class="Box m-3 filelist">
@@ -603,7 +603,7 @@
     <div class="nav">
       <a class="nav prev" href="#File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -758,9 +758,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -915,7 +915,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
@@ -1081,7 +1081,7 @@
     <div class="nav">
       <a class="nav prev" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1278,7 +1278,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
     </div>

--- a/tests/html/reference/nested-filter/clang-10/coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/html/reference/nested-filter/clang-10/coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-filter/clang-10/coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/nested-filter/clang-10/coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-filter/clang-10/coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
+++ b/tests/html/reference/nested-filter/clang-10/coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.D.de4bee21461092ca61985814ef11fc54.html"></a>
+      <a class="nav prev" href="coverage_nested.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
       <a class="nav next" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
     </div>

--- a/tests/html/reference/nested-filter/clang-10/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/nested-filter/clang-10/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-filter/clang-10/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/nested-filter/clang-10/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-filter/clang-10/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/nested-filter/clang-10/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -97,7 +97,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-filter/clang-10/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/nested-filter/clang-10/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
       <a class="nav next" href="coverage_nested.html"></a>
     </div>

--- a/tests/html/reference/nested-filter/clang-12/coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/html/reference/nested-filter/clang-12/coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-filter/clang-12/coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/nested-filter/clang-12/coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-filter/clang-12/coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
+++ b/tests/html/reference/nested-filter/clang-12/coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.D.de4bee21461092ca61985814ef11fc54.html"></a>
+      <a class="nav prev" href="coverage_nested.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
       <a class="nav next" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
     </div>

--- a/tests/html/reference/nested-filter/clang-12/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/nested-filter/clang-12/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-filter/clang-12/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/nested-filter/clang-12/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-filter/clang-12/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/nested-filter/clang-12/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -97,7 +97,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-filter/clang-12/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/nested-filter/clang-12/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
       <a class="nav next" href="coverage_nested.html"></a>
     </div>

--- a/tests/html/reference/nested-filter/gcc-14/coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/html/reference/nested-filter/gcc-14/coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -110,9 +110,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-filter/gcc-14/coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/nested-filter/gcc-14/coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-filter/gcc-14/coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
+++ b/tests/html/reference/nested-filter/gcc-14/coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
@@ -102,7 +102,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.D.de4bee21461092ca61985814ef11fc54.html"></a>
+      <a class="nav prev" href="coverage_nested.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
       <a class="nav next" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
     </div>

--- a/tests/html/reference/nested-filter/gcc-14/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/nested-filter/gcc-14/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-filter/gcc-14/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/nested-filter/gcc-14/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -110,9 +110,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-filter/gcc-14/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/nested-filter/gcc-14/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -104,7 +104,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-filter/gcc-14/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/nested-filter/gcc-14/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -102,7 +102,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
       <a class="nav next" href="coverage_nested.html"></a>
     </div>

--- a/tests/html/reference/nested-filter/gcc-5/coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/html/reference/nested-filter/gcc-5/coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-filter/gcc-5/coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/nested-filter/gcc-5/coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-filter/gcc-5/coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
+++ b/tests/html/reference/nested-filter/gcc-5/coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.D.de4bee21461092ca61985814ef11fc54.html"></a>
+      <a class="nav prev" href="coverage_nested.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
       <a class="nav next" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
     </div>

--- a/tests/html/reference/nested-filter/gcc-5/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/nested-filter/gcc-5/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-filter/gcc-5/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/nested-filter/gcc-5/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-filter/gcc-5/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/nested-filter/gcc-5/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -97,7 +97,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-filter/gcc-5/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/nested-filter/gcc-5/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
       <a class="nav next" href="coverage_nested.html"></a>
     </div>

--- a/tests/html/reference/nested-sort-none/clang-10/coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/html/reference/nested-sort-none/clang-10/coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-none/clang-10/coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/nested-sort-none/clang-10/coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-none/clang-10/coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
+++ b/tests/html/reference/nested-sort-none/clang-10/coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.D.de4bee21461092ca61985814ef11fc54.html"></a>
+      <a class="nav prev" href="coverage_nested.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
       <a class="nav next" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
     </div>

--- a/tests/html/reference/nested-sort-none/clang-10/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/nested-sort-none/clang-10/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-none/clang-10/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/nested-sort-none/clang-10/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-none/clang-10/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/nested-sort-none/clang-10/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -97,7 +97,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-none/clang-10/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/nested-sort-none/clang-10/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav next" href="coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-none/clang-10/coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/tests/html/reference/nested-sort-none/clang-10/coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav prev" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
       <a class="nav next" href="coverage_nested.html"></a>
     </div>

--- a/tests/html/reference/nested-sort-none/clang-12/coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/html/reference/nested-sort-none/clang-12/coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-none/clang-12/coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/nested-sort-none/clang-12/coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-none/clang-12/coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
+++ b/tests/html/reference/nested-sort-none/clang-12/coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.D.de4bee21461092ca61985814ef11fc54.html"></a>
+      <a class="nav prev" href="coverage_nested.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
       <a class="nav next" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
     </div>

--- a/tests/html/reference/nested-sort-none/clang-12/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/nested-sort-none/clang-12/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-none/clang-12/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/nested-sort-none/clang-12/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-none/clang-12/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/nested-sort-none/clang-12/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -97,7 +97,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-none/clang-12/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/nested-sort-none/clang-12/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav next" href="coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-none/clang-12/coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/tests/html/reference/nested-sort-none/clang-12/coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav prev" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
       <a class="nav next" href="coverage_nested.html"></a>
     </div>

--- a/tests/html/reference/nested-sort-none/gcc-11/coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/tests/html/reference/nested-sort-none/gcc-11/coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav prev" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
       <a class="nav next" href="coverage_nested.html"></a>
     </div>

--- a/tests/html/reference/nested-sort-none/gcc-14/coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/html/reference/nested-sort-none/gcc-14/coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -110,9 +110,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-none/gcc-14/coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/nested-sort-none/gcc-14/coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-none/gcc-14/coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
+++ b/tests/html/reference/nested-sort-none/gcc-14/coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
@@ -102,7 +102,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.D.de4bee21461092ca61985814ef11fc54.html"></a>
+      <a class="nav prev" href="coverage_nested.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
       <a class="nav next" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
     </div>

--- a/tests/html/reference/nested-sort-none/gcc-14/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/nested-sort-none/gcc-14/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-none/gcc-14/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/nested-sort-none/gcc-14/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -110,9 +110,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-none/gcc-14/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/nested-sort-none/gcc-14/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -104,7 +104,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-none/gcc-14/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/nested-sort-none/gcc-14/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav next" href="coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-none/gcc-14/coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/tests/html/reference/nested-sort-none/gcc-14/coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -102,7 +102,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav prev" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
       <a class="nav next" href="coverage_nested.html"></a>
     </div>

--- a/tests/html/reference/nested-sort-none/gcc-5/coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/html/reference/nested-sort-none/gcc-5/coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-none/gcc-5/coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/nested-sort-none/gcc-5/coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-none/gcc-5/coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
+++ b/tests/html/reference/nested-sort-none/gcc-5/coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.D.de4bee21461092ca61985814ef11fc54.html"></a>
+      <a class="nav prev" href="coverage_nested.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
       <a class="nav next" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
     </div>

--- a/tests/html/reference/nested-sort-none/gcc-5/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/nested-sort-none/gcc-5/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-none/gcc-5/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/nested-sort-none/gcc-5/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-none/gcc-5/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/nested-sort-none/gcc-5/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -97,7 +97,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-none/gcc-5/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/nested-sort-none/gcc-5/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
-      <a class="nav next" href="coverage_nested.B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav next" href="coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-none/gcc-5/coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/tests/html/reference/nested-sort-none/gcc-5/coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav prev" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
       <a class="nav next" href="coverage_nested.html"></a>
     </div>

--- a/tests/html/reference/nested-sort-none/gcc-9/coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/tests/html/reference/nested-sort-none/gcc-9/coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage_nested.B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav prev" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
       <a class="nav index" href="coverage_nested.html"></a>
       <a class="nav next" href="coverage_nested.html"></a>
     </div>

--- a/tests/html/reference/nested-sort-uncovered-number/clang-10/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/html/reference/nested-sort-uncovered-number/clang-10/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-number/clang-10/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/nested-sort-uncovered-number/clang-10/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-number/clang-10/coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
+++ b/tests/html/reference/nested-sort-uncovered-number/clang-10/coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.D.de4bee21461092ca61985814ef11fc54.html"></a>
+      <a class="nav prev" href="coverage.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
     </div>

--- a/tests/html/reference/nested-sort-uncovered-number/clang-10/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/nested-sort-uncovered-number/clang-10/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-number/clang-10/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/nested-sort-uncovered-number/clang-10/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-number/clang-10/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/nested-sort-uncovered-number/clang-10/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -97,7 +97,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-number/clang-10/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/nested-sort-uncovered-number/clang-10/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav next" href="coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-number/clang-10/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/tests/html/reference/nested-sort-uncovered-number/clang-10/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav prev" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.html"></a>
     </div>

--- a/tests/html/reference/nested-sort-uncovered-number/clang-12/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/html/reference/nested-sort-uncovered-number/clang-12/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-number/clang-12/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/nested-sort-uncovered-number/clang-12/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-number/clang-12/coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
+++ b/tests/html/reference/nested-sort-uncovered-number/clang-12/coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.D.de4bee21461092ca61985814ef11fc54.html"></a>
+      <a class="nav prev" href="coverage.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
     </div>

--- a/tests/html/reference/nested-sort-uncovered-number/clang-12/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/nested-sort-uncovered-number/clang-12/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-number/clang-12/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/nested-sort-uncovered-number/clang-12/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-number/clang-12/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/nested-sort-uncovered-number/clang-12/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -97,7 +97,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-number/clang-12/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/nested-sort-uncovered-number/clang-12/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav next" href="coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-number/clang-12/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/tests/html/reference/nested-sort-uncovered-number/clang-12/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav prev" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.html"></a>
     </div>

--- a/tests/html/reference/nested-sort-uncovered-number/gcc-11/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/tests/html/reference/nested-sort-uncovered-number/gcc-11/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav prev" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.html"></a>
     </div>

--- a/tests/html/reference/nested-sort-uncovered-number/gcc-14/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/html/reference/nested-sort-uncovered-number/gcc-14/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -110,9 +110,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-number/gcc-14/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/nested-sort-uncovered-number/gcc-14/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-number/gcc-14/coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
+++ b/tests/html/reference/nested-sort-uncovered-number/gcc-14/coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
@@ -102,7 +102,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.D.de4bee21461092ca61985814ef11fc54.html"></a>
+      <a class="nav prev" href="coverage.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
     </div>

--- a/tests/html/reference/nested-sort-uncovered-number/gcc-14/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/nested-sort-uncovered-number/gcc-14/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-number/gcc-14/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/nested-sort-uncovered-number/gcc-14/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -110,9 +110,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-number/gcc-14/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/nested-sort-uncovered-number/gcc-14/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -104,7 +104,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-number/gcc-14/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/nested-sort-uncovered-number/gcc-14/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav next" href="coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-number/gcc-14/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/tests/html/reference/nested-sort-uncovered-number/gcc-14/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -102,7 +102,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav prev" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.html"></a>
     </div>

--- a/tests/html/reference/nested-sort-uncovered-number/gcc-5/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/html/reference/nested-sort-uncovered-number/gcc-5/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-number/gcc-5/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/nested-sort-uncovered-number/gcc-5/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-number/gcc-5/coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
+++ b/tests/html/reference/nested-sort-uncovered-number/gcc-5/coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.D.de4bee21461092ca61985814ef11fc54.html"></a>
+      <a class="nav prev" href="coverage.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
     </div>

--- a/tests/html/reference/nested-sort-uncovered-number/gcc-5/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/nested-sort-uncovered-number/gcc-5/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-number/gcc-5/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/nested-sort-uncovered-number/gcc-5/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-number/gcc-5/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/nested-sort-uncovered-number/gcc-5/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -97,7 +97,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-number/gcc-5/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/nested-sort-uncovered-number/gcc-5/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav next" href="coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-number/gcc-5/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/tests/html/reference/nested-sort-uncovered-number/gcc-5/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav prev" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.html"></a>
     </div>

--- a/tests/html/reference/nested-sort-uncovered-number/gcc-9/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/tests/html/reference/nested-sort-uncovered-number/gcc-9/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav prev" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.html"></a>
     </div>

--- a/tests/html/reference/nested-sort-uncovered-percentage/clang-10/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/html/reference/nested-sort-uncovered-percentage/clang-10/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-percentage/clang-10/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/nested-sort-uncovered-percentage/clang-10/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-percentage/clang-10/coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
+++ b/tests/html/reference/nested-sort-uncovered-percentage/clang-10/coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.D.de4bee21461092ca61985814ef11fc54.html"></a>
+      <a class="nav prev" href="coverage.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
     </div>

--- a/tests/html/reference/nested-sort-uncovered-percentage/clang-10/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/nested-sort-uncovered-percentage/clang-10/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-percentage/clang-10/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/nested-sort-uncovered-percentage/clang-10/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-percentage/clang-10/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/nested-sort-uncovered-percentage/clang-10/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -97,7 +97,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-percentage/clang-10/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/nested-sort-uncovered-percentage/clang-10/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav next" href="coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-percentage/clang-10/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/tests/html/reference/nested-sort-uncovered-percentage/clang-10/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav prev" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.html"></a>
     </div>

--- a/tests/html/reference/nested-sort-uncovered-percentage/clang-12/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/html/reference/nested-sort-uncovered-percentage/clang-12/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-percentage/clang-12/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/nested-sort-uncovered-percentage/clang-12/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-percentage/clang-12/coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
+++ b/tests/html/reference/nested-sort-uncovered-percentage/clang-12/coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.D.de4bee21461092ca61985814ef11fc54.html"></a>
+      <a class="nav prev" href="coverage.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
     </div>

--- a/tests/html/reference/nested-sort-uncovered-percentage/clang-12/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/nested-sort-uncovered-percentage/clang-12/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-percentage/clang-12/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/nested-sort-uncovered-percentage/clang-12/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-percentage/clang-12/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/nested-sort-uncovered-percentage/clang-12/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -97,7 +97,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-percentage/clang-12/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/nested-sort-uncovered-percentage/clang-12/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav next" href="coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-percentage/clang-12/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/tests/html/reference/nested-sort-uncovered-percentage/clang-12/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav prev" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.html"></a>
     </div>

--- a/tests/html/reference/nested-sort-uncovered-percentage/gcc-11/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/tests/html/reference/nested-sort-uncovered-percentage/gcc-11/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav prev" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.html"></a>
     </div>

--- a/tests/html/reference/nested-sort-uncovered-percentage/gcc-14/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/html/reference/nested-sort-uncovered-percentage/gcc-14/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -110,9 +110,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-percentage/gcc-14/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/nested-sort-uncovered-percentage/gcc-14/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-percentage/gcc-14/coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
+++ b/tests/html/reference/nested-sort-uncovered-percentage/gcc-14/coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
@@ -102,7 +102,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.D.de4bee21461092ca61985814ef11fc54.html"></a>
+      <a class="nav prev" href="coverage.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
     </div>

--- a/tests/html/reference/nested-sort-uncovered-percentage/gcc-14/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/nested-sort-uncovered-percentage/gcc-14/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-percentage/gcc-14/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/nested-sort-uncovered-percentage/gcc-14/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -110,9 +110,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-percentage/gcc-14/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/nested-sort-uncovered-percentage/gcc-14/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -104,7 +104,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-percentage/gcc-14/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/nested-sort-uncovered-percentage/gcc-14/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav next" href="coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-percentage/gcc-14/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/tests/html/reference/nested-sort-uncovered-percentage/gcc-14/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -102,7 +102,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav prev" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.html"></a>
     </div>

--- a/tests/html/reference/nested-sort-uncovered-percentage/gcc-5/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/html/reference/nested-sort-uncovered-percentage/gcc-5/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-percentage/gcc-5/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/nested-sort-uncovered-percentage/gcc-5/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-percentage/gcc-5/coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
+++ b/tests/html/reference/nested-sort-uncovered-percentage/gcc-5/coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.D.de4bee21461092ca61985814ef11fc54.html"></a>
+      <a class="nav prev" href="coverage.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
     </div>

--- a/tests/html/reference/nested-sort-uncovered-percentage/gcc-5/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/nested-sort-uncovered-percentage/gcc-5/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-percentage/gcc-5/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/nested-sort-uncovered-percentage/gcc-5/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-percentage/gcc-5/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/nested-sort-uncovered-percentage/gcc-5/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -97,7 +97,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-percentage/gcc-5/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/nested-sort-uncovered-percentage/gcc-5/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav next" href="coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/html/reference/nested-sort-uncovered-percentage/gcc-5/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/tests/html/reference/nested-sort-uncovered-percentage/gcc-5/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav prev" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.html"></a>
     </div>

--- a/tests/html/reference/nested-sort-uncovered-percentage/gcc-9/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/tests/html/reference/nested-sort-uncovered-percentage/gcc-9/coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav prev" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.html"></a>
     </div>

--- a/tests/html/reference/nested-theme-boost-blue/clang-10/coverage_nested.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html
+++ b/tests/html/reference/nested-theme-boost-blue/clang-10/coverage_nested.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html
@@ -150,10 +150,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.subdir_9.63bd3dc96170cd4173f6130222e788f0.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_nested.B.9d5ed678fe57bcca610140957afab571.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/nested-theme-boost-blue/clang-10/coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/nested-theme-boost-blue/clang-10/coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -154,10 +154,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/nested-theme-boost-blue/clang-10/coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
+++ b/tests/html/reference/nested-theme-boost-blue/clang-10/coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
@@ -150,9 +150,9 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.D.de4bee21461092ca61985814ef11fc54.html" title="Previous file">
+      <span class="nav-link nav-prev disabled" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
-      </a>
+      </span>
       <a class="nav-link nav-next" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>

--- a/tests/html/reference/nested-theme-boost-blue/clang-10/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/nested-theme-boost-blue/clang-10/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -154,7 +154,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <a class="nav-link nav-next" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Next file">

--- a/tests/html/reference/nested-theme-boost-blue/clang-10/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/nested-theme-boost-blue/clang-10/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -153,7 +153,7 @@
       <a class="nav-link nav-prev" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/nested-theme-boost-blue/clang-10/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/nested-theme-boost-blue/clang-10/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -157,7 +157,7 @@
       <a class="nav-link nav-prev" href="coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/nested-theme-boost-blue/clang-10/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/nested-theme-boost-blue/clang-10/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -150,10 +150,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_nested.subdir_9.63bd3dc96170cd4173f6130222e788f0.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_nested.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/nested-theme-boost-blue/clang-10/coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/tests/html/reference/nested-theme-boost-blue/clang-10/coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -154,7 +154,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.B.9d5ed678fe57bcca610140957afab571.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_nested.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <span class="nav-link nav-next disabled" title="Next file">

--- a/tests/html/reference/nested-theme-boost-blue/clang-12/coverage_nested.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html
+++ b/tests/html/reference/nested-theme-boost-blue/clang-12/coverage_nested.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html
@@ -150,10 +150,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.subdir_9.63bd3dc96170cd4173f6130222e788f0.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_nested.B.9d5ed678fe57bcca610140957afab571.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/nested-theme-boost-blue/clang-12/coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/nested-theme-boost-blue/clang-12/coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -154,10 +154,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/nested-theme-boost-blue/clang-12/coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
+++ b/tests/html/reference/nested-theme-boost-blue/clang-12/coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
@@ -150,9 +150,9 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.D.de4bee21461092ca61985814ef11fc54.html" title="Previous file">
+      <span class="nav-link nav-prev disabled" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
-      </a>
+      </span>
       <a class="nav-link nav-next" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>

--- a/tests/html/reference/nested-theme-boost-blue/clang-12/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/nested-theme-boost-blue/clang-12/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -154,7 +154,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <a class="nav-link nav-next" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Next file">

--- a/tests/html/reference/nested-theme-boost-blue/clang-12/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/nested-theme-boost-blue/clang-12/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -153,7 +153,7 @@
       <a class="nav-link nav-prev" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/nested-theme-boost-blue/clang-12/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/nested-theme-boost-blue/clang-12/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -157,7 +157,7 @@
       <a class="nav-link nav-prev" href="coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/nested-theme-boost-blue/clang-12/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/nested-theme-boost-blue/clang-12/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -150,10 +150,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_nested.subdir_9.63bd3dc96170cd4173f6130222e788f0.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_nested.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/nested-theme-boost-blue/clang-12/coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/tests/html/reference/nested-theme-boost-blue/clang-12/coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -154,7 +154,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.B.9d5ed678fe57bcca610140957afab571.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_nested.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <span class="nav-link nav-next disabled" title="Next file">

--- a/tests/html/reference/nested-theme-boost-blue/gcc-11/coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-11/coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -154,7 +154,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.B.9d5ed678fe57bcca610140957afab571.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_nested.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <span class="nav-link nav-next disabled" title="Next file">

--- a/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html
@@ -154,10 +154,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.subdir_9.63bd3dc96170cd4173f6130222e788f0.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_nested.B.9d5ed678fe57bcca610140957afab571.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -158,10 +158,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
@@ -154,9 +154,9 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.D.de4bee21461092ca61985814ef11fc54.html" title="Previous file">
+      <span class="nav-link nav-prev disabled" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
-      </a>
+      </span>
       <a class="nav-link nav-next" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>

--- a/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -158,7 +158,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <a class="nav-link nav-next" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Next file">

--- a/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -157,7 +157,7 @@
       <a class="nav-link nav-prev" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -161,7 +161,7 @@
       <a class="nav-link nav-prev" href="coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -154,10 +154,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_nested.subdir_9.63bd3dc96170cd4173f6130222e788f0.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_nested.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -158,7 +158,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.B.9d5ed678fe57bcca610140957afab571.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_nested.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <span class="nav-link nav-next disabled" title="Next file">

--- a/tests/html/reference/nested-theme-boost-blue/gcc-5/coverage_nested.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-5/coverage_nested.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html
@@ -150,10 +150,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.subdir_9.63bd3dc96170cd4173f6130222e788f0.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_nested.B.9d5ed678fe57bcca610140957afab571.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/nested-theme-boost-blue/gcc-5/coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-5/coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -154,10 +154,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/nested-theme-boost-blue/gcc-5/coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-5/coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
@@ -150,9 +150,9 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.D.de4bee21461092ca61985814ef11fc54.html" title="Previous file">
+      <span class="nav-link nav-prev disabled" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
-      </a>
+      </span>
       <a class="nav-link nav-next" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>

--- a/tests/html/reference/nested-theme-boost-blue/gcc-5/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-5/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -154,7 +154,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <a class="nav-link nav-next" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Next file">

--- a/tests/html/reference/nested-theme-boost-blue/gcc-5/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-5/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -153,7 +153,7 @@
       <a class="nav-link nav-prev" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/nested-theme-boost-blue/gcc-5/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-5/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -157,7 +157,7 @@
       <a class="nav-link nav-prev" href="coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/nested-theme-boost-blue/gcc-5/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-5/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -150,10 +150,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_nested.subdir_9.63bd3dc96170cd4173f6130222e788f0.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_nested.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/nested-theme-boost-blue/gcc-5/coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-5/coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -154,7 +154,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.B.9d5ed678fe57bcca610140957afab571.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_nested.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <span class="nav-link nav-next disabled" title="Next file">

--- a/tests/html/reference/nested-theme-boost-blue/gcc-9/coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-9/coverage_nested.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html
@@ -154,7 +154,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.B.9d5ed678fe57bcca610140957afab571.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_nested.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <span class="nav-link nav-next disabled" title="Next file">

--- a/tests/html/reference/nested-theme-boost-green/clang-10/coverage_nested.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html
+++ b/tests/html/reference/nested-theme-boost-green/clang-10/coverage_nested.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html
@@ -150,7 +150,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.subdir_9.63bd3dc96170cd4173f6130222e788f0.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <span class="nav-link nav-next disabled" title="Next file">

--- a/tests/html/reference/nested-theme-boost-green/clang-10/coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/nested-theme-boost-green/clang-10/coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -154,10 +154,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/nested-theme-boost-green/clang-10/coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
+++ b/tests/html/reference/nested-theme-boost-green/clang-10/coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
@@ -150,9 +150,9 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.D.de4bee21461092ca61985814ef11fc54.html" title="Previous file">
+      <span class="nav-link nav-prev disabled" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
-      </a>
+      </span>
       <a class="nav-link nav-next" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>

--- a/tests/html/reference/nested-theme-boost-green/clang-10/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/nested-theme-boost-green/clang-10/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -154,7 +154,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <a class="nav-link nav-next" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Next file">

--- a/tests/html/reference/nested-theme-boost-green/clang-10/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/nested-theme-boost-green/clang-10/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -153,7 +153,7 @@
       <a class="nav-link nav-prev" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/nested-theme-boost-green/clang-10/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/nested-theme-boost-green/clang-10/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -157,7 +157,7 @@
       <a class="nav-link nav-prev" href="coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/nested-theme-boost-green/clang-10/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/nested-theme-boost-green/clang-10/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -150,10 +150,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_nested.subdir_9.63bd3dc96170cd4173f6130222e788f0.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_nested.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/nested-theme-boost-green/clang-12/coverage_nested.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html
+++ b/tests/html/reference/nested-theme-boost-green/clang-12/coverage_nested.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html
@@ -150,7 +150,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.subdir_9.63bd3dc96170cd4173f6130222e788f0.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <span class="nav-link nav-next disabled" title="Next file">

--- a/tests/html/reference/nested-theme-boost-green/clang-12/coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/nested-theme-boost-green/clang-12/coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -154,10 +154,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/nested-theme-boost-green/clang-12/coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
+++ b/tests/html/reference/nested-theme-boost-green/clang-12/coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
@@ -150,9 +150,9 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.D.de4bee21461092ca61985814ef11fc54.html" title="Previous file">
+      <span class="nav-link nav-prev disabled" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
-      </a>
+      </span>
       <a class="nav-link nav-next" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>

--- a/tests/html/reference/nested-theme-boost-green/clang-12/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/nested-theme-boost-green/clang-12/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -154,7 +154,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <a class="nav-link nav-next" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Next file">

--- a/tests/html/reference/nested-theme-boost-green/clang-12/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/nested-theme-boost-green/clang-12/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -153,7 +153,7 @@
       <a class="nav-link nav-prev" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/nested-theme-boost-green/clang-12/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/nested-theme-boost-green/clang-12/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -157,7 +157,7 @@
       <a class="nav-link nav-prev" href="coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/nested-theme-boost-green/clang-12/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/nested-theme-boost-green/clang-12/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -150,10 +150,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_nested.subdir_9.63bd3dc96170cd4173f6130222e788f0.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_nested.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html
+++ b/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html
@@ -154,7 +154,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.subdir_9.63bd3dc96170cd4173f6130222e788f0.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <span class="nav-link nav-next disabled" title="Next file">

--- a/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -158,10 +158,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
+++ b/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
@@ -154,9 +154,9 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.D.de4bee21461092ca61985814ef11fc54.html" title="Previous file">
+      <span class="nav-link nav-prev disabled" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
-      </a>
+      </span>
       <a class="nav-link nav-next" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>

--- a/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -158,7 +158,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <a class="nav-link nav-next" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Next file">

--- a/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -157,7 +157,7 @@
       <a class="nav-link nav-prev" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -161,7 +161,7 @@
       <a class="nav-link nav-prev" href="coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -154,10 +154,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_nested.subdir_9.63bd3dc96170cd4173f6130222e788f0.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_nested.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/nested-theme-boost-green/gcc-5/coverage_nested.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html
+++ b/tests/html/reference/nested-theme-boost-green/gcc-5/coverage_nested.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html
@@ -150,7 +150,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.subdir_9.63bd3dc96170cd4173f6130222e788f0.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <span class="nav-link nav-next disabled" title="Next file">

--- a/tests/html/reference/nested-theme-boost-green/gcc-5/coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/html/reference/nested-theme-boost-green/gcc-5/coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -154,10 +154,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/nested-theme-boost-green/gcc-5/coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
+++ b/tests/html/reference/nested-theme-boost-green/gcc-5/coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html
@@ -150,9 +150,9 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.D.de4bee21461092ca61985814ef11fc54.html" title="Previous file">
+      <span class="nav-link nav-prev disabled" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
-      </a>
+      </span>
       <a class="nav-link nav-next" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>

--- a/tests/html/reference/nested-theme-boost-green/gcc-5/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/html/reference/nested-theme-boost-green/gcc-5/coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -154,7 +154,7 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
       <a class="nav-link nav-next" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Next file">

--- a/tests/html/reference/nested-theme-boost-green/gcc-5/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/html/reference/nested-theme-boost-green/gcc-5/coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -153,7 +153,7 @@
       <a class="nav-link nav-prev" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/nested-theme-boost-green/gcc-5/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/html/reference/nested-theme-boost-green/gcc-5/coverage_nested.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -157,7 +157,7 @@
       <a class="nav-link nav-prev" href="coverage_nested.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_nested.file1.cpp.11975e1ce5d9c157e76130f444523bea.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/nested-theme-boost-green/gcc-5/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/html/reference/nested-theme-boost-green/gcc-5/coverage_nested.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -150,10 +150,10 @@
       <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
     </div>
     <div class="source-nav-links">
-      <a class="nav-link nav-prev" href="coverage_nested.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html" title="Previous file">
+      <a class="nav-link nav-prev" href="coverage_nested.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html" title="Previous file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z" transform="rotate(180 8 8)"/></svg>
       </a>
-      <a class="nav-link nav-next" href="coverage_nested.subdir_9.63bd3dc96170cd4173f6130222e788f0.html" title="Next file">
+      <a class="nav-link nav-next" href="coverage_nested.File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html" title="Next file">
         <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M8 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 011.06-1.06l3.22 3.22V2.75A.75.75 0 018 2z"/></svg>
       </a>
     </div>

--- a/tests/html/reference/nested-theme-default-js/clang-10/coverage_single_page.html
+++ b/tests/html/reference/nested-theme-default-js/clang-10/coverage_single_page.html
@@ -1296,7 +1296,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </nav>
         <main>
 <script>
-  gcovr.default_content_id = "/";
+  gcovr.default_content_id = "coverage_single_page.html";
 </script>
 <hr class="js-disabled-hidden"/>
 <div id="functions.html" class="js-enabled-hidden js-disabled-hidden" data-title="Functions">
@@ -1384,7 +1384,7 @@ document.addEventListener("DOMContentLoaded", () => {
   </details>
 </div>
 
-<div id="" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
 <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
   </nav>
@@ -2044,7 +2044,7 @@ document.addEventListener("DOMContentLoaded", () => {
 </div>
   <hr class="js-enabled-hidden block-separator"/>
 </div>
-<div id="/" class="js-enabled-hidden js-disabled-hidden" data-title="">
+<div id="coverage_single_page.html" class="js-enabled-hidden js-disabled-hidden" data-title="">
   <nav>
 <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
   </nav>
@@ -2195,7 +2195,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#D.de4bee21461092ca61985814ef11fc54.html"></a>
+      <a class="nav prev" href="#coverage_single_page.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
     </div>
@@ -2352,7 +2352,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2512,9 +2512,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2674,7 +2674,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
@@ -2845,7 +2845,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -3047,9 +3047,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav next" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -3181,9 +3181,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav prev" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav next" href="#main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -3364,7 +3364,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav prev" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#coverage_single_page.html"></a>
     </div>

--- a/tests/html/reference/nested-theme-default-js/clang-12/coverage_single_page.html
+++ b/tests/html/reference/nested-theme-default-js/clang-12/coverage_single_page.html
@@ -1296,7 +1296,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </nav>
         <main>
 <script>
-  gcovr.default_content_id = "/";
+  gcovr.default_content_id = "coverage_single_page.html";
 </script>
 <hr class="js-disabled-hidden"/>
 <div id="functions.html" class="js-enabled-hidden js-disabled-hidden" data-title="Functions">
@@ -1384,7 +1384,7 @@ document.addEventListener("DOMContentLoaded", () => {
   </details>
 </div>
 
-<div id="" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
 <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
   </nav>
@@ -2044,7 +2044,7 @@ document.addEventListener("DOMContentLoaded", () => {
 </div>
   <hr class="js-enabled-hidden block-separator"/>
 </div>
-<div id="/" class="js-enabled-hidden js-disabled-hidden" data-title="">
+<div id="coverage_single_page.html" class="js-enabled-hidden js-disabled-hidden" data-title="">
   <nav>
 <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
   </nav>
@@ -2195,7 +2195,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#D.de4bee21461092ca61985814ef11fc54.html"></a>
+      <a class="nav prev" href="#coverage_single_page.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
     </div>
@@ -2352,7 +2352,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2512,9 +2512,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2674,7 +2674,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
@@ -2845,7 +2845,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -3047,9 +3047,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav next" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -3181,9 +3181,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav prev" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav next" href="#main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -3364,7 +3364,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav prev" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#coverage_single_page.html"></a>
     </div>

--- a/tests/html/reference/nested-theme-default-js/gcc-11/coverage_single_page.html
+++ b/tests/html/reference/nested-theme-default-js/gcc-11/coverage_single_page.html
@@ -1296,7 +1296,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </nav>
         <main>
 <script>
-  gcovr.default_content_id = "/";
+  gcovr.default_content_id = "coverage_single_page.html";
 </script>
 <hr class="js-disabled-hidden"/>
 <div id="functions.html" class="js-enabled-hidden js-disabled-hidden" data-title="Functions">
@@ -1384,7 +1384,7 @@ document.addEventListener("DOMContentLoaded", () => {
   </details>
 </div>
 
-<div id="" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
 <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
   </nav>
@@ -2044,7 +2044,7 @@ document.addEventListener("DOMContentLoaded", () => {
 </div>
   <hr class="js-enabled-hidden block-separator"/>
 </div>
-<div id="/" class="js-enabled-hidden js-disabled-hidden" data-title="">
+<div id="coverage_single_page.html" class="js-enabled-hidden js-disabled-hidden" data-title="">
   <nav>
 <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
   </nav>
@@ -2195,7 +2195,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#D.de4bee21461092ca61985814ef11fc54.html"></a>
+      <a class="nav prev" href="#coverage_single_page.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
     </div>
@@ -2352,7 +2352,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2512,9 +2512,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2674,7 +2674,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
@@ -2845,7 +2845,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -3047,9 +3047,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav next" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -3181,9 +3181,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav prev" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav next" href="#main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -3364,7 +3364,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav prev" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#coverage_single_page.html"></a>
     </div>

--- a/tests/html/reference/nested-theme-default-js/gcc-14/coverage_single_page.html
+++ b/tests/html/reference/nested-theme-default-js/gcc-14/coverage_single_page.html
@@ -1301,7 +1301,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </nav>
         <main>
 <script>
-  gcovr.default_content_id = "/";
+  gcovr.default_content_id = "coverage_single_page.html";
 </script>
 <hr class="js-disabled-hidden"/>
 <div id="functions.html" class="js-enabled-hidden js-disabled-hidden" data-title="Functions">
@@ -1400,7 +1400,7 @@ document.addEventListener("DOMContentLoaded", () => {
   </details>
 </div>
 
-<div id="" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
 <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
   </nav>
@@ -2180,7 +2180,7 @@ document.addEventListener("DOMContentLoaded", () => {
 </div>
   <hr class="js-enabled-hidden block-separator"/>
 </div>
-<div id="/" class="js-enabled-hidden js-disabled-hidden" data-title="">
+<div id="coverage_single_page.html" class="js-enabled-hidden js-disabled-hidden" data-title="">
   <nav>
 <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
   </nav>
@@ -2351,7 +2351,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#D.de4bee21461092ca61985814ef11fc54.html"></a>
+      <a class="nav prev" href="#coverage_single_page.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
     </div>
@@ -2534,7 +2534,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2726,9 +2726,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2920,7 +2920,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
@@ -3124,7 +3124,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -3366,9 +3366,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav next" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -3519,9 +3519,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav prev" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav next" href="#main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -3736,7 +3736,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav prev" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#coverage_single_page.html"></a>
     </div>

--- a/tests/html/reference/nested-theme-default-js/gcc-5/coverage_single_page.html
+++ b/tests/html/reference/nested-theme-default-js/gcc-5/coverage_single_page.html
@@ -1296,7 +1296,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </nav>
         <main>
 <script>
-  gcovr.default_content_id = "/";
+  gcovr.default_content_id = "coverage_single_page.html";
 </script>
 <hr class="js-disabled-hidden"/>
 <div id="functions.html" class="js-enabled-hidden js-disabled-hidden" data-title="Functions">
@@ -1384,7 +1384,7 @@ document.addEventListener("DOMContentLoaded", () => {
   </details>
 </div>
 
-<div id="" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
 <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
   </nav>
@@ -2044,7 +2044,7 @@ document.addEventListener("DOMContentLoaded", () => {
 </div>
   <hr class="js-enabled-hidden block-separator"/>
 </div>
-<div id="/" class="js-enabled-hidden js-disabled-hidden" data-title="">
+<div id="coverage_single_page.html" class="js-enabled-hidden js-disabled-hidden" data-title="">
   <nav>
 <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
   </nav>
@@ -2195,7 +2195,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#D.de4bee21461092ca61985814ef11fc54.html"></a>
+      <a class="nav prev" href="#coverage_single_page.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
     </div>
@@ -2352,7 +2352,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2512,9 +2512,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2674,7 +2674,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
@@ -2845,7 +2845,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -3047,9 +3047,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav next" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -3181,9 +3181,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav prev" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav next" href="#main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -3364,7 +3364,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav prev" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#coverage_single_page.html"></a>
     </div>

--- a/tests/html/reference/nested-theme-default-js/gcc-9/coverage_single_page.html
+++ b/tests/html/reference/nested-theme-default-js/gcc-9/coverage_single_page.html
@@ -1296,7 +1296,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </nav>
         <main>
 <script>
-  gcovr.default_content_id = "/";
+  gcovr.default_content_id = "coverage_single_page.html";
 </script>
 <hr class="js-disabled-hidden"/>
 <div id="functions.html" class="js-enabled-hidden js-disabled-hidden" data-title="Functions">
@@ -1384,7 +1384,7 @@ document.addEventListener("DOMContentLoaded", () => {
   </details>
 </div>
 
-<div id="" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
 <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
   </nav>
@@ -2044,7 +2044,7 @@ document.addEventListener("DOMContentLoaded", () => {
 </div>
   <hr class="js-enabled-hidden block-separator"/>
 </div>
-<div id="/" class="js-enabled-hidden js-disabled-hidden" data-title="">
+<div id="coverage_single_page.html" class="js-enabled-hidden js-disabled-hidden" data-title="">
   <nav>
 <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
   </nav>
@@ -2195,7 +2195,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#D.de4bee21461092ca61985814ef11fc54.html"></a>
+      <a class="nav prev" href="#coverage_single_page.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
     </div>
@@ -2352,7 +2352,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2512,9 +2512,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2674,7 +2674,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
@@ -2845,7 +2845,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -3047,9 +3047,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav next" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -3181,9 +3181,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav prev" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav next" href="#main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -3364,7 +3364,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav prev" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#coverage_single_page.html"></a>
     </div>

--- a/tests/html/reference/nested-theme-default-static/clang-10/coverage_single_page.html
+++ b/tests/html/reference/nested-theme-default-static/clang-10/coverage_single_page.html
@@ -142,7 +142,7 @@
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
   </nav>
 <div class="Box m-3 filelist">
@@ -442,7 +442,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#D.de4bee21461092ca61985814ef11fc54.html"></a>
+      <a class="nav prev" href="#coverage_single_page.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
     </div>
@@ -599,7 +599,7 @@
     <div class="nav">
       <a class="nav prev" href="#File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -759,9 +759,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -921,7 +921,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
@@ -1092,7 +1092,7 @@
     <div class="nav">
       <a class="nav prev" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1294,9 +1294,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav next" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1428,7 +1428,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav prev" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#coverage_single_page.html"></a>
     </div>

--- a/tests/html/reference/nested-theme-default-static/clang-12/coverage_single_page.html
+++ b/tests/html/reference/nested-theme-default-static/clang-12/coverage_single_page.html
@@ -142,7 +142,7 @@
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
   </nav>
 <div class="Box m-3 filelist">
@@ -442,7 +442,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#D.de4bee21461092ca61985814ef11fc54.html"></a>
+      <a class="nav prev" href="#coverage_single_page.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
     </div>
@@ -599,7 +599,7 @@
     <div class="nav">
       <a class="nav prev" href="#File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -759,9 +759,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -921,7 +921,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
@@ -1092,7 +1092,7 @@
     <div class="nav">
       <a class="nav prev" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1294,9 +1294,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav next" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1428,7 +1428,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav prev" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#coverage_single_page.html"></a>
     </div>

--- a/tests/html/reference/nested-theme-default-static/gcc-14/coverage_single_page.html
+++ b/tests/html/reference/nested-theme-default-static/gcc-14/coverage_single_page.html
@@ -157,7 +157,7 @@
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
   </nav>
 <div class="Box m-3 filelist">
@@ -507,7 +507,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#D.de4bee21461092ca61985814ef11fc54.html"></a>
+      <a class="nav prev" href="#coverage_single_page.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
     </div>
@@ -690,7 +690,7 @@
     <div class="nav">
       <a class="nav prev" href="#File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -882,9 +882,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1076,7 +1076,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
@@ -1280,7 +1280,7 @@
     <div class="nav">
       <a class="nav prev" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1522,9 +1522,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav next" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1675,7 +1675,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav prev" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#coverage_single_page.html"></a>
     </div>

--- a/tests/html/reference/nested-theme-default-static/gcc-5/coverage_single_page.html
+++ b/tests/html/reference/nested-theme-default-static/gcc-5/coverage_single_page.html
@@ -142,7 +142,7 @@
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
   </nav>
 <div class="Box m-3 filelist">
@@ -442,7 +442,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#D.de4bee21461092ca61985814ef11fc54.html"></a>
+      <a class="nav prev" href="#coverage_single_page.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
     </div>
@@ -599,7 +599,7 @@
     <div class="nav">
       <a class="nav prev" href="#File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -759,9 +759,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -921,7 +921,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
@@ -1092,7 +1092,7 @@
     <div class="nav">
       <a class="nav prev" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1294,9 +1294,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav next" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1428,7 +1428,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav prev" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#coverage_single_page.html"></a>
     </div>

--- a/tests/html/reference/nested-theme-github-js/clang-10/coverage_single_page.html
+++ b/tests/html/reference/nested-theme-github-js/clang-10/coverage_single_page.html
@@ -760,7 +760,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </nav>
         <main>
 <script>
-  gcovr.default_content_id = "/";
+  gcovr.default_content_id = "coverage_single_page.html";
 </script>
 <hr class="js-disabled-hidden"/>
 <div id="functions.html" class="js-enabled-hidden js-disabled-hidden" data-title="Functions">
@@ -848,7 +848,7 @@ document.addEventListener("DOMContentLoaded", () => {
   </details>
 </div>
 
-<div id="" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
 <div class="m-3">
   <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
@@ -1571,7 +1571,7 @@ document.addEventListener("DOMContentLoaded", () => {
 </div>
   <hr class="js-enabled-hidden block-separator"/>
 </div>
-<div id="/" class="js-enabled-hidden js-disabled-hidden" data-title="">
+<div id="coverage_single_page.html" class="js-enabled-hidden js-disabled-hidden" data-title="">
   <nav>
 <div class="m-3">
   <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
@@ -1724,7 +1724,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#D.de4bee21461092ca61985814ef11fc54.html"></a>
+      <a class="nav prev" href="#coverage_single_page.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
     </div>
@@ -1876,7 +1876,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2031,9 +2031,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2188,7 +2188,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
@@ -2354,7 +2354,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2551,9 +2551,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav next" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2680,9 +2680,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav prev" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav next" href="#main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2858,7 +2858,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav prev" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#coverage_single_page.html"></a>
     </div>

--- a/tests/html/reference/nested-theme-github-js/clang-12/coverage_single_page.html
+++ b/tests/html/reference/nested-theme-github-js/clang-12/coverage_single_page.html
@@ -760,7 +760,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </nav>
         <main>
 <script>
-  gcovr.default_content_id = "/";
+  gcovr.default_content_id = "coverage_single_page.html";
 </script>
 <hr class="js-disabled-hidden"/>
 <div id="functions.html" class="js-enabled-hidden js-disabled-hidden" data-title="Functions">
@@ -848,7 +848,7 @@ document.addEventListener("DOMContentLoaded", () => {
   </details>
 </div>
 
-<div id="" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
 <div class="m-3">
   <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
@@ -1571,7 +1571,7 @@ document.addEventListener("DOMContentLoaded", () => {
 </div>
   <hr class="js-enabled-hidden block-separator"/>
 </div>
-<div id="/" class="js-enabled-hidden js-disabled-hidden" data-title="">
+<div id="coverage_single_page.html" class="js-enabled-hidden js-disabled-hidden" data-title="">
   <nav>
 <div class="m-3">
   <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
@@ -1724,7 +1724,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#D.de4bee21461092ca61985814ef11fc54.html"></a>
+      <a class="nav prev" href="#coverage_single_page.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
     </div>
@@ -1876,7 +1876,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2031,9 +2031,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2188,7 +2188,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
@@ -2354,7 +2354,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2551,9 +2551,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav next" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2680,9 +2680,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav prev" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav next" href="#main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2858,7 +2858,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav prev" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#coverage_single_page.html"></a>
     </div>

--- a/tests/html/reference/nested-theme-github-js/gcc-11/coverage_single_page.html
+++ b/tests/html/reference/nested-theme-github-js/gcc-11/coverage_single_page.html
@@ -760,7 +760,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </nav>
         <main>
 <script>
-  gcovr.default_content_id = "/";
+  gcovr.default_content_id = "coverage_single_page.html";
 </script>
 <hr class="js-disabled-hidden"/>
 <div id="functions.html" class="js-enabled-hidden js-disabled-hidden" data-title="Functions">
@@ -848,7 +848,7 @@ document.addEventListener("DOMContentLoaded", () => {
   </details>
 </div>
 
-<div id="" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
 <div class="m-3">
   <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
@@ -1571,7 +1571,7 @@ document.addEventListener("DOMContentLoaded", () => {
 </div>
   <hr class="js-enabled-hidden block-separator"/>
 </div>
-<div id="/" class="js-enabled-hidden js-disabled-hidden" data-title="">
+<div id="coverage_single_page.html" class="js-enabled-hidden js-disabled-hidden" data-title="">
   <nav>
 <div class="m-3">
   <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
@@ -1724,7 +1724,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#D.de4bee21461092ca61985814ef11fc54.html"></a>
+      <a class="nav prev" href="#coverage_single_page.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
     </div>
@@ -1876,7 +1876,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2031,9 +2031,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2188,7 +2188,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
@@ -2354,7 +2354,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2551,9 +2551,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav next" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2680,9 +2680,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav prev" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav next" href="#main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2858,7 +2858,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav prev" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#coverage_single_page.html"></a>
     </div>

--- a/tests/html/reference/nested-theme-github-js/gcc-14/coverage_single_page.html
+++ b/tests/html/reference/nested-theme-github-js/gcc-14/coverage_single_page.html
@@ -765,7 +765,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </nav>
         <main>
 <script>
-  gcovr.default_content_id = "/";
+  gcovr.default_content_id = "coverage_single_page.html";
 </script>
 <hr class="js-disabled-hidden"/>
 <div id="functions.html" class="js-enabled-hidden js-disabled-hidden" data-title="Functions">
@@ -864,7 +864,7 @@ document.addEventListener("DOMContentLoaded", () => {
   </details>
 </div>
 
-<div id="" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
 <div class="m-3">
   <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
@@ -1707,7 +1707,7 @@ document.addEventListener("DOMContentLoaded", () => {
 </div>
   <hr class="js-enabled-hidden block-separator"/>
 </div>
-<div id="/" class="js-enabled-hidden js-disabled-hidden" data-title="">
+<div id="coverage_single_page.html" class="js-enabled-hidden js-disabled-hidden" data-title="">
   <nav>
 <div class="m-3">
   <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
@@ -1880,7 +1880,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#D.de4bee21461092ca61985814ef11fc54.html"></a>
+      <a class="nav prev" href="#coverage_single_page.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
     </div>
@@ -2058,7 +2058,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2245,9 +2245,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2434,7 +2434,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
@@ -2633,7 +2633,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2870,9 +2870,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav next" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -3018,9 +3018,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav prev" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav next" href="#main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -3230,7 +3230,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav prev" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#coverage_single_page.html"></a>
     </div>

--- a/tests/html/reference/nested-theme-github-js/gcc-5/coverage_single_page.html
+++ b/tests/html/reference/nested-theme-github-js/gcc-5/coverage_single_page.html
@@ -760,7 +760,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </nav>
         <main>
 <script>
-  gcovr.default_content_id = "/";
+  gcovr.default_content_id = "coverage_single_page.html";
 </script>
 <hr class="js-disabled-hidden"/>
 <div id="functions.html" class="js-enabled-hidden js-disabled-hidden" data-title="Functions">
@@ -848,7 +848,7 @@ document.addEventListener("DOMContentLoaded", () => {
   </details>
 </div>
 
-<div id="" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
 <div class="m-3">
   <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
@@ -1571,7 +1571,7 @@ document.addEventListener("DOMContentLoaded", () => {
 </div>
   <hr class="js-enabled-hidden block-separator"/>
 </div>
-<div id="/" class="js-enabled-hidden js-disabled-hidden" data-title="">
+<div id="coverage_single_page.html" class="js-enabled-hidden js-disabled-hidden" data-title="">
   <nav>
 <div class="m-3">
   <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
@@ -1724,7 +1724,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#D.de4bee21461092ca61985814ef11fc54.html"></a>
+      <a class="nav prev" href="#coverage_single_page.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
     </div>
@@ -1876,7 +1876,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2031,9 +2031,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2188,7 +2188,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
@@ -2354,7 +2354,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2551,9 +2551,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav next" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2680,9 +2680,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav prev" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav next" href="#main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2858,7 +2858,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav prev" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#coverage_single_page.html"></a>
     </div>

--- a/tests/html/reference/nested-theme-github-js/gcc-9/coverage_single_page.html
+++ b/tests/html/reference/nested-theme-github-js/gcc-9/coverage_single_page.html
@@ -760,7 +760,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </nav>
         <main>
 <script>
-  gcovr.default_content_id = "/";
+  gcovr.default_content_id = "coverage_single_page.html";
 </script>
 <hr class="js-disabled-hidden"/>
 <div id="functions.html" class="js-enabled-hidden js-disabled-hidden" data-title="Functions">
@@ -848,7 +848,7 @@ document.addEventListener("DOMContentLoaded", () => {
   </details>
 </div>
 
-<div id="" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
 <div class="m-3">
   <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
@@ -1571,7 +1571,7 @@ document.addEventListener("DOMContentLoaded", () => {
 </div>
   <hr class="js-enabled-hidden block-separator"/>
 </div>
-<div id="/" class="js-enabled-hidden js-disabled-hidden" data-title="">
+<div id="coverage_single_page.html" class="js-enabled-hidden js-disabled-hidden" data-title="">
   <nav>
 <div class="m-3">
   <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
@@ -1724,7 +1724,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#D.de4bee21461092ca61985814ef11fc54.html"></a>
+      <a class="nav prev" href="#coverage_single_page.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
     </div>
@@ -1876,7 +1876,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2031,9 +2031,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2188,7 +2188,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
@@ -2354,7 +2354,7 @@ document.addEventListener("DOMContentLoaded", () => {
     <div class="nav">
       <a class="nav prev" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2551,9 +2551,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav next" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2680,9 +2680,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav prev" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav next" href="#main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -2858,7 +2858,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#B.9d5ed678fe57bcca610140957afab571.html"></a>
+      <a class="nav prev" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#coverage_single_page.html"></a>
     </div>

--- a/tests/html/reference/nested-theme-github-static/clang-10/coverage_single_page.html
+++ b/tests/html/reference/nested-theme-github-static/clang-10/coverage_single_page.html
@@ -136,7 +136,7 @@
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
   </nav>
 <div class="Box m-3 filelist">
@@ -451,7 +451,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#D.de4bee21461092ca61985814ef11fc54.html"></a>
+      <a class="nav prev" href="#coverage_single_page.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
     </div>
@@ -603,7 +603,7 @@
     <div class="nav">
       <a class="nav prev" href="#File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -758,9 +758,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -915,7 +915,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
@@ -1081,7 +1081,7 @@
     <div class="nav">
       <a class="nav prev" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1278,9 +1278,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav next" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1407,7 +1407,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav prev" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#coverage_single_page.html"></a>
     </div>

--- a/tests/html/reference/nested-theme-github-static/clang-12/coverage_single_page.html
+++ b/tests/html/reference/nested-theme-github-static/clang-12/coverage_single_page.html
@@ -136,7 +136,7 @@
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
   </nav>
 <div class="Box m-3 filelist">
@@ -451,7 +451,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#D.de4bee21461092ca61985814ef11fc54.html"></a>
+      <a class="nav prev" href="#coverage_single_page.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
     </div>
@@ -603,7 +603,7 @@
     <div class="nav">
       <a class="nav prev" href="#File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -758,9 +758,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -915,7 +915,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
@@ -1081,7 +1081,7 @@
     <div class="nav">
       <a class="nav prev" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1278,9 +1278,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav next" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1407,7 +1407,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav prev" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#coverage_single_page.html"></a>
     </div>

--- a/tests/html/reference/nested-theme-github-static/gcc-14/coverage_single_page.html
+++ b/tests/html/reference/nested-theme-github-static/gcc-14/coverage_single_page.html
@@ -151,7 +151,7 @@
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
   </nav>
 <div class="Box m-3 filelist">
@@ -516,7 +516,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#D.de4bee21461092ca61985814ef11fc54.html"></a>
+      <a class="nav prev" href="#coverage_single_page.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
     </div>
@@ -694,7 +694,7 @@
     <div class="nav">
       <a class="nav prev" href="#File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -881,9 +881,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1070,7 +1070,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
@@ -1269,7 +1269,7 @@
     <div class="nav">
       <a class="nav prev" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1506,9 +1506,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav next" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1654,7 +1654,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav prev" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#coverage_single_page.html"></a>
     </div>

--- a/tests/html/reference/nested-theme-github-static/gcc-5/coverage_single_page.html
+++ b/tests/html/reference/nested-theme-github-static/gcc-5/coverage_single_page.html
@@ -136,7 +136,7 @@
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
   </nav>
 <div class="Box m-3 filelist">
@@ -451,7 +451,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#D.de4bee21461092ca61985814ef11fc54.html"></a>
+      <a class="nav prev" href="#coverage_single_page.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
     </div>
@@ -603,7 +603,7 @@
     <div class="nav">
       <a class="nav prev" href="#File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -758,9 +758,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -915,7 +915,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="#file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
@@ -1081,7 +1081,7 @@
     <div class="nav">
       <a class="nav prev" href="#file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1278,9 +1278,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="#File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="#"></a>
-      <a class="nav next" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav next" href="#File2.cpp.1aed42bd33fceec1188f2f95c6e8946c.html"></a>
     </div>
   </div>
   <div class="source-table-container">
@@ -1407,7 +1407,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="#subdir_9.63bd3dc96170cd4173f6130222e788f0.html"></a>
+      <a class="nav prev" href="#file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
       <a class="nav index" href="#"></a>
       <a class="nav next" href="#coverage_single_page.html"></a>
     </div>

--- a/tests/nested/reference/linked/clang-10/coverage.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
+++ b/tests/nested/reference/linked/clang-10/coverage.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
@@ -97,9 +97,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
+      <a class="nav prev" href="coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav next" href="coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/linked/clang-10/coverage.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
+++ b/tests/nested/reference/linked/clang-10/coverage.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
@@ -90,9 +90,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav prev" href="coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav next" href="coverage.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/linked/clang-10/coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
+++ b/tests/nested/reference/linked/clang-10/coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
@@ -90,9 +90,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav prev" href="coverage.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav next" href="coverage.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/linked/clang-10/coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
+++ b/tests/nested/reference/linked/clang-10/coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
@@ -97,9 +97,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav prev" href="coverage.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
+      <a class="nav next" href="coverage.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/linked/clang-10/coverage.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
+++ b/tests/nested/reference/linked/clang-10/coverage.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
@@ -92,7 +92,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav next" href="coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/linked/clang-10/coverage.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
+++ b/tests/nested/reference/linked/clang-10/coverage.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
@@ -90,7 +90,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav prev" href="coverage.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.main.cpp.13fb8fc771195717481a98e084ed0848.html"></a>
     </div>

--- a/tests/nested/reference/linked/clang-12/coverage.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
+++ b/tests/nested/reference/linked/clang-12/coverage.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
@@ -97,9 +97,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
+      <a class="nav prev" href="coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav next" href="coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/linked/clang-12/coverage.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
+++ b/tests/nested/reference/linked/clang-12/coverage.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
@@ -90,9 +90,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav prev" href="coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav next" href="coverage.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/linked/clang-12/coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
+++ b/tests/nested/reference/linked/clang-12/coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
@@ -90,9 +90,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav prev" href="coverage.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav next" href="coverage.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/linked/clang-12/coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
+++ b/tests/nested/reference/linked/clang-12/coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
@@ -97,9 +97,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav prev" href="coverage.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
+      <a class="nav next" href="coverage.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/linked/clang-12/coverage.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
+++ b/tests/nested/reference/linked/clang-12/coverage.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
@@ -92,7 +92,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav next" href="coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/linked/clang-12/coverage.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
+++ b/tests/nested/reference/linked/clang-12/coverage.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
@@ -90,7 +90,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav prev" href="coverage.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.main.cpp.13fb8fc771195717481a98e084ed0848.html"></a>
     </div>

--- a/tests/nested/reference/linked/clang-15-Darwin/coverage.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
+++ b/tests/nested/reference/linked/clang-15-Darwin/coverage.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
@@ -97,9 +97,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
+      <a class="nav prev" href="coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav next" href="coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/linked/clang-15-Darwin/coverage.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
+++ b/tests/nested/reference/linked/clang-15-Darwin/coverage.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
@@ -90,9 +90,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav prev" href="coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav next" href="coverage.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/linked/clang-15-Darwin/coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
+++ b/tests/nested/reference/linked/clang-15-Darwin/coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
@@ -90,9 +90,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav prev" href="coverage.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav next" href="coverage.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/linked/clang-15-Darwin/coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
+++ b/tests/nested/reference/linked/clang-15-Darwin/coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
@@ -97,9 +97,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav prev" href="coverage.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
+      <a class="nav next" href="coverage.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/linked/clang-15-Darwin/coverage.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
+++ b/tests/nested/reference/linked/clang-15-Darwin/coverage.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
@@ -92,7 +92,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav next" href="coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/linked/clang-15-Darwin/coverage.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
+++ b/tests/nested/reference/linked/clang-15-Darwin/coverage.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
@@ -90,7 +90,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav prev" href="coverage.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.main.cpp.13fb8fc771195717481a98e084ed0848.html"></a>
     </div>

--- a/tests/nested/reference/linked/clang-17-Darwin/coverage.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
+++ b/tests/nested/reference/linked/clang-17-Darwin/coverage.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
@@ -97,9 +97,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
+      <a class="nav prev" href="coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav next" href="coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/linked/clang-17-Darwin/coverage.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
+++ b/tests/nested/reference/linked/clang-17-Darwin/coverage.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
@@ -90,9 +90,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav prev" href="coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav next" href="coverage.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/linked/clang-17-Darwin/coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
+++ b/tests/nested/reference/linked/clang-17-Darwin/coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
@@ -90,9 +90,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav prev" href="coverage.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav next" href="coverage.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/linked/clang-17-Darwin/coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
+++ b/tests/nested/reference/linked/clang-17-Darwin/coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
@@ -97,9 +97,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav prev" href="coverage.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
+      <a class="nav next" href="coverage.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/linked/clang-17-Darwin/coverage.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
+++ b/tests/nested/reference/linked/clang-17-Darwin/coverage.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
@@ -92,7 +92,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav next" href="coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/linked/clang-17-Darwin/coverage.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
+++ b/tests/nested/reference/linked/clang-17-Darwin/coverage.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
@@ -90,7 +90,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav prev" href="coverage.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.main.cpp.13fb8fc771195717481a98e084ed0848.html"></a>
     </div>

--- a/tests/nested/reference/linked/gcc-14/coverage.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
+++ b/tests/nested/reference/linked/gcc-14/coverage.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
@@ -105,9 +105,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
+      <a class="nav prev" href="coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav next" href="coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/linked/gcc-14/coverage.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
+++ b/tests/nested/reference/linked/gcc-14/coverage.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
@@ -97,9 +97,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav prev" href="coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav next" href="coverage.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/linked/gcc-14/coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
+++ b/tests/nested/reference/linked/gcc-14/coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
@@ -97,9 +97,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav prev" href="coverage.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav next" href="coverage.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/linked/gcc-14/coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
+++ b/tests/nested/reference/linked/gcc-14/coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
@@ -105,9 +105,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav prev" href="coverage.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
+      <a class="nav next" href="coverage.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/linked/gcc-14/coverage.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
+++ b/tests/nested/reference/linked/gcc-14/coverage.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
@@ -99,7 +99,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav next" href="coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/linked/gcc-14/coverage.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
+++ b/tests/nested/reference/linked/gcc-14/coverage.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
@@ -97,7 +97,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav prev" href="coverage.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.main.cpp.13fb8fc771195717481a98e084ed0848.html"></a>
     </div>

--- a/tests/nested/reference/linked/gcc-5/coverage.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
+++ b/tests/nested/reference/linked/gcc-5/coverage.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html
@@ -97,9 +97,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
+      <a class="nav prev" href="coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav next" href="coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/linked/gcc-5/coverage.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
+++ b/tests/nested/reference/linked/gcc-5/coverage.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html
@@ -90,9 +90,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav prev" href="coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav next" href="coverage.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/linked/gcc-5/coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
+++ b/tests/nested/reference/linked/gcc-5/coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html
@@ -90,9 +90,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
+      <a class="nav prev" href="coverage.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav next" href="coverage.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/linked/gcc-5/coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
+++ b/tests/nested/reference/linked/gcc-5/coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html
@@ -97,9 +97,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
+      <a class="nav prev" href="coverage.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html"></a>
+      <a class="nav next" href="coverage.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/linked/gcc-5/coverage.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
+++ b/tests/nested/reference/linked/gcc-5/coverage.file5.cpp.cde4c7e07f79b4a315bd6b72e5bfe2dd.html
@@ -92,7 +92,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.File6.cpp.d50a8531ab312aa3faac8eaedb567137.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File2.cpp.0b63fd09c7d89df6cfd850bed4aef633.html"></a>
+      <a class="nav next" href="coverage.file1.cpp.46c73eeafdf12f5341eb32413a90169e.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/linked/gcc-5/coverage.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
+++ b/tests/nested/reference/linked/gcc-5/coverage.file7.cpp.f551d0ebeb9c429aba16ade7468659dd.html
@@ -90,7 +90,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file3.cpp.05c5eb887e5d0a7183edce836a6718cd.html"></a>
+      <a class="nav prev" href="coverage.File4.cpp.65a4d8d1a16f0b88f258c253517669ec.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.main.cpp.13fb8fc771195717481a98e084ed0848.html"></a>
     </div>

--- a/tests/nested/reference/oos/clang-10/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/nested/reference/oos/clang-10/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">2 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/oos/clang-10/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/nested/reference/oos/clang-10/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">1 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/oos/clang-10/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/nested/reference/oos/clang-10/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">1 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/oos/clang-10/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/nested/reference/oos/clang-10/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">2 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/oos/clang-10/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/nested/reference/oos/clang-10/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -97,7 +97,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/oos/clang-10/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/nested/reference/oos/clang-10/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">1 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>

--- a/tests/nested/reference/oos/clang-12/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/nested/reference/oos/clang-12/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">2 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/oos/clang-12/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/nested/reference/oos/clang-12/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">1 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/oos/clang-12/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/nested/reference/oos/clang-12/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">1 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/oos/clang-12/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/nested/reference/oos/clang-12/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">2 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/oos/clang-12/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/nested/reference/oos/clang-12/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -97,7 +97,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/oos/clang-12/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/nested/reference/oos/clang-12/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">1 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>

--- a/tests/nested/reference/oos/gcc-14/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/nested/reference/oos/gcc-14/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -110,9 +110,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">2 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/oos/gcc-14/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/nested/reference/oos/gcc-14/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">1 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/oos/gcc-14/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/nested/reference/oos/gcc-14/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">1 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/oos/gcc-14/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/nested/reference/oos/gcc-14/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -110,9 +110,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">2 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/oos/gcc-14/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/nested/reference/oos/gcc-14/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -104,7 +104,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/oos/gcc-14/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/nested/reference/oos/gcc-14/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -102,7 +102,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">1 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>

--- a/tests/nested/reference/oos/gcc-5/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/nested/reference/oos/gcc-5/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">2 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/oos/gcc-5/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/nested/reference/oos/gcc-5/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">1 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/oos/gcc-5/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/nested/reference/oos/gcc-5/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">1 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/oos/gcc-5/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/nested/reference/oos/gcc-5/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">2 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/oos/gcc-5/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/nested/reference/oos/gcc-5/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -97,7 +97,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/oos/gcc-5/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/nested/reference/oos/gcc-5/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">1 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>

--- a/tests/nested/reference/standard/clang-10/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/nested/reference/standard/clang-10/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/standard/clang-10/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/nested/reference/standard/clang-10/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/standard/clang-10/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/nested/reference/standard/clang-10/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/standard/clang-10/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/nested/reference/standard/clang-10/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/standard/clang-10/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/nested/reference/standard/clang-10/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -97,7 +97,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/standard/clang-10/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/nested/reference/standard/clang-10/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>

--- a/tests/nested/reference/standard/clang-12/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/nested/reference/standard/clang-12/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/standard/clang-12/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/nested/reference/standard/clang-12/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/standard/clang-12/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/nested/reference/standard/clang-12/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/standard/clang-12/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/nested/reference/standard/clang-12/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/standard/clang-12/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/nested/reference/standard/clang-12/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -97,7 +97,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/standard/clang-12/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/nested/reference/standard/clang-12/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>

--- a/tests/nested/reference/standard/gcc-14/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/nested/reference/standard/gcc-14/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -110,9 +110,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/standard/gcc-14/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/nested/reference/standard/gcc-14/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/standard/gcc-14/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/nested/reference/standard/gcc-14/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/standard/gcc-14/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/nested/reference/standard/gcc-14/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -110,9 +110,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/standard/gcc-14/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/nested/reference/standard/gcc-14/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -104,7 +104,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/standard/gcc-14/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/nested/reference/standard/gcc-14/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -102,7 +102,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>

--- a/tests/nested/reference/standard/gcc-5/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
+++ b/tests/nested/reference/standard/gcc-5/coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
+      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/standard/gcc-5/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
+++ b/tests/nested/reference/standard/gcc-5/coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/standard/gcc-5/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
+++ b/tests/nested/reference/standard/gcc-5/coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html
@@ -95,9 +95,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
+      <a class="nav prev" href="coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/standard/gcc-5/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
+++ b/tests/nested/reference/standard/gcc-5/coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html
@@ -102,9 +102,9 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
+      <a class="nav prev" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html"></a>
+      <a class="nav next" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/standard/gcc-5/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
+++ b/tests/nested/reference/standard/gcc-5/coverage.file5.cpp.4f0be33a4dcfe398ba897b87f58ca7ce.html
@@ -97,7 +97,7 @@
     <div class="nav">
       <a class="nav prev" href="coverage.File6.cpp.73326d74f2aeb2719dd6d8a9bcc3e582.html"></a>
       <a class="nav index" href="coverage.html"></a>
-      <a class="nav next" href="coverage.File2.cpp.79143a710ebe69deafa175a1453e33cd.html"></a>
+      <a class="nav next" href="coverage.file1.cpp.11975e1ce5d9c157e76130f444523bea.html"></a>
     </div>
   </div>
   <div class="source-table-container">

--- a/tests/nested/reference/standard/gcc-5/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
+++ b/tests/nested/reference/standard/gcc-5/coverage.file7.cpp.fa9d180b71a3402bed7d24bb1966eaf5.html
@@ -95,7 +95,7 @@
       <button type="button" class="button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">0 excluded</button>
     </div>
     <div class="nav">
-      <a class="nav prev" href="coverage.file3.cpp.bcfa344b5512d8cd5857f2fe86511d71.html"></a>
+      <a class="nav prev" href="coverage.File4.cpp.1d7a80554861eb8b5c21bc2e26ff8f70.html"></a>
       <a class="nav index" href="coverage.html"></a>
       <a class="nav next" href="coverage.main.cpp.9ddfb860fa969e91a7bb17e903455bce.html"></a>
     </div>

--- a/tests/template-function/reference/template-function/clang-10/coverage.html
+++ b/tests/template-function/reference/template-function/clang-10/coverage.html
@@ -1301,7 +1301,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </nav>
         <main>
 <script>
-  gcovr.default_content_id = "/";
+  gcovr.default_content_id = "gcovr-directory-root";
 </script>
 <hr class="js-disabled-hidden"/>
 <div id="functions.html" class="js-enabled-hidden js-disabled-hidden" data-title="Functions">
@@ -1347,7 +1347,7 @@ document.addEventListener("DOMContentLoaded", () => {
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
 <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
   </nav>

--- a/tests/template-function/reference/template-function/clang-10/coverage.merged.html
+++ b/tests/template-function/reference/template-function/clang-10/coverage.merged.html
@@ -1301,7 +1301,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </nav>
         <main>
 <script>
-  gcovr.default_content_id = "/";
+  gcovr.default_content_id = "gcovr-directory-root";
 </script>
 <hr class="js-disabled-hidden"/>
 <div id="merged.functions.html" class="js-enabled-hidden js-disabled-hidden" data-title="Functions">
@@ -1347,7 +1347,7 @@ document.addEventListener("DOMContentLoaded", () => {
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
 <a href="#merged.functions.html" class="js-disabled-hidden">List of functions</a>
   </nav>

--- a/tests/template-function/reference/template-function/clang-11/coverage.html
+++ b/tests/template-function/reference/template-function/clang-11/coverage.html
@@ -1301,7 +1301,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </nav>
         <main>
 <script>
-  gcovr.default_content_id = "/";
+  gcovr.default_content_id = "gcovr-directory-root";
 </script>
 <hr class="js-disabled-hidden"/>
 <div id="functions.html" class="js-enabled-hidden js-disabled-hidden" data-title="Functions">
@@ -1347,7 +1347,7 @@ document.addEventListener("DOMContentLoaded", () => {
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
 <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
   </nav>

--- a/tests/template-function/reference/template-function/clang-11/coverage.merged.html
+++ b/tests/template-function/reference/template-function/clang-11/coverage.merged.html
@@ -1301,7 +1301,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </nav>
         <main>
 <script>
-  gcovr.default_content_id = "/";
+  gcovr.default_content_id = "gcovr-directory-root";
 </script>
 <hr class="js-disabled-hidden"/>
 <div id="merged.functions.html" class="js-enabled-hidden js-disabled-hidden" data-title="Functions">
@@ -1347,7 +1347,7 @@ document.addEventListener("DOMContentLoaded", () => {
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
 <a href="#merged.functions.html" class="js-disabled-hidden">List of functions</a>
   </nav>

--- a/tests/template-function/reference/template-function/clang-12/coverage.html
+++ b/tests/template-function/reference/template-function/clang-12/coverage.html
@@ -1301,7 +1301,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </nav>
         <main>
 <script>
-  gcovr.default_content_id = "/";
+  gcovr.default_content_id = "gcovr-directory-root";
 </script>
 <hr class="js-disabled-hidden"/>
 <div id="functions.html" class="js-enabled-hidden js-disabled-hidden" data-title="Functions">
@@ -1347,7 +1347,7 @@ document.addEventListener("DOMContentLoaded", () => {
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
 <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
   </nav>

--- a/tests/template-function/reference/template-function/clang-12/coverage.merged.html
+++ b/tests/template-function/reference/template-function/clang-12/coverage.merged.html
@@ -1301,7 +1301,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </nav>
         <main>
 <script>
-  gcovr.default_content_id = "/";
+  gcovr.default_content_id = "gcovr-directory-root";
 </script>
 <hr class="js-disabled-hidden"/>
 <div id="merged.functions.html" class="js-enabled-hidden js-disabled-hidden" data-title="Functions">
@@ -1347,7 +1347,7 @@ document.addEventListener("DOMContentLoaded", () => {
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
 <a href="#merged.functions.html" class="js-disabled-hidden">List of functions</a>
   </nav>

--- a/tests/template-function/reference/template-function/clang-17-Darwin/coverage.html
+++ b/tests/template-function/reference/template-function/clang-17-Darwin/coverage.html
@@ -1301,7 +1301,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </nav>
         <main>
 <script>
-  gcovr.default_content_id = "/";
+  gcovr.default_content_id = "gcovr-directory-root";
 </script>
 <hr class="js-disabled-hidden"/>
 <div id="functions.html" class="js-enabled-hidden js-disabled-hidden" data-title="Functions">
@@ -1347,7 +1347,7 @@ document.addEventListener("DOMContentLoaded", () => {
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
 <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
   </nav>

--- a/tests/template-function/reference/template-function/clang-17-Darwin/coverage.merged.html
+++ b/tests/template-function/reference/template-function/clang-17-Darwin/coverage.merged.html
@@ -1301,7 +1301,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </nav>
         <main>
 <script>
-  gcovr.default_content_id = "/";
+  gcovr.default_content_id = "gcovr-directory-root";
 </script>
 <hr class="js-disabled-hidden"/>
 <div id="merged.functions.html" class="js-enabled-hidden js-disabled-hidden" data-title="Functions">
@@ -1347,7 +1347,7 @@ document.addEventListener("DOMContentLoaded", () => {
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
 <a href="#merged.functions.html" class="js-disabled-hidden">List of functions</a>
   </nav>

--- a/tests/template-function/reference/template-function/clang-18/coverage.html
+++ b/tests/template-function/reference/template-function/clang-18/coverage.html
@@ -1301,7 +1301,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </nav>
         <main>
 <script>
-  gcovr.default_content_id = "/";
+  gcovr.default_content_id = "gcovr-directory-root";
 </script>
 <hr class="js-disabled-hidden"/>
 <div id="functions.html" class="js-enabled-hidden js-disabled-hidden" data-title="Functions">
@@ -1347,7 +1347,7 @@ document.addEventListener("DOMContentLoaded", () => {
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
 <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
   </nav>

--- a/tests/template-function/reference/template-function/clang-18/coverage.merged.html
+++ b/tests/template-function/reference/template-function/clang-18/coverage.merged.html
@@ -1301,7 +1301,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </nav>
         <main>
 <script>
-  gcovr.default_content_id = "/";
+  gcovr.default_content_id = "gcovr-directory-root";
 </script>
 <hr class="js-disabled-hidden"/>
 <div id="merged.functions.html" class="js-enabled-hidden js-disabled-hidden" data-title="Functions">
@@ -1347,7 +1347,7 @@ document.addEventListener("DOMContentLoaded", () => {
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
 <a href="#merged.functions.html" class="js-disabled-hidden">List of functions</a>
   </nav>

--- a/tests/template-function/reference/template-function/gcc-14/coverage.html
+++ b/tests/template-function/reference/template-function/gcc-14/coverage.html
@@ -1306,7 +1306,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </nav>
         <main>
 <script>
-  gcovr.default_content_id = "/";
+  gcovr.default_content_id = "gcovr-directory-root";
 </script>
 <hr class="js-disabled-hidden"/>
 <div id="functions.html" class="js-enabled-hidden js-disabled-hidden" data-title="Functions">
@@ -1357,7 +1357,7 @@ document.addEventListener("DOMContentLoaded", () => {
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
 <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
   </nav>

--- a/tests/template-function/reference/template-function/gcc-14/coverage.merged.html
+++ b/tests/template-function/reference/template-function/gcc-14/coverage.merged.html
@@ -1306,7 +1306,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </nav>
         <main>
 <script>
-  gcovr.default_content_id = "/";
+  gcovr.default_content_id = "gcovr-directory-root";
 </script>
 <hr class="js-disabled-hidden"/>
 <div id="merged.functions.html" class="js-enabled-hidden js-disabled-hidden" data-title="Functions">
@@ -1357,7 +1357,7 @@ document.addEventListener("DOMContentLoaded", () => {
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
 <a href="#merged.functions.html" class="js-disabled-hidden">List of functions</a>
   </nav>

--- a/tests/template-function/reference/template-function/gcc-5/coverage.html
+++ b/tests/template-function/reference/template-function/gcc-5/coverage.html
@@ -1301,7 +1301,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </nav>
         <main>
 <script>
-  gcovr.default_content_id = "/";
+  gcovr.default_content_id = "gcovr-directory-root";
 </script>
 <hr class="js-disabled-hidden"/>
 <div id="functions.html" class="js-enabled-hidden js-disabled-hidden" data-title="Functions">
@@ -1347,7 +1347,7 @@ document.addEventListener("DOMContentLoaded", () => {
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
 <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
   </nav>

--- a/tests/template-function/reference/template-function/gcc-5/coverage.merged.html
+++ b/tests/template-function/reference/template-function/gcc-5/coverage.merged.html
@@ -1301,7 +1301,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </nav>
         <main>
 <script>
-  gcovr.default_content_id = "/";
+  gcovr.default_content_id = "gcovr-directory-root";
 </script>
 <hr class="js-disabled-hidden"/>
 <div id="merged.functions.html" class="js-enabled-hidden js-disabled-hidden" data-title="Functions">
@@ -1347,7 +1347,7 @@ document.addEventListener("DOMContentLoaded", () => {
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
 <a href="#merged.functions.html" class="js-disabled-hidden">List of functions</a>
   </nav>

--- a/tests/template-function/reference/template-function/gcc-8/coverage.html
+++ b/tests/template-function/reference/template-function/gcc-8/coverage.html
@@ -1301,7 +1301,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </nav>
         <main>
 <script>
-  gcovr.default_content_id = "/";
+  gcovr.default_content_id = "gcovr-directory-root";
 </script>
 <hr class="js-disabled-hidden"/>
 <div id="functions.html" class="js-enabled-hidden js-disabled-hidden" data-title="Functions">
@@ -1347,7 +1347,7 @@ document.addEventListener("DOMContentLoaded", () => {
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
 <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
   </nav>

--- a/tests/template-function/reference/template-function/gcc-8/coverage.merged.html
+++ b/tests/template-function/reference/template-function/gcc-8/coverage.merged.html
@@ -1301,7 +1301,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </nav>
         <main>
 <script>
-  gcovr.default_content_id = "/";
+  gcovr.default_content_id = "gcovr-directory-root";
 </script>
 <hr class="js-disabled-hidden"/>
 <div id="merged.functions.html" class="js-enabled-hidden js-disabled-hidden" data-title="Functions">
@@ -1347,7 +1347,7 @@ document.addEventListener("DOMContentLoaded", () => {
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
 <a href="#merged.functions.html" class="js-disabled-hidden">List of functions</a>
   </nav>

--- a/tests/template-function/reference/template-function/gcc-9/coverage.html
+++ b/tests/template-function/reference/template-function/gcc-9/coverage.html
@@ -1301,7 +1301,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </nav>
         <main>
 <script>
-  gcovr.default_content_id = "/";
+  gcovr.default_content_id = "gcovr-directory-root";
 </script>
 <hr class="js-disabled-hidden"/>
 <div id="functions.html" class="js-enabled-hidden js-disabled-hidden" data-title="Functions">
@@ -1347,7 +1347,7 @@ document.addEventListener("DOMContentLoaded", () => {
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
 <a href="#functions.html" class="js-disabled-hidden">List of functions</a>
   </nav>

--- a/tests/template-function/reference/template-function/gcc-9/coverage.merged.html
+++ b/tests/template-function/reference/template-function/gcc-9/coverage.merged.html
@@ -1301,7 +1301,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </nav>
         <main>
 <script>
-  gcovr.default_content_id = "/";
+  gcovr.default_content_id = "gcovr-directory-root";
 </script>
 <hr class="js-disabled-hidden"/>
 <div id="merged.functions.html" class="js-enabled-hidden js-disabled-hidden" data-title="Functions">
@@ -1347,7 +1347,7 @@ document.addEventListener("DOMContentLoaded", () => {
   </details>
 </div>
 
-<div id="/" class="js-enabled-hidden" data-title="">
+<div id="gcovr-directory-root" class="js-enabled-hidden" data-title="">
   <nav>
 <a href="#merged.functions.html" class="js-disabled-hidden">List of functions</a>
   </nav>


### PR DESCRIPTION
- Add `StrictUndefined` to all Jinja2 environments.
- Refactor HTML generation to have better reuse.
- Use always alphanumerical sort order for next/previous links. Do not
  use directories in links.