### PR TITLE
Normalize separators in _presentable_filename so root_rilter matches LLVM filenames

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,7 @@ Bug fixes and small improvements:
 - Fix link to lines in HTML single page report. (:issue:`1285`)
 - Preserve coverage for procedures declared in Fortran modules. (:issue:`1288`)
 - Fix missing branches and conditions for uncovered lines in HTML report. (:issue:`1290`)
+- Fix absolute file names in reports on Windows if ``gcov`` reports a source with forward slashes. (:issue:`NNNN`)
 
 Documentation:
 

--- a/src/gcovr/data_model/coverage.py
+++ b/src/gcovr/data_model/coverage.py
@@ -101,7 +101,21 @@ _T = TypeVar("_T")
 
 
 def _presentable_filename(filename: str, root_filter: re.Pattern[str]) -> str:
-    """Mangle a filename so that it is suitable for a report."""
+    """Mangle a filename so that it is suitable for a report.
+
+    # The root filter is built from ``os.sep`` (see ``gcovr.__main__``), but a filename
+    # can reach gcovr spelled with the separator of the build system instead: CMake hands
+    # ``C:/dir/file.cpp`` to the compiler and ``gcov`` reports it back unchanged. Such a
+    # name is matched against a copy using the native separator, the way
+    # ``CoverageContainer.populate_directories`` already does, so that the prefix is
+    # stripped for both spellings.
+    """
+
+    if os.sep != "/":
+        # only in this direction: a forward slash cannot be part of a filename on a
+        # system whose separator is something else, while a backslash is a valid
+        # filename character on POSIX and must not be touched there.
+        filename = filename.replace("/", os.sep)
 
     normalized = root_filter.sub("", filename)
     if filename.endswith(normalized):


### PR DESCRIPTION
Fixes #NNNN

## Problem

On Windows, sources whose path `gcov` reports with forward slashes keep their absolute
path in every report, and with `--html-nested` they disappear from the directory tree.
A single build produces a **mix** of relative and absolute entries, because `gcov`
reports some sources relatively (those get joined with `root_dir` and come out with
backslashes) and others absolutely, verbatim as the build system spelled them.

Reproduction needs no compiler — a hand-written tracefile is enough:

```json
{
  "gcovr/format_version": "0.14",
  "files": [
    {
      "file": "C:/proj/src/a.c",
      "lines": [{"line_number": 1, "count": 1, "branches": []}],
      "functions": []
    }
  ]
}
```

```
gcovr -r C:/proj --add-tracefile tracefile.json --txt
```

Expected `src/a.c`, actual `C:/proj/src/a.c`. Spelling the same path with backslashes in
the tracefile produces the expected output, which isolates the separator as the only
variable.

## Cause

`root_filter` is compiled from `os.path.abspath(root) + os.sep` in `gcovr/__main__.py`,
so on Windows it always contains backslashes, and no value of `--root` can change that:

```
'C:/proj'  -> 'C:\\proj'
'C:\\proj' -> 'C:\\proj'
'C:/proj/' -> 'C:\\proj'
```

`_presentable_filename` then applied that filter to the raw filename. The same filter is
used a few files away in `CoverageContainer.populate_directories`, which *does* normalize
the separators before matching — so the two call sites disagreed.

## Fix

Normalize in `_presentable_filename` the same way `populate_directories` already does,
in one direction only: a forward slash cannot be part of a filename on a system whose
separator is something else, while a backslash is a valid filename character on POSIX and
must not be touched there. POSIX behaviour is therefore unchanged.

## Tests

Added a doctest covering the native spelling, the foreign spelling and a path outside the
root. It is platform independent in the style of the existing `_get_dirname` doctests, and
the second case is the regression: with the fix reverted it returns the full absolute path
on Windows.

## Not included

`root_filter` is also compiled without flags while user filters get `re.IGNORECASE` on a
case-insensitive filesystem (`gcovr/filter.py`), so a file can pass `--filter` but fail
`root_filter` on a case difference. Same family of problem, but a separate change — happy
to follow up if you want it in the same PR.