### PR TITLE
Fix CodeQL security issue

### DIFF
--- a/.github/codeql.yml
+++ b/.github/codeql.yml
@@ -1,0 +1,4 @@
+---
+paths-ignore:
+  - src/gcovr/formats/html/common/gcovr.js
+  - src/gcovr/formats/html/boost/gcovr.js

--- a/noxfile.py
+++ b/noxfile.py
@@ -638,7 +638,9 @@ def html2jpeg(session: nox.Session) -> None:
 
             content = re.sub(
                 r'<link rel="stylesheet" href="([^"]+)"/>',
-                lambda match: f'<style type="text/css">{read_file(os.path.join(os.path.dirname(html), match[1]))}</style>',
+                lambda match: (
+                    f'<style type="text/css">{read_file(os.path.join(os.path.dirname(html), match[1]))}</style>'
+                ),
                 read_file(html),
             )
             payload: requests._types.JsonType = {

--- a/src/gcovr/formats/gcov/read.py
+++ b/src/gcovr/formats/gcov/read.py
@@ -124,8 +124,9 @@ def find_existing_gcov_files(
         LOGGER.debug("Scanning directory %s for gcov files...", search_path)
         gcov_files = list(
             search_file(
-                lambda fname: re.compile(r".*\.gcov(?:\.json\.gz)?$").match(fname)
-                is not None,
+                lambda fname: (
+                    re.compile(r".*\.gcov(?:\.json\.gz)?$").match(fname) is not None
+                ),
                 search_path,
                 exclude_directory=exclude_directory,
             )

--- a/src/gcovr/formats/html/boost/functions_page.content.html
+++ b/src/gcovr/formats/html/boost/functions_page.content.html
@@ -23,8 +23,8 @@
   </div>
 </div>
 
-<script type="application/json" id="functions-data">
-[
+<script>
+window.GCOVR_FUNCTION_DATA = [
   {% for entry in function_list %}
   {% if not loop.first %},{% endif %}
   {
@@ -45,8 +45,6 @@
 </script>
 <script>
   window.__functionsPageConfig = {
-    singlePage: {{ "true" if info.single_page else "false" }},
-    htmlFilename: "{{ html_filename | default("") }}",
     showBranches: {{ "true" if info.branches.total > info.branches.excluded else "false" }},
     showConditions: {{ "true" if SHOW_CONDITION_COVERAGE else "false" }},
     showDecisions: {{ "true" if SHOW_DECISION else "false" }},

--- a/src/gcovr/formats/html/boost/gcovr.js
+++ b/src/gcovr/formats/html/boost/gcovr.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);
@@ -1460,7 +1453,7 @@
         row.appendChild(colCalls);
       }
 
-{% if info.diff_report %}
+/* {% if info.diff_report %} */
       var colDiff = document.createElement('div');
       colDiff.className = 'col-diff';
       var diffVal = document.createElement('span');
@@ -1469,7 +1462,7 @@
       diffVal.textContent = diffText;
       colDiff.appendChild(diffVal);
       row.appendChild(colDiff);
-{% endif %}
+/* {% endif %} */
 
       return row;
     }

--- a/src/gcovr/formats/html/common/gcovr.js
+++ b/src/gcovr/formats/html/common/gcovr.js
@@ -17,12 +17,12 @@ gcovr.fileLoaded = function () {
 
   gcovr.addOnClickHandler("div.sortable", gcovr.sortGridTable);
 
-  {% if info.single_page %}
+/* {% if info.single_page %} */
   gcovr.singlePageSetup();
-  {% else %}
+/* {% else %} */
   gcovr.source_table_body = document.querySelector(".source-table-container > table > tbody")
   gcovr.initScrollMarkers();
-  {% endif %}
+/* {% endif %} */
   window.addEventListener("resize", () => {
     gcovr.initScrollMarkers();
   });
@@ -35,7 +35,7 @@ gcovr.addOnClickHandler = function (selector, handler) {
   });
 };
 
-{% if info.single_page %}
+/* {% if info.single_page %} */
 gcovr.singlePageSetup = function () {
   document.body.classList.add("js-enabled")
   document.body.classList.remove("js-disabled")
@@ -115,7 +115,7 @@ gcovr.singlePageActivateElement = function () {
     gcovr.initScrollMarkers();
   }
 };
-{% endif %}
+/* {% endif %} */
 
 gcovr.toggleLines = function (event) {
   const btn = event.target.closest("button");

--- a/src/gcovr/formats/html/write.py
+++ b/src/gcovr/formats/html/write.py
@@ -562,7 +562,11 @@ def write_report(
     javascript_data = (
         None
         if options.html_static_report
-        else theme_environment(options).get_template("gcovr.js").render(**data).strip()
+        else re.sub(
+            r"/\*\s*\*/\n",  # Remove empty comments which are a leftover around jinja2 directives
+            "",
+            theme_environment(options).get_template("gcovr.js").render(**data),
+        ).strip()
     )
 
     if self_contained:

--- a/tests/.gitattributes
+++ b/tests/.gitattributes
@@ -8,6 +8,8 @@
 # (While linguist-generated might be appropriate here,
 # that attribute would also suppress diffs on GH. Can't have that!)
 */reference/**/*.* linguist-detectable=false
+*/source/*.*       linguist-detectable=false
+*/source/**/*.*    linguist-detectable=false
 **/Makefile        linguist-detectable=false
 **/CMakeLists.txt  linguist-detectable=false
 **/*.cmd           linguist-detectable=false

--- a/tests/compare/reference/changed/clang-10/coverage.boost.functions.html
+++ b/tests/compare/reference/changed/clang-10/coverage.boost.functions.html
@@ -129,8 +129,8 @@
   </div>
 </div>
 
-<script type="application/json" id="functions-data">
-[
+<script>
+window.GCOVR_FUNCTION_DATA = [
   {
     "name": "_Z3barv",
     "filename": "subdir/A/File2.cpp",
@@ -265,8 +265,6 @@
 </script>
 <script>
   window.__functionsPageConfig = {
-    singlePage: false,
-    htmlFilename: "",
     showBranches: true,
     showConditions: false,
     showDecisions: false,

--- a/tests/compare/reference/changed/clang-10/coverage.boost.js
+++ b/tests/compare/reference/changed/clang-10/coverage.boost.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/compare/reference/changed/clang-12/coverage.boost.functions.html
+++ b/tests/compare/reference/changed/clang-12/coverage.boost.functions.html
@@ -129,8 +129,8 @@
   </div>
 </div>
 
-<script type="application/json" id="functions-data">
-[
+<script>
+window.GCOVR_FUNCTION_DATA = [
   {
     "name": "bar()",
     "filename": "subdir/A/File2.cpp",
@@ -265,8 +265,6 @@
 </script>
 <script>
   window.__functionsPageConfig = {
-    singlePage: false,
-    htmlFilename: "",
     showBranches: true,
     showConditions: false,
     showDecisions: false,

--- a/tests/compare/reference/changed/clang-12/coverage.boost.js
+++ b/tests/compare/reference/changed/clang-12/coverage.boost.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/compare/reference/changed/gcc-11/coverage.boost.js
+++ b/tests/compare/reference/changed/gcc-11/coverage.boost.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/compare/reference/changed/gcc-14-Windows/coverage.boost.js
+++ b/tests/compare/reference/changed/gcc-14-Windows/coverage.boost.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/compare/reference/changed/gcc-14/coverage.boost.functions.html
+++ b/tests/compare/reference/changed/gcc-14/coverage.boost.functions.html
@@ -130,8 +130,8 @@
   </div>
 </div>
 
-<script type="application/json" id="functions-data">
-[
+<script>
+window.GCOVR_FUNCTION_DATA = [
   {
     "name": "bar()",
     "filename": "subdir/A/File2.cpp",
@@ -266,8 +266,6 @@
 </script>
 <script>
   window.__functionsPageConfig = {
-    singlePage: false,
-    htmlFilename: "",
     showBranches: true,
     showConditions: true,
     showDecisions: false,

--- a/tests/compare/reference/changed/gcc-14/coverage.boost.js
+++ b/tests/compare/reference/changed/gcc-14/coverage.boost.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/compare/reference/changed/gcc-15-Windows/coverage.boost.js
+++ b/tests/compare/reference/changed/gcc-15-Windows/coverage.boost.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/compare/reference/changed/gcc-5/coverage.boost.functions.html
+++ b/tests/compare/reference/changed/gcc-5/coverage.boost.functions.html
@@ -129,8 +129,8 @@
   </div>
 </div>
 
-<script type="application/json" id="functions-data">
-[
+<script>
+window.GCOVR_FUNCTION_DATA = [
   {
     "name": "bar()",
     "filename": "subdir/A/File2.cpp",
@@ -265,8 +265,6 @@
 </script>
 <script>
   window.__functionsPageConfig = {
-    singlePage: false,
-    htmlFilename: "",
     showBranches: true,
     showConditions: false,
     showDecisions: false,

--- a/tests/compare/reference/changed/gcc-5/coverage.boost.js
+++ b/tests/compare/reference/changed/gcc-5/coverage.boost.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/compare/reference/changed/gcc-9/coverage.boost.js
+++ b/tests/compare/reference/changed/gcc-9/coverage.boost.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/compare/reference/equal/clang-10/coverage.boost.functions.html
+++ b/tests/compare/reference/equal/clang-10/coverage.boost.functions.html
@@ -129,8 +129,8 @@
   </div>
 </div>
 
-<script type="application/json" id="functions-data">
-[
+<script>
+window.GCOVR_FUNCTION_DATA = [
   {
     "name": "_Z3barv",
     "filename": "subdir/A/File2.cpp",
@@ -265,8 +265,6 @@
 </script>
 <script>
   window.__functionsPageConfig = {
-    singlePage: false,
-    htmlFilename: "",
     showBranches: true,
     showConditions: false,
     showDecisions: false,

--- a/tests/compare/reference/equal/clang-10/coverage.boost.js
+++ b/tests/compare/reference/equal/clang-10/coverage.boost.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/compare/reference/equal/clang-12/coverage.boost.functions.html
+++ b/tests/compare/reference/equal/clang-12/coverage.boost.functions.html
@@ -129,8 +129,8 @@
   </div>
 </div>
 
-<script type="application/json" id="functions-data">
-[
+<script>
+window.GCOVR_FUNCTION_DATA = [
   {
     "name": "bar()",
     "filename": "subdir/A/File2.cpp",
@@ -265,8 +265,6 @@
 </script>
 <script>
   window.__functionsPageConfig = {
-    singlePage: false,
-    htmlFilename: "",
     showBranches: true,
     showConditions: false,
     showDecisions: false,

--- a/tests/compare/reference/equal/clang-12/coverage.boost.js
+++ b/tests/compare/reference/equal/clang-12/coverage.boost.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/compare/reference/equal/gcc-11/coverage.boost.js
+++ b/tests/compare/reference/equal/gcc-11/coverage.boost.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/compare/reference/equal/gcc-14-Windows/coverage.boost.js
+++ b/tests/compare/reference/equal/gcc-14-Windows/coverage.boost.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/compare/reference/equal/gcc-14/coverage.boost.functions.html
+++ b/tests/compare/reference/equal/gcc-14/coverage.boost.functions.html
@@ -130,8 +130,8 @@
   </div>
 </div>
 
-<script type="application/json" id="functions-data">
-[
+<script>
+window.GCOVR_FUNCTION_DATA = [
   {
     "name": "bar()",
     "filename": "subdir/A/File2.cpp",
@@ -266,8 +266,6 @@
 </script>
 <script>
   window.__functionsPageConfig = {
-    singlePage: false,
-    htmlFilename: "",
     showBranches: true,
     showConditions: true,
     showDecisions: false,

--- a/tests/compare/reference/equal/gcc-14/coverage.boost.js
+++ b/tests/compare/reference/equal/gcc-14/coverage.boost.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/compare/reference/equal/gcc-15-Windows/coverage.boost.js
+++ b/tests/compare/reference/equal/gcc-15-Windows/coverage.boost.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/compare/reference/equal/gcc-5/coverage.boost.functions.html
+++ b/tests/compare/reference/equal/gcc-5/coverage.boost.functions.html
@@ -129,8 +129,8 @@
   </div>
 </div>
 
-<script type="application/json" id="functions-data">
-[
+<script>
+window.GCOVR_FUNCTION_DATA = [
   {
     "name": "bar()",
     "filename": "subdir/A/File2.cpp",
@@ -265,8 +265,6 @@
 </script>
 <script>
   window.__functionsPageConfig = {
-    singlePage: false,
-    htmlFilename: "",
     showBranches: true,
     showConditions: false,
     showDecisions: false,

--- a/tests/compare/reference/equal/gcc-5/coverage.boost.js
+++ b/tests/compare/reference/equal/gcc-5/coverage.boost.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/compare/reference/equal/gcc-9/coverage.boost.js
+++ b/tests/compare/reference/equal/gcc-9/coverage.boost.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/exclusion/reference/exclude-line-branch/clang-10/coverage.boost.functions.html
+++ b/tests/exclusion/reference/exclude-line-branch/clang-10/coverage.boost.functions.html
@@ -129,8 +129,8 @@
   </div>
 </div>
 
-<script type="application/json" id="functions-data">
-[
+<script>
+window.GCOVR_FUNCTION_DATA = [
   {
     "name": "_Z3bari",
     "filename": "exclude-line-branch/bar.cpp",
@@ -213,8 +213,6 @@
 </script>
 <script>
   window.__functionsPageConfig = {
-    singlePage: false,
-    htmlFilename: "",
     showBranches: false,
     showConditions: false,
     showDecisions: false,

--- a/tests/exclusion/reference/exclude-line-branch/clang-10/coverage.boost.js
+++ b/tests/exclusion/reference/exclude-line-branch/clang-10/coverage.boost.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/exclusion/reference/exclude-line-branch/clang-11/coverage.boost.js
+++ b/tests/exclusion/reference/exclude-line-branch/clang-11/coverage.boost.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/exclusion/reference/exclude-line-branch/clang-12/coverage.boost.functions.html
+++ b/tests/exclusion/reference/exclude-line-branch/clang-12/coverage.boost.functions.html
@@ -129,8 +129,8 @@
   </div>
 </div>
 
-<script type="application/json" id="functions-data">
-[
+<script>
+window.GCOVR_FUNCTION_DATA = [
   {
     "name": "Bar::Bar()",
     "filename": "exclude-line-branch/main.cpp",
@@ -200,8 +200,6 @@
 </script>
 <script>
   window.__functionsPageConfig = {
-    singlePage: false,
-    htmlFilename: "",
     showBranches: false,
     showConditions: false,
     showDecisions: false,

--- a/tests/exclusion/reference/exclude-line-branch/clang-12/coverage.boost.js
+++ b/tests/exclusion/reference/exclude-line-branch/clang-12/coverage.boost.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/exclusion/reference/exclude-line-branch/gcc-11/coverage.boost.js
+++ b/tests/exclusion/reference/exclude-line-branch/gcc-11/coverage.boost.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/exclusion/reference/exclude-line-branch/gcc-14/coverage.boost.functions.html
+++ b/tests/exclusion/reference/exclude-line-branch/gcc-14/coverage.boost.functions.html
@@ -130,8 +130,8 @@
   </div>
 </div>
 
-<script type="application/json" id="functions-data">
-[
+<script>
+window.GCOVR_FUNCTION_DATA = [
   {
     "name": "Bar::Bar()",
     "filename": "exclude-line-branch/main.cpp",
@@ -201,8 +201,6 @@
 </script>
 <script>
   window.__functionsPageConfig = {
-    singlePage: false,
-    htmlFilename: "",
     showBranches: false,
     showConditions: true,
     showDecisions: false,

--- a/tests/exclusion/reference/exclude-line-branch/gcc-14/coverage.boost.js
+++ b/tests/exclusion/reference/exclude-line-branch/gcc-14/coverage.boost.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/exclusion/reference/exclude-line-branch/gcc-5/coverage.boost.functions.html
+++ b/tests/exclusion/reference/exclude-line-branch/gcc-5/coverage.boost.functions.html
@@ -129,8 +129,8 @@
   </div>
 </div>
 
-<script type="application/json" id="functions-data">
-[
+<script>
+window.GCOVR_FUNCTION_DATA = [
   {
     "name": "Bar::Bar()",
     "filename": "exclude-line-branch/main.cpp",
@@ -200,8 +200,6 @@
 </script>
 <script>
   window.__functionsPageConfig = {
-    singlePage: false,
-    htmlFilename: "",
     showBranches: false,
     showConditions: false,
     showDecisions: false,

--- a/tests/exclusion/reference/exclude-line-branch/gcc-5/coverage.boost.js
+++ b/tests/exclusion/reference/exclude-line-branch/gcc-5/coverage.boost.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/exclusion/reference/exclude-line-branch/gcc-6/coverage.boost.functions.html
+++ b/tests/exclusion/reference/exclude-line-branch/gcc-6/coverage.boost.functions.html
@@ -129,8 +129,8 @@
   </div>
 </div>
 
-<script type="application/json" id="functions-data">
-[
+<script>
+window.GCOVR_FUNCTION_DATA = [
   {
     "name": "Bar::Bar()",
     "filename": "exclude-line-branch/main.cpp",
@@ -200,8 +200,6 @@
 </script>
 <script>
   window.__functionsPageConfig = {
-    singlePage: false,
-    htmlFilename: "",
     showBranches: false,
     showConditions: false,
     showDecisions: false,

--- a/tests/exclusion/reference/exclude-line-branch/gcc-6/coverage.boost.js
+++ b/tests/exclusion/reference/exclude-line-branch/gcc-6/coverage.boost.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/exclusion/reference/exclude-line-branch/gcc-8/coverage.boost.functions.html
+++ b/tests/exclusion/reference/exclude-line-branch/gcc-8/coverage.boost.functions.html
@@ -129,8 +129,8 @@
   </div>
 </div>
 
-<script type="application/json" id="functions-data">
-[
+<script>
+window.GCOVR_FUNCTION_DATA = [
   {
     "name": "Bar::Bar()",
     "filename": "exclude-line-branch/main.cpp",
@@ -200,8 +200,6 @@
 </script>
 <script>
   window.__functionsPageConfig = {
-    singlePage: false,
-    htmlFilename: "",
     showBranches: false,
     showConditions: false,
     showDecisions: false,

--- a/tests/exclusion/reference/exclude-line-branch/gcc-8/coverage.boost.js
+++ b/tests/exclusion/reference/exclude-line-branch/gcc-8/coverage.boost.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/html/reference/details-theme-boost-blue/clang-10/coverage_details.functions.html
+++ b/tests/html/reference/details-theme-boost-blue/clang-10/coverage_details.functions.html
@@ -68,8 +68,8 @@
   </div>
 </div>
 
-<script type="application/json" id="functions-data">
-[
+<script>
+window.GCOVR_FUNCTION_DATA = [
   {
     "name": "_Z3barv",
     "filename": "A/subdir_0/subdir_1/subdir_2/subdir_3/subdir_4/subdir_5/subdir_6/subdir_7/subdir_8/subdir_9/File2.cpp",
@@ -191,8 +191,6 @@
 </script>
 <script>
   window.__functionsPageConfig = {
-    singlePage: false,
-    htmlFilename: "",
     showBranches: true,
     showConditions: false,
     showDecisions: false,

--- a/tests/html/reference/details-theme-boost-blue/clang-10/coverage_details.js
+++ b/tests/html/reference/details-theme-boost-blue/clang-10/coverage_details.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/html/reference/details-theme-boost-blue/clang-12/coverage_details.functions.html
+++ b/tests/html/reference/details-theme-boost-blue/clang-12/coverage_details.functions.html
@@ -68,8 +68,8 @@
   </div>
 </div>
 
-<script type="application/json" id="functions-data">
-[
+<script>
+window.GCOVR_FUNCTION_DATA = [
   {
     "name": "bar()",
     "filename": "A/subdir_0/subdir_1/subdir_2/subdir_3/subdir_4/subdir_5/subdir_6/subdir_7/subdir_8/subdir_9/File2.cpp",
@@ -191,8 +191,6 @@
 </script>
 <script>
   window.__functionsPageConfig = {
-    singlePage: false,
-    htmlFilename: "",
     showBranches: true,
     showConditions: false,
     showDecisions: false,

--- a/tests/html/reference/details-theme-boost-blue/clang-12/coverage_details.js
+++ b/tests/html/reference/details-theme-boost-blue/clang-12/coverage_details.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/html/reference/details-theme-boost-blue/gcc-14/coverage_details.functions.html
+++ b/tests/html/reference/details-theme-boost-blue/gcc-14/coverage_details.functions.html
@@ -69,8 +69,8 @@
   </div>
 </div>
 
-<script type="application/json" id="functions-data">
-[
+<script>
+window.GCOVR_FUNCTION_DATA = [
   {
     "name": "bar()",
     "filename": "A/subdir_0/subdir_1/subdir_2/subdir_3/subdir_4/subdir_5/subdir_6/subdir_7/subdir_8/subdir_9/File2.cpp",
@@ -192,8 +192,6 @@
 </script>
 <script>
   window.__functionsPageConfig = {
-    singlePage: false,
-    htmlFilename: "",
     showBranches: true,
     showConditions: true,
     showDecisions: false,

--- a/tests/html/reference/details-theme-boost-blue/gcc-14/coverage_details.js
+++ b/tests/html/reference/details-theme-boost-blue/gcc-14/coverage_details.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/html/reference/details-theme-boost-blue/gcc-5/coverage_details.functions.html
+++ b/tests/html/reference/details-theme-boost-blue/gcc-5/coverage_details.functions.html
@@ -68,8 +68,8 @@
   </div>
 </div>
 
-<script type="application/json" id="functions-data">
-[
+<script>
+window.GCOVR_FUNCTION_DATA = [
   {
     "name": "bar()",
     "filename": "A/subdir_0/subdir_1/subdir_2/subdir_3/subdir_4/subdir_5/subdir_6/subdir_7/subdir_8/subdir_9/File2.cpp",
@@ -191,8 +191,6 @@
 </script>
 <script>
   window.__functionsPageConfig = {
-    singlePage: false,
-    htmlFilename: "",
     showBranches: true,
     showConditions: false,
     showDecisions: false,

--- a/tests/html/reference/details-theme-boost-blue/gcc-5/coverage_details.js
+++ b/tests/html/reference/details-theme-boost-blue/gcc-5/coverage_details.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/html/reference/details-theme-boost-green/clang-10/coverage_details.functions.html
+++ b/tests/html/reference/details-theme-boost-green/clang-10/coverage_details.functions.html
@@ -68,8 +68,8 @@
   </div>
 </div>
 
-<script type="application/json" id="functions-data">
-[
+<script>
+window.GCOVR_FUNCTION_DATA = [
   {
     "name": "_Z3barv",
     "filename": "A/subdir_0/subdir_1/subdir_2/subdir_3/subdir_4/subdir_5/subdir_6/subdir_7/subdir_8/subdir_9/File2.cpp",
@@ -191,8 +191,6 @@
 </script>
 <script>
   window.__functionsPageConfig = {
-    singlePage: false,
-    htmlFilename: "",
     showBranches: true,
     showConditions: false,
     showDecisions: false,

--- a/tests/html/reference/details-theme-boost-green/clang-10/coverage_details.js
+++ b/tests/html/reference/details-theme-boost-green/clang-10/coverage_details.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/html/reference/details-theme-boost-green/clang-12/coverage_details.functions.html
+++ b/tests/html/reference/details-theme-boost-green/clang-12/coverage_details.functions.html
@@ -68,8 +68,8 @@
   </div>
 </div>
 
-<script type="application/json" id="functions-data">
-[
+<script>
+window.GCOVR_FUNCTION_DATA = [
   {
     "name": "bar()",
     "filename": "A/subdir_0/subdir_1/subdir_2/subdir_3/subdir_4/subdir_5/subdir_6/subdir_7/subdir_8/subdir_9/File2.cpp",
@@ -191,8 +191,6 @@
 </script>
 <script>
   window.__functionsPageConfig = {
-    singlePage: false,
-    htmlFilename: "",
     showBranches: true,
     showConditions: false,
     showDecisions: false,

--- a/tests/html/reference/details-theme-boost-green/clang-12/coverage_details.js
+++ b/tests/html/reference/details-theme-boost-green/clang-12/coverage_details.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/html/reference/details-theme-boost-green/gcc-14/coverage_details.functions.html
+++ b/tests/html/reference/details-theme-boost-green/gcc-14/coverage_details.functions.html
@@ -69,8 +69,8 @@
   </div>
 </div>
 
-<script type="application/json" id="functions-data">
-[
+<script>
+window.GCOVR_FUNCTION_DATA = [
   {
     "name": "bar()",
     "filename": "A/subdir_0/subdir_1/subdir_2/subdir_3/subdir_4/subdir_5/subdir_6/subdir_7/subdir_8/subdir_9/File2.cpp",
@@ -192,8 +192,6 @@
 </script>
 <script>
   window.__functionsPageConfig = {
-    singlePage: false,
-    htmlFilename: "",
     showBranches: true,
     showConditions: true,
     showDecisions: false,

--- a/tests/html/reference/details-theme-boost-green/gcc-14/coverage_details.js
+++ b/tests/html/reference/details-theme-boost-green/gcc-14/coverage_details.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/html/reference/details-theme-boost-green/gcc-5/coverage_details.functions.html
+++ b/tests/html/reference/details-theme-boost-green/gcc-5/coverage_details.functions.html
@@ -68,8 +68,8 @@
   </div>
 </div>
 
-<script type="application/json" id="functions-data">
-[
+<script>
+window.GCOVR_FUNCTION_DATA = [
   {
     "name": "bar()",
     "filename": "A/subdir_0/subdir_1/subdir_2/subdir_3/subdir_4/subdir_5/subdir_6/subdir_7/subdir_8/subdir_9/File2.cpp",
@@ -191,8 +191,6 @@
 </script>
 <script>
   window.__functionsPageConfig = {
-    singlePage: false,
-    htmlFilename: "",
     showBranches: true,
     showConditions: false,
     showDecisions: false,

--- a/tests/html/reference/details-theme-boost-green/gcc-5/coverage_details.js
+++ b/tests/html/reference/details-theme-boost-green/gcc-5/coverage_details.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/html/reference/nested-theme-boost-blue/clang-10/coverage_nested.functions.html
+++ b/tests/html/reference/nested-theme-boost-blue/clang-10/coverage_nested.functions.html
@@ -129,8 +129,8 @@
   </div>
 </div>
 
-<script type="application/json" id="functions-data">
-[
+<script>
+window.GCOVR_FUNCTION_DATA = [
   {
     "name": "_Z3barv",
     "filename": "A/subdir_0/subdir_1/subdir_2/subdir_3/subdir_4/subdir_5/subdir_6/subdir_7/subdir_8/subdir_9/File2.cpp",
@@ -265,8 +265,6 @@
 </script>
 <script>
   window.__functionsPageConfig = {
-    singlePage: false,
-    htmlFilename: "",
     showBranches: true,
     showConditions: false,
     showDecisions: false,

--- a/tests/html/reference/nested-theme-boost-blue/clang-10/coverage_nested.js
+++ b/tests/html/reference/nested-theme-boost-blue/clang-10/coverage_nested.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/html/reference/nested-theme-boost-blue/clang-12/coverage_nested.functions.html
+++ b/tests/html/reference/nested-theme-boost-blue/clang-12/coverage_nested.functions.html
@@ -129,8 +129,8 @@
   </div>
 </div>
 
-<script type="application/json" id="functions-data">
-[
+<script>
+window.GCOVR_FUNCTION_DATA = [
   {
     "name": "bar()",
     "filename": "A/subdir_0/subdir_1/subdir_2/subdir_3/subdir_4/subdir_5/subdir_6/subdir_7/subdir_8/subdir_9/File2.cpp",
@@ -265,8 +265,6 @@
 </script>
 <script>
   window.__functionsPageConfig = {
-    singlePage: false,
-    htmlFilename: "",
     showBranches: true,
     showConditions: false,
     showDecisions: false,

--- a/tests/html/reference/nested-theme-boost-blue/clang-12/coverage_nested.js
+++ b/tests/html/reference/nested-theme-boost-blue/clang-12/coverage_nested.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/html/reference/nested-theme-boost-blue/gcc-11/coverage_nested.js
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-11/coverage_nested.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.functions.html
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.functions.html
@@ -130,8 +130,8 @@
   </div>
 </div>
 
-<script type="application/json" id="functions-data">
-[
+<script>
+window.GCOVR_FUNCTION_DATA = [
   {
     "name": "bar()",
     "filename": "A/subdir_0/subdir_1/subdir_2/subdir_3/subdir_4/subdir_5/subdir_6/subdir_7/subdir_8/subdir_9/File2.cpp",
@@ -266,8 +266,6 @@
 </script>
 <script>
   window.__functionsPageConfig = {
-    singlePage: false,
-    htmlFilename: "",
     showBranches: true,
     showConditions: true,
     showDecisions: false,

--- a/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.js
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-14/coverage_nested.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/html/reference/nested-theme-boost-blue/gcc-5/coverage_nested.functions.html
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-5/coverage_nested.functions.html
@@ -129,8 +129,8 @@
   </div>
 </div>
 
-<script type="application/json" id="functions-data">
-[
+<script>
+window.GCOVR_FUNCTION_DATA = [
   {
     "name": "bar()",
     "filename": "A/subdir_0/subdir_1/subdir_2/subdir_3/subdir_4/subdir_5/subdir_6/subdir_7/subdir_8/subdir_9/File2.cpp",
@@ -265,8 +265,6 @@
 </script>
 <script>
   window.__functionsPageConfig = {
-    singlePage: false,
-    htmlFilename: "",
     showBranches: true,
     showConditions: false,
     showDecisions: false,

--- a/tests/html/reference/nested-theme-boost-blue/gcc-5/coverage_nested.js
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-5/coverage_nested.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/html/reference/nested-theme-boost-blue/gcc-9/coverage_nested.js
+++ b/tests/html/reference/nested-theme-boost-blue/gcc-9/coverage_nested.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/html/reference/nested-theme-boost-green/clang-10/coverage_nested.functions.html
+++ b/tests/html/reference/nested-theme-boost-green/clang-10/coverage_nested.functions.html
@@ -129,8 +129,8 @@
   </div>
 </div>
 
-<script type="application/json" id="functions-data">
-[
+<script>
+window.GCOVR_FUNCTION_DATA = [
   {
     "name": "_Z3barv",
     "filename": "A/subdir_0/subdir_1/subdir_2/subdir_3/subdir_4/subdir_5/subdir_6/subdir_7/subdir_8/subdir_9/File2.cpp",
@@ -252,8 +252,6 @@
 </script>
 <script>
   window.__functionsPageConfig = {
-    singlePage: false,
-    htmlFilename: "",
     showBranches: true,
     showConditions: false,
     showDecisions: false,

--- a/tests/html/reference/nested-theme-boost-green/clang-10/coverage_nested.js
+++ b/tests/html/reference/nested-theme-boost-green/clang-10/coverage_nested.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/html/reference/nested-theme-boost-green/clang-12/coverage_nested.functions.html
+++ b/tests/html/reference/nested-theme-boost-green/clang-12/coverage_nested.functions.html
@@ -129,8 +129,8 @@
   </div>
 </div>
 
-<script type="application/json" id="functions-data">
-[
+<script>
+window.GCOVR_FUNCTION_DATA = [
   {
     "name": "bar()",
     "filename": "A/subdir_0/subdir_1/subdir_2/subdir_3/subdir_4/subdir_5/subdir_6/subdir_7/subdir_8/subdir_9/File2.cpp",
@@ -252,8 +252,6 @@
 </script>
 <script>
   window.__functionsPageConfig = {
-    singlePage: false,
-    htmlFilename: "",
     showBranches: true,
     showConditions: false,
     showDecisions: false,

--- a/tests/html/reference/nested-theme-boost-green/clang-12/coverage_nested.js
+++ b/tests/html/reference/nested-theme-boost-green/clang-12/coverage_nested.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.functions.html
+++ b/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.functions.html
@@ -130,8 +130,8 @@
   </div>
 </div>
 
-<script type="application/json" id="functions-data">
-[
+<script>
+window.GCOVR_FUNCTION_DATA = [
   {
     "name": "bar()",
     "filename": "A/subdir_0/subdir_1/subdir_2/subdir_3/subdir_4/subdir_5/subdir_6/subdir_7/subdir_8/subdir_9/File2.cpp",
@@ -253,8 +253,6 @@
 </script>
 <script>
   window.__functionsPageConfig = {
-    singlePage: false,
-    htmlFilename: "",
     showBranches: true,
     showConditions: true,
     showDecisions: false,

--- a/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.js
+++ b/tests/html/reference/nested-theme-boost-green/gcc-14/coverage_nested.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/html/reference/nested-theme-boost-green/gcc-5/coverage_nested.functions.html
+++ b/tests/html/reference/nested-theme-boost-green/gcc-5/coverage_nested.functions.html
@@ -129,8 +129,8 @@
   </div>
 </div>
 
-<script type="application/json" id="functions-data">
-[
+<script>
+window.GCOVR_FUNCTION_DATA = [
   {
     "name": "bar()",
     "filename": "A/subdir_0/subdir_1/subdir_2/subdir_3/subdir_4/subdir_5/subdir_6/subdir_7/subdir_8/subdir_9/File2.cpp",
@@ -252,8 +252,6 @@
 </script>
 <script>
   window.__functionsPageConfig = {
-    singlePage: false,
-    htmlFilename: "",
     showBranches: true,
     showConditions: false,
     showDecisions: false,

--- a/tests/html/reference/nested-theme-boost-green/gcc-5/coverage_nested.js
+++ b/tests/html/reference/nested-theme-boost-green/gcc-5/coverage_nested.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/html/reference/theme-boost-blue/clang-10/coverage.functions.html
+++ b/tests/html/reference/theme-boost-blue/clang-10/coverage.functions.html
@@ -68,8 +68,8 @@
   </div>
 </div>
 
-<script type="application/json" id="functions-data">
-[
+<script>
+window.GCOVR_FUNCTION_DATA = [
   {
     "name": "main",
     "filename": "main.cpp",
@@ -87,8 +87,6 @@
 </script>
 <script>
   window.__functionsPageConfig = {
-    singlePage: false,
-    htmlFilename: "",
     showBranches: false,
     showConditions: false,
     showDecisions: false,

--- a/tests/html/reference/theme-boost-blue/clang-10/coverage.js
+++ b/tests/html/reference/theme-boost-blue/clang-10/coverage.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/html/reference/theme-boost-blue/gcc-14/coverage.js
+++ b/tests/html/reference/theme-boost-blue/gcc-14/coverage.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/html/reference/theme-boost-blue/gcc-5/coverage.functions.html
+++ b/tests/html/reference/theme-boost-blue/gcc-5/coverage.functions.html
@@ -68,8 +68,8 @@
   </div>
 </div>
 
-<script type="application/json" id="functions-data">
-[
+<script>
+window.GCOVR_FUNCTION_DATA = [
   {
     "name": "main",
     "filename": "main.cpp",
@@ -87,8 +87,6 @@
 </script>
 <script>
   window.__functionsPageConfig = {
-    singlePage: false,
-    htmlFilename: "",
     showBranches: false,
     showConditions: false,
     showDecisions: false,

--- a/tests/html/reference/theme-boost-blue/gcc-5/coverage.js
+++ b/tests/html/reference/theme-boost-blue/gcc-5/coverage.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/html/reference/theme-boost-green/clang-10/coverage.functions.html
+++ b/tests/html/reference/theme-boost-green/clang-10/coverage.functions.html
@@ -68,8 +68,8 @@
   </div>
 </div>
 
-<script type="application/json" id="functions-data">
-[
+<script>
+window.GCOVR_FUNCTION_DATA = [
   {
     "name": "main",
     "filename": "main.cpp",
@@ -87,8 +87,6 @@
 </script>
 <script>
   window.__functionsPageConfig = {
-    singlePage: false,
-    htmlFilename: "",
     showBranches: false,
     showConditions: false,
     showDecisions: false,

--- a/tests/html/reference/theme-boost-green/clang-10/coverage.js
+++ b/tests/html/reference/theme-boost-green/clang-10/coverage.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/html/reference/theme-boost-green/gcc-14/coverage.js
+++ b/tests/html/reference/theme-boost-green/gcc-14/coverage.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);

--- a/tests/html/reference/theme-boost-green/gcc-5/coverage.functions.html
+++ b/tests/html/reference/theme-boost-green/gcc-5/coverage.functions.html
@@ -68,8 +68,8 @@
   </div>
 </div>
 
-<script type="application/json" id="functions-data">
-[
+<script>
+window.GCOVR_FUNCTION_DATA = [
   {
     "name": "main",
     "filename": "main.cpp",
@@ -87,8 +87,6 @@
 </script>
 <script>
   window.__functionsPageConfig = {
-    singlePage: false,
-    htmlFilename: "",
     showBranches: false,
     showConditions: false,
     showDecisions: false,

--- a/tests/html/reference/theme-boost-green/gcc-5/coverage.js
+++ b/tests/html/reference/theme-boost-green/gcc-5/coverage.js
@@ -811,18 +811,16 @@
   // ===========================================
 
   function initFunctionRows() {
-    var dataEl = document.getElementById('functions-data');
-    if (!dataEl) return;
+    if (!window.GCOVR_FUNCTION_DATA) return;
 
     var config = window.__functionsPageConfig || {};
-    var data = JSON.parse(dataEl.textContent);
+    var data = window.GCOVR_FUNCTION_DATA;
     var container = document.querySelector('.functions-body');
     var loadingEl = document.getElementById('functions-loading');
     var showBranches = config.showBranches;
     var showConditions = config.showConditions;
     var showDecisions = config.showDecisions;
     var showCalls = config.showCalls;
-    var singlePage = config.singlePage;
     var currentFile = config.htmlFilename || '';
 
     if (data.length === 0) {
@@ -843,11 +841,6 @@
       renderVisible();
     });
 
-    function buildHref(entry) {
-      if (singlePage) return '#' + entry.html_filename + '|l' + entry.line;
-      if (currentFile !== entry.html_filename) return entry.html_filename + '#l' + entry.line;
-      return '#l' + entry.line;
-    }
 
     function entryKey(entry) {
       return entry.name + '|' + entry.filename + ':' + entry.line;
@@ -869,7 +862,7 @@
       // col-function
       var colFn = el('div', 'col-function');
       var a = document.createElement('a');
-      a.href = buildHref(entry);
+      a.href = entry.html_filename + '#L' + entry.line;
       a.appendChild(el('span', 'function-name', entry.name));
       a.appendChild(el('span', 'function-location', entry.filename + ':' + entry.line));
       colFn.appendChild(a);


### PR DESCRIPTION
- `DOM text reinterpreted as HTML` because the function list in the HTML was parsed in
  javascript and the href attribute was set from it.
- Remove yet unused variables for single page report in boost theme.

[no changelog]